### PR TITLE
Add GetLandmarks RPC for spatial landmark queries

### DIFF
--- a/include/lar/service/navigation_service.h
+++ b/include/lar/service/navigation_service.h
@@ -15,6 +15,10 @@ public:
                          const proto::GetPathRequest* request,
                          proto::GetPathResponse* response) override;
 
+    grpc::Status GetLandmarks(grpc::ServerContext* context,
+                              const proto::GetLandmarksRequest* request,
+                              proto::GetLandmarksResponse* response) override;
+
 private:
     Map& map_;
 };

--- a/proto/navigation.proto
+++ b/proto/navigation.proto
@@ -30,7 +30,7 @@ message Landmark {
   double x = 2;
   double y = 3;
   double z = 4;
-  bytes descriptor = 5;
+  bytes desc = 5;
 }
 
 message GetPathRequest {

--- a/proto/navigation.proto
+++ b/proto/navigation.proto
@@ -3,6 +3,34 @@ package lar.proto;
 
 service NavigationService {
   rpc GetPath(GetPathRequest) returns (GetPathResponse);
+  rpc GetLandmarks(GetLandmarksRequest) returns (GetLandmarksResponse);
+}
+
+message GetLandmarksRequest {
+  Rect query = 1;
+  int32 limit = 2;  // -1 for no limit
+}
+
+message GetLandmarksResponse {
+  repeated Landmark landmarks = 1;
+}
+
+message Rect {
+  Point lower = 1;
+  Point upper = 2;
+}
+
+message Point {
+  double x = 1;
+  double y = 2;
+}
+
+message Landmark {
+  uint64 id = 1;
+  double x = 2;
+  double y = 3;
+  double z = 4;
+  bytes descriptor = 5;
 }
 
 message GetPathRequest {

--- a/src/service/navigation_service.cpp
+++ b/src/service/navigation_service.cpp
@@ -47,7 +47,7 @@ grpc::Status NavigationServiceImpl::GetLandmarks(
         proto_landmark->set_x(landmark->position.x());
         proto_landmark->set_y(landmark->position.y());
         proto_landmark->set_z(landmark->position.z());
-        proto_landmark->set_descriptor_(
+        proto_landmark->set_desc(
             landmark->desc.data,
             landmark->desc.total() * landmark->desc.elemSize()
         );

--- a/src/service/navigation_service.cpp
+++ b/src/service/navigation_service.cpp
@@ -1,4 +1,5 @@
 #include "lar/service/navigation_service.h"
+#include "lar/core/spatial/rect.h"
 
 namespace lar {
 
@@ -19,6 +20,37 @@ grpc::Status NavigationServiceImpl::GetPath(
         proto_anchor->set_x(anchor->transform.translation().x());
         proto_anchor->set_y(anchor->transform.translation().y());
         proto_anchor->set_z(anchor->transform.translation().z());
+    }
+
+    return grpc::Status::OK;
+}
+
+grpc::Status NavigationServiceImpl::GetLandmarks(
+    grpc::ServerContext* /*context*/,
+    const proto::GetLandmarksRequest* request,
+    proto::GetLandmarksResponse* response) {
+
+    // Convert proto Rect to lar::Rect
+    Rect query(
+        request->query().lower().x(), request->query().lower().y(),
+        request->query().upper().x(), request->query().upper().y()
+    );
+
+    // Find landmarks in the query region
+    std::vector<Landmark*> results;
+    map_.landmarks.find(query, results, request->limit());
+
+    // Convert results to proto Landmark messages
+    for (const Landmark* landmark : results) {
+        auto* proto_landmark = response->add_landmarks();
+        proto_landmark->set_id(landmark->id);
+        proto_landmark->set_x(landmark->position.x());
+        proto_landmark->set_y(landmark->position.y());
+        proto_landmark->set_z(landmark->position.z());
+        proto_landmark->set_descriptor_(
+            landmark->desc.data,
+            landmark->desc.total() * landmark->desc.elemSize()
+        );
     }
 
     return grpc::Status::OK;

--- a/src/service/navigation_service.cpp
+++ b/src/service/navigation_service.cpp
@@ -47,10 +47,14 @@ grpc::Status NavigationServiceImpl::GetLandmarks(
         proto_landmark->set_x(landmark->position.x());
         proto_landmark->set_y(landmark->position.y());
         proto_landmark->set_z(landmark->position.z());
-        proto_landmark->set_desc(
-            landmark->desc.data,
-            landmark->desc.total() * landmark->desc.elemSize()
-        );
+
+        // Only set descriptor if it's valid and non-empty
+        if (!landmark->desc.empty() && landmark->desc.isContinuous()) {
+            proto_landmark->set_desc(
+                landmark->desc.data,
+                landmark->desc.total() * landmark->desc.elemSize()
+            );
+        }
     }
 
     return grpc::Status::OK;


### PR DESCRIPTION
Adds a `GetLandmarks` RPC method to fetch point cloud data from the backend server. Enables mobile clients to query only nearby landmarks instead of downloading the entire map, which is essential for large-scale outdoor AR localization.

  Build & Run

  ```bash
  make fast
  ./bin/lar_server /path/to/map.json

  Loading map from: /path/to/map.json
  Loaded map with 69 anchors
  Server listening on 0.0.0.0:50051
```

  Example query

  ```
grpcurl -plaintext \
    -d '{"query": {"lower": {"x": -100, "y": -100}, "upper": {"x": 100, "y": 100}}, "limit": 5}' \
    localhost:50051 \
    lar.proto.NavigationService/GetLandmarks

  {
    "landmarks": [
      {"id": "432005", "x": -21.56, "y": -1.82, "z": -14.21, "descriptor": "AQomZzcE..."},
      {"id": "432020", "x": -31.21, "y": -4.29, "z": -1.07, "descriptor": "FgcBD2sy..."},
      {"id": "37482", "x": -146.67, "y": 7.38, "z": 304.38, "descriptor": "GQQAAAAC..."},
      {"id": "432041", "x": -16.24, "y": -1.56, "z": -12.49, "descriptor": "Dw8fJQoO..."},
      {"id": "432010", "x": -19.87, "y": -2.31, "z": -15.36, "descriptor": "kFgGAQAA..."}
    ]
  }
```
