### PR TITLE
Migrate to OpenCV 5.0 (slim static-library xcframeworks)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/bin)
 
 find_package(Eigen3 3.4.90 REQUIRED)
-find_package(OpenCV 4.5.4 REQUIRED core calib3d features2d imgcodecs imgproc)
+find_package(OpenCV 5.0 REQUIRED core geometry features flann imgcodecs imgproc)
 find_package(nlohmann_json 3.11.3 REQUIRED)
 find_package(g2o 1.0.0 REQUIRED)
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -13,7 +13,7 @@ set_target_properties(lar_create_map
 add_executable(lar_localize lar_localize.cpp)
 target_link_libraries(lar_localize
   lar_tracking lar_mapping
-  opencv_core opencv_features2d opencv_imgcodecs
+  opencv_core opencv_features opencv_imgcodecs
 )
 set_target_properties(lar_localize
   PROPERTIES

--- a/cmake/SuperBuild.cmake
+++ b/cmake/SuperBuild.cmake
@@ -61,7 +61,7 @@ ExternalProject_Add(opencv
     -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/install
     ${COMMON_TOOLCHAIN_ARGS}
     -DCMAKE_POLICY_DEFAULT_CMP0048=NEW
-    -DBUILD_LIST=core,calib3d,features2d,imgcodecs,imgproc
+    -DBUILD_LIST=core,geometry,features,imgcodecs,imgproc
     -DBUILD_SHARED_LIBS=OFF
     -DBUILD_DOCS=OFF
     -DBUILD_TESTS=OFF

--- a/include/lar/tracking/tracker.h
+++ b/include/lar/tracking/tracker.h
@@ -3,7 +3,7 @@
 
 #include <Eigen/Core>
 #include <opencv2/core/types.hpp>
-#include <opencv2/calib3d.hpp>
+#include <opencv2/geometry.hpp>  // solvePnPRansac / Rodrigues (was calib3d in OpenCV 4)
 
 #include "lar/core/map.h"
 #include "lar/mapping/frame.h"

--- a/script/build_opencv_framework.bash
+++ b/script/build_opencv_framework.bash
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 #
-# Builds the opencv2 xcframework(s) used by lar-swift.
+# Builds the opencv2 xcframework(s) used by lar-swift, for OpenCV 5.
 #
-# Produces TWO static variants (both arm64-only, slimmed module set):
+# Default output: STATIC-LIBRARY xcframeworks (libopencv2.a + Headers/opencv2). SPM
+# *links* static-library xcframeworks and never embeds them — which is required for
+# the iOS app to install. (Embedding a static .framework makes Xcode write a broken
+# stub binary and the device install fails: "parse_macho_iterate_slices failed".)
+# The Swift layer is opencv-free, so opencv needs no framework/Swift module — a plain
+# static library + C++ headers is enough.
+#
 #   opencv2.xcframework            Release + debug info  (dev: fast + symbolicated)
-#   opencv2-optimized.xcframework  Release, stripped      (distribution / App Clip size)
+#   opencv2-optimized.xcframework  Release, no debug info (distribution / App-Clip size)
 #
-# Both are STATIC (no --dynamic) so SPM links them into the app rather than
-# embedding them, and both have their iOS slices flattened to shallow bundles
-# (opencv builds static frameworks as deep/versioned bundles, which iOS rejects).
+# Set OPENCV_DYNAMIC=1 to instead emit embeddable *dynamic* frameworks (larger; loses
+# the static/App-Clip size benefit, but a standard build with no .a repackaging).
+#
+# Toolchain (OpenCV 5 + Xcode 26): requires cmake < 4 and python 3.12 (see
+# ensure_toolchain). OpenCV's source workarounds are applied by
+# script/patches/apply_opencv5_patches.sh.
 #
 # Usage:
 #   ./script/build_opencv_framework.bash            # build both variants
@@ -20,39 +29,53 @@ ROOT=$(pwd)
 FRAMEWORKS_PATH="$ROOT/build/frameworks"
 OPENCV_BUILD="$ROOT/thirdparty/opencv/platforms/apple/build_xcframework.py"
 WHICH="${1:-both}"
+DYNAMIC="${OPENCV_DYNAMIC:-0}"
 
-mkdir -p "$FRAMEWORKS_PATH"
-
-export CC=/usr/bin/clang
-export CXX=/usr/bin/clang++
-export AR=/usr/bin/ar
-export RANLIB=/usr/bin/ranlib
+export CC=/usr/bin/clang CXX=/usr/bin/clang++ AR=/usr/bin/ar RANLIB=/usr/bin/ranlib
 export IPHONEOS_DEPLOYMENT_TARGET=12.0
 export MACOSX_DEPLOYMENT_TARGET=10.15
 
-# Slimmed module set + arm64-only, static. Shared by both variants.
+# OpenCV 5's -GXcode build breaks on cmake 4.x (compiler detection) and on python 3.14
+# (Obj-C binding generator). Prefer uv-managed cmake 3.x + python 3.12 if present, then
+# verify. Install without admin: `uv tool install "cmake<4"` and `uv python install 3.12`.
+ensure_toolchain() {
+    [ -x "$HOME/.local/bin/cmake" ] && export PATH="$HOME/.local/bin:$PATH"
+    local py312; py312="$(ls -d "$HOME"/.local/share/uv/python/cpython-3.12*/bin 2>/dev/null | head -1 || true)"
+    [ -n "$py312" ] && export PATH="$py312:$PATH"
+
+    local cmajor pyminor
+    cmajor="$(cmake --version 2>/dev/null | sed -n '1s/.*version \([0-9][0-9]*\).*/\1/p')"
+    pyminor="$(python3 -c 'import sys; print(sys.version_info.minor)' 2>/dev/null || echo 99)"
+    if [ -z "${cmajor:-}" ] || [ "$cmajor" -ge 4 ]; then
+        echo "ERROR: OpenCV's -GXcode build needs cmake < 4 (have: $(cmake --version 2>/dev/null | head -1))." >&2
+        echo "       Install without admin:  uv tool install 'cmake<4'" >&2
+        exit 1
+    fi
+    if [ "$pyminor" -ge 13 ]; then
+        echo "ERROR: OpenCV's Obj-C binding generator needs python 3.12 (have: $(python3 --version 2>/dev/null))." >&2
+        echo "       Install:  uv python install 3.12" >&2
+        exit 1
+    fi
+    echo "Toolchain OK: $(cmake --version | head -1), $(python3 --version)"
+}
+
 COMMON_ARGS=(
     --without dnn --without gapi --without highgui --without ml
     --without objdetect --without photo --without stitching
     --without video --without videoio --without parallel
-    --macos_archs=arm64
-    --iphoneos_archs=arm64
-    --iphonesimulator_archs=arm64
-    --catalyst_archs=''
-    --disable-bitcode
-    --build_only_specified_archs
+    --without ptcloud  # unused; its objc VolumeType binding clashes with macOS Carbon OSType
+    --macos_archs=arm64 --iphoneos_archs=arm64 --iphonesimulator_archs=arm64
+    --catalyst_archs='' --disable-bitcode --build_only_specified_archs
 )
+[ "$DYNAMIC" = "1" ] && COMMON_ARGS+=(--dynamic)
 
-# iOS frameworks must be shallow bundles (Info.plist + binary at the root).
-# opencv builds static frameworks as deep/versioned bundles, so flatten the
-# iOS slices. The macOS slice keeps its valid versioned layout.
+# iOS frameworks must be shallow bundles (Info.plist + binary at the root). Static
+# frameworks build deep/versioned, so flatten the iOS slices (macOS stays versioned).
 flatten_ios_slices() {
-    local xc="$1"
-    local slice fw
+    local xc="$1" slice fw
     for slice in ios-arm64 ios-arm64-simulator; do
         fw="$xc/$slice/opencv2.framework"
         [ -d "$fw/Versions" ] || continue
-        echo "Flattening $slice ..."
         rm -f "$fw/Headers" "$fw/Modules" "$fw/Resources" "$fw/opencv2"
         mv "$fw/Versions/A/opencv2" "$fw/Versions/A/Headers" "$fw/Versions/A/Modules" "$fw/"
         mv "$fw/Versions/A/Resources/Info.plist" "$fw/Info.plist"
@@ -60,33 +83,65 @@ flatten_ios_slices() {
     done
 }
 
-# build_variant <output-name> [extra build_xcframework.py args...]
-build_variant() {
-    local out_name="$1"; shift
-    echo "==> Building $out_name"
-    rm -rf "$FRAMEWORKS_PATH/opencv2.xcframework"
-    python3 "$OPENCV_BUILD" --out "$FRAMEWORKS_PATH" "${COMMON_ARGS[@]}" "$@"
-    flatten_ios_slices "$FRAMEWORKS_PATH/opencv2.xcframework"
-    rm -rf "$FRAMEWORKS_PATH/$out_name"
-    mv "$FRAMEWORKS_PATH/opencv2.xcframework" "$FRAMEWORKS_PATH/$out_name"
-    echo "==> Done: $FRAMEWORKS_PATH/$out_name"
+# Convert a static .framework xcframework into a static-LIBRARY xcframework
+# (libopencv2.a + Headers/opencv2) so SPM links it instead of embedding it.
+repackage_static_lib() {
+    local fwxc="$1" outxc="$2" strip_dbg="${3:-no}" stage="$FRAMEWORKS_PATH/.libstage"
+    rm -rf "$stage" "$outxc"; mkdir -p "$stage"
+    local args=() slice fw bin hdr
+    for slice in ios-arm64 ios-arm64-simulator macos-arm64; do
+        fw="$fwxc/$slice/opencv2.framework"; [ -d "$fw" ] || continue
+        if [ -d "$fw/Versions/A" ]; then bin="$fw/Versions/A/opencv2"; hdr="$fw/Versions/A/Headers"
+        else bin="$fw/opencv2"; hdr="$fw/Headers"; fi
+        mkdir -p "$stage/$slice/include/opencv2"
+        cp "$bin" "$stage/$slice/libopencv2.a"
+        # DWARF in a static .a isn't linked into the app (it doesn't change app/App-Clip
+        # binary size) but it bloats the repo ~7x; strip it for the distribution variant.
+        [ "$strip_dbg" = "yes" ] && strip -S "$stage/$slice/libopencv2.a"
+        cp -R "$hdr"/. "$stage/$slice/include/opencv2/"
+        args+=(-library "$stage/$slice/libopencv2.a" -headers "$stage/$slice/include")
+    done
+    xcodebuild -create-xcframework "${args[@]}" -output "$outxc"
+    rm -rf "$stage"
 }
 
-if [ "$WHICH" = "debug" ] || [ "$WHICH" = "both" ]; then
-    # Release with debug info: optimized at runtime, symbolicated.
-    build_variant opencv2.xcframework --debug_info
-fi
-
-if [ "$WHICH" = "optimized" ] || [ "$WHICH" = "both" ]; then
-    # Release, no debug info: smallest static lib for distribution / App Clip.
-    build_variant opencv2-optimized.xcframework
-fi
-
-mkdir -p "$ROOT/lib"
-for name in opencv2.xcframework opencv2-optimized.xcframework; do
-    if [ -d "$FRAMEWORKS_PATH/$name" ]; then
-        rm -rf "$ROOT/lib/$name"
-        mv "$FRAMEWORKS_PATH/$name" "$ROOT/lib/$name"
-        echo "Installed $ROOT/lib/$name"
+# build_variant <final-name> [extra build_xcframework.py args...]
+build_variant() {
+    local final="$1" strip_dbg="$2"; shift 2
+    echo "==> Building $final"
+    rm -rf "$FRAMEWORKS_PATH/opencv2.xcframework" "$FRAMEWORKS_PATH/$final"
+    python3 "$OPENCV_BUILD" --out "$FRAMEWORKS_PATH" "${COMMON_ARGS[@]}" "$@"
+    flatten_ios_slices "$FRAMEWORKS_PATH/opencv2.xcframework"
+    if [ "$DYNAMIC" = "1" ]; then
+        mv "$FRAMEWORKS_PATH/opencv2.xcframework" "$FRAMEWORKS_PATH/$final"   # dynamic framework, embeddable
+    else
+        repackage_static_lib "$FRAMEWORKS_PATH/opencv2.xcframework" "$FRAMEWORKS_PATH/$final" "$strip_dbg"  # static lib, linked
+        rm -rf "$FRAMEWORKS_PATH/opencv2.xcframework"
     fi
-done
+    echo "==> Done: $FRAMEWORKS_PATH/$final"
+}
+
+ensure_toolchain
+"$ROOT/script/patches/apply_opencv5_patches.sh"
+mkdir -p "$FRAMEWORKS_PATH"
+
+if [ "$WHICH" = "debug" ] || [ "$WHICH" = "both" ]; then
+    build_variant opencv2-debug.xcframework no --debug_info   # keep opencv debug symbols
+fi
+if [ "$WHICH" = "optimized" ] || [ "$WHICH" = "both" ]; then
+    build_variant opencv2-optimized.xcframework yes           # strip DWARF (smaller repo)
+fi
+
+# Install: the debug variant becomes the default opencv2.xcframework Package.swift links;
+# the optimized variant keeps its suffixed name (selected via OPENCV_OPTIMIZED=1).
+mkdir -p "$ROOT/lib"
+if [ -d "$FRAMEWORKS_PATH/opencv2-debug.xcframework" ]; then
+    rm -rf "$ROOT/lib/opencv2.xcframework"
+    mv "$FRAMEWORKS_PATH/opencv2-debug.xcframework" "$ROOT/lib/opencv2.xcframework"
+    echo "Installed $ROOT/lib/opencv2.xcframework (debug)"
+fi
+if [ -d "$FRAMEWORKS_PATH/opencv2-optimized.xcframework" ]; then
+    rm -rf "$ROOT/lib/opencv2-optimized.xcframework"
+    mv "$FRAMEWORKS_PATH/opencv2-optimized.xcframework" "$ROOT/lib/opencv2-optimized.xcframework"
+    echo "Installed $ROOT/lib/opencv2-optimized.xcframework"
+fi

--- a/script/build_opencv_framework.bash
+++ b/script/build_opencv_framework.bash
@@ -1,67 +1,92 @@
 #!/usr/bin/env bash
+#
+# Builds the opencv2 xcframework(s) used by lar-swift.
+#
+# Produces TWO static variants (both arm64-only, slimmed module set):
+#   opencv2.xcframework            Release + debug info  (dev: fast + symbolicated)
+#   opencv2-optimized.xcframework  Release, stripped      (distribution / App Clip size)
+#
+# Both are STATIC (no --dynamic) so SPM links them into the app rather than
+# embedding them, and both have their iOS slices flattened to shallow bundles
+# (opencv builds static frameworks as deep/versioned bundles, which iOS rejects).
+#
+# Usage:
+#   ./script/build_opencv_framework.bash            # build both variants
+#   ./script/build_opencv_framework.bash debug      # only opencv2.xcframework
+#   ./script/build_opencv_framework.bash optimized  # only opencv2-optimized.xcframework
+set -euo pipefail
 
-FRAMEWORKS_PATH=`pwd`/build/frameworks
-XCFRAMEWORK_PATH=$FRAMEWORKS_PATH/opencv2.xcframework
-RESOURCES_PATH=`pwd`/script/resources/apple/opencv2/Resources
+ROOT=$(pwd)
+FRAMEWORKS_PATH="$ROOT/build/frameworks"
+OPENCV_BUILD="$ROOT/thirdparty/opencv/platforms/apple/build_xcframework.py"
+WHICH="${1:-both}"
 
-mkdir -p $FRAMEWORKS_PATH
+mkdir -p "$FRAMEWORKS_PATH"
 
 export CC=/usr/bin/clang
 export CXX=/usr/bin/clang++
 export AR=/usr/bin/ar
 export RANLIB=/usr/bin/ranlib
 export IPHONEOS_DEPLOYMENT_TARGET=12.0
-export MACOSX_DEPLOYMENT_TARGET=10.15 # Also set macOS target
+export MACOSX_DEPLOYMENT_TARGET=10.15
 
-# Pass additional CMake arguments to disable problematic PNG optimizations
-python3 `pwd`/thirdparty/opencv/platforms/apple/build_xcframework.py \
-    --out $FRAMEWORKS_PATH \
-    --without dnn \
-    --without gapi \
-    --without highgui \
-    --without ml \
-    --without objdetect \
-    --without photo \
-    --without stitching \
-    --without video \
-    --without videoio \
-    --without parallel \
-    --macos_archs=arm64 \
-    --iphoneos_archs=arm64 \
-    --iphonesimulator_archs=arm64 \
-    --catalyst_archs='' \
-    --disable-bitcode \
+# Slimmed module set + arm64-only, static. Shared by both variants.
+COMMON_ARGS=(
+    --without dnn --without gapi --without highgui --without ml
+    --without objdetect --without photo --without stitching
+    --without video --without videoio --without parallel
+    --macos_archs=arm64
+    --iphoneos_archs=arm64
+    --iphonesimulator_archs=arm64
+    --catalyst_archs=''
+    --disable-bitcode
     --build_only_specified_archs
+)
 
-# Copy correct Resources folder to each platform variant
-copy_resources() {
-    local PLATFORM_DIR="$1"
-    local FRAMEWORK_PATH="$XCFRAMEWORK_PATH/$PLATFORM_DIR/opencv2.framework"
-    
-    if [ -d "$FRAMEWORK_PATH" ] && [ -d "$RESOURCES_PATH" ]; then
-        echo "Copying Resources to $PLATFORM_DIR"
-        # rm -rf "$FRAMEWORK_PATH/Resources"
-        # cp -r "$RESOURCES_PATH" "$FRAMEWORK_PATH/Resources"
-        echo "Copied Resources to $FRAMEWORK_PATH"
-    else
-        echo "Warning: Framework path $FRAMEWORK_PATH or Resources path $RESOURCES_PATH not found"
-    fi
+# iOS frameworks must be shallow bundles (Info.plist + binary at the root).
+# opencv builds static frameworks as deep/versioned bundles, so flatten the
+# iOS slices. The macOS slice keeps its valid versioned layout.
+flatten_ios_slices() {
+    local xc="$1"
+    local slice fw
+    for slice in ios-arm64 ios-arm64-simulator; do
+        fw="$xc/$slice/opencv2.framework"
+        [ -d "$fw/Versions" ] || continue
+        echo "Flattening $slice ..."
+        rm -f "$fw/Headers" "$fw/Modules" "$fw/Resources" "$fw/opencv2"
+        mv "$fw/Versions/A/opencv2" "$fw/Versions/A/Headers" "$fw/Versions/A/Modules" "$fw/"
+        mv "$fw/Versions/A/Resources/Info.plist" "$fw/Info.plist"
+        rm -rf "$fw/Versions"
+    done
 }
 
-# Copy Resources to all platform variants
-if [ -d "$XCFRAMEWORK_PATH" ]; then
-    echo "Copying Resources folder to OpenCV XCFramework..."
-    
-    # copy_resources "ios-arm64"
-    # copy_resources "ios-arm64_x86_64-simulator" 
-    # copy_resources "ios-arm64_x86_64-maccatalyst"
-    # copy_resources "macos-arm64_x86_64"
-    
-    echo "Resources copying completed"
-else
-    echo "Error: XCFramework not found at $XCFRAMEWORK_PATH"
-    exit 1
+# build_variant <output-name> [extra build_xcframework.py args...]
+build_variant() {
+    local out_name="$1"; shift
+    echo "==> Building $out_name"
+    rm -rf "$FRAMEWORKS_PATH/opencv2.xcframework"
+    python3 "$OPENCV_BUILD" --out "$FRAMEWORKS_PATH" "${COMMON_ARGS[@]}" "$@"
+    flatten_ios_slices "$FRAMEWORKS_PATH/opencv2.xcframework"
+    rm -rf "$FRAMEWORKS_PATH/$out_name"
+    mv "$FRAMEWORKS_PATH/opencv2.xcframework" "$FRAMEWORKS_PATH/$out_name"
+    echo "==> Done: $FRAMEWORKS_PATH/$out_name"
+}
+
+if [ "$WHICH" = "debug" ] || [ "$WHICH" = "both" ]; then
+    # Release with debug info: optimized at runtime, symbolicated.
+    build_variant opencv2.xcframework --debug_info
 fi
 
-mkdir -p `pwd`/lib
-mv $FRAMEWORKS_PATH/opencv2.xcframework `pwd`/lib
+if [ "$WHICH" = "optimized" ] || [ "$WHICH" = "both" ]; then
+    # Release, no debug info: smallest static lib for distribution / App Clip.
+    build_variant opencv2-optimized.xcframework
+fi
+
+mkdir -p "$ROOT/lib"
+for name in opencv2.xcframework opencv2-optimized.xcframework; do
+    if [ -d "$FRAMEWORKS_PATH/$name" ]; then
+        rm -rf "$ROOT/lib/$name"
+        mv "$FRAMEWORKS_PATH/$name" "$ROOT/lib/$name"
+        echo "Installed $ROOT/lib/$name"
+    fi
+done

--- a/script/patches/apply_opencv5_patches.sh
+++ b/script/patches/apply_opencv5_patches.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Apply the OpenCV 5.0.0 source workarounds needed to build its iOS xcframework
+# under Xcode 26. These patch the vendored thirdparty/opencv (5.0.0 tag).
+#
+# All are upstream-known and fixed on the 5.x branch but not in the 5.0.0 release,
+# so DELETE this script once thirdparty/opencv is bumped to a 5.0.x that includes:
+#   - PR #29257  (LightGlueMatcher swift_name)
+#   - the Xcode-26 docbuild / tapi-version fix
+#
+# Idempotent: safe to run repeatedly. Invoked by build_opencv_framework.bash.
+#
+# NOTE: the toolchain requirements live in build_opencv_framework.bash, not here:
+#   - cmake < 4   (OpenCV 4/5 -GXcode compiler detection breaks on cmake 4.x)
+#   - python 3.12 (OpenCV's Obj-C binding generator breaks on python 3.14)
+set -euo pipefail
+
+OPENCV="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../thirdparty/opencv" && pwd)"
+echo "Applying OpenCV 5 build workarounds to $OPENCV"
+
+# 1) build_framework.py's get_current_branch() runs `git branch --show-current`,
+#    which is empty on a detached HEAD (we check out the 5.0.0 tag) -> hard error.
+#    Put opencv on a named branch at the same commit.
+if ! git -C "$OPENCV" symbolic-ref -q HEAD >/dev/null 2>&1; then
+    rev="$(git -C "$OPENCV" rev-parse --short HEAD)"
+    git -C "$OPENCV" switch -c "opencv-build-${rev}" 2>/dev/null \
+        || git -C "$OPENCV" switch "opencv-build-${rev}"
+    echo "  [1/3] opencv on branch opencv-build-${rev}"
+else
+    echo "  [1/3] opencv already on a named branch"
+fi
+
+# 2) LightGlueMatcher's Obj-C binding emits a conflicting swift_name (clang rejects
+#    it as a hard error). Upstream fix PR #29257: rename the create(modelPath)
+#    factory to createFromFile via a gen_dict.json func_arg_fix.
+python3 - "$OPENCV/modules/features/misc/objc/gen_dict.json" <<'PY'
+import collections, json, sys
+path = sys.argv[1]
+data = json.load(open(path), object_pairs_hook=collections.OrderedDict)
+faf = data.setdefault("func_arg_fix", collections.OrderedDict())
+sig = ("(LightGlueMatcher*)create:(NSString*)modelPath scoreThreshold:(float)"
+       "scoreThreshold backend:(int)backend target:(int)target")
+lg = faf.setdefault("LightGlueMatcher", collections.OrderedDict())
+lg[sig] = {"create": {"name": "createFromFile"}}
+json.dump(data, open(path, "w"), indent=4)
+PY
+echo "  [2/3] LightGlueMatcher create -> createFromFile (PR #29257)"
+
+# 3) DocC docbuild step fails on Xcode 26 ("Could not parse tapi version"); we
+#    don't ship docs, so disable it (it is force-enabled for Xcode >= 13).
+perl -0pi -e \
+    's/self\.build_docs = xcode_ver >= 13/self.build_docs = False  # Xcode 26 docbuild tapi bug/' \
+    "$OPENCV/platforms/ios/build_framework.py"
+echo "  [3/4] DocC docbuild disabled (ios/build_framework.py)"
+
+# 4) With docbuild disabled there is no docs/ dir, so build_xcframework.py's
+#    "copy documentation" phase must tolerate its absence.
+perl -0pi -e \
+    's{(docs_dst = "\{\}/docs_\{\}"\.format\(args\.out, platform\)\n)}{$1            if not os.path.exists(docs_src):\n                continue\n}' \
+    "$OPENCV/platforms/apple/build_xcframework.py"
+echo "  [4/4] docs-copy made tolerant of missing docs (apple/build_xcframework.py)"
+
+echo "Done."

--- a/src/tracking/CMakeLists.txt
+++ b/src/tracking/CMakeLists.txt
@@ -86,9 +86,9 @@ target_compile_options(lar_tracking PRIVATE
 target_link_libraries(lar_tracking
   PUBLIC
     opencv_core
-    opencv_calib3d
+    opencv_geometry    # solvePnPRansac / Rodrigues (was calib3d in OpenCV 4)
     opencv_imgproc
-    opencv_features2d  # For KeyPointsFilter utilities
+    opencv_features    # For KeyPointsFilter utilities (was features2d in OpenCV 4)
     opencv_flann       # For custom FlannMatcher
     lar_core
     lar_mapping

--- a/src/tracking/confidence_estimation/geometric_confidence_estimator.cpp
+++ b/src/tracking/confidence_estimation/geometric_confidence_estimator.cpp
@@ -6,6 +6,7 @@
 #include "lar/tracking/filtered_tracker_config.h"
 #include "lar/core/landmark.h"
 #include <opencv2/imgproc.hpp>
+#include <opencv2/geometry.hpp>  // cv::boundingRect moved imgproc -> geometry in OpenCV 5
 #include <algorithm>
 #include <iostream>
 

--- a/src/tracking/tracker.cpp
+++ b/src/tracking/tracker.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <opencv2/calib3d.hpp>
+#include <opencv2/geometry.hpp>
 
 #include "lar/tracking/tracker.h"
 
@@ -143,8 +143,9 @@ namespace lar {
       this->matches.emplace_back(landmark, kpts[match.queryIdx]);
     }
     
-    // Store inliers (subset of matches)
-    for (int i = 0; i < inliers.rows; i++) {
+    // Store inliers (subset of matches). Use total() not rows: OpenCV 5's
+    // 1D vector->Mat change can yield a 1xN inliers vector instead of Nx1.
+    for (int i = 0; i < (int)inliers.total(); i++) {
       int match_idx = inliers.at<int>(i);
       auto& match = matches[match_idx];
       Landmark* landmark = local_landmarks[match.trainIdx];


### PR DESCRIPTION
Migrates the C++ core to **OpenCV 5.0.0** and reworks the iOS/macOS framework build.

**OpenCV 5 source/CMake**
- `thirdparty/opencv` → 5.0.0 release tag
- `calib3d` split → `geometry` (solvePnPRansac/Rodrigues) and `features2d` → `features`; updated `find_package`, link targets, `BUILD_LIST`
- `cv::boundingRect` moved imgproc → geometry; `solvePnPRansac` inliers iterated with `.total()` (OpenCV 5 1D `vector→Mat`)

**Build pipeline (`build_opencv_framework.bash`)**
- Emits slim, arm64-only **static-library** xcframeworks (`libopencv2.a` + headers) so SPM links (not embeds) opencv — required for iOS install
- Pins the toolchain (cmake < 4, python 3.12) and applies OpenCV-5.0.0/Xcode-26 build workarounds via `script/patches/apply_opencv5_patches.sh` (named branch; LightGlue `swift_name` PR #29257; DocC docbuild/tapi); strips the distribution variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)
