### PR TITLE
FilteredTracker: decouple per-frame ops from measurement CV with fine-grained locking

### DIFF
--- a/include/lar/tracking/filtered_tracker.h
+++ b/include/lar/tracking/filtered_tracker.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <chrono>
+#include <mutex>
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 #include <opencv2/core.hpp>
@@ -25,6 +26,23 @@ namespace lar {
  * - T_lar_from_camera: Camera pose IN LAR world coordinates (primary state)
  * - T_vio_from_camera: Camera pose IN VIO world coordinates
  * - T_lar_from_vio: Coordinate transform FROM VIO TO LAR world (output)
+ *
+ * THREAD SAFETY:
+ * The lightweight per-frame operations (updateVIOCameraPose, predictStep,
+ * getFilteredTransform, getPositionUncertainty, isInitialized, reset) are safe to call
+ * concurrently with measurementUpdate. They only touch the filter / VIO state, which is
+ * guarded by state_mutex_ and held for microseconds.
+ *
+ * measurementUpdate runs its expensive computer-vision localization (base_tracker_) WITHOUT
+ * holding state_mutex_, so a 0.5-2s localization never blocks the per-frame thread (e.g. the
+ * ARKit delegate). It only locks briefly to snapshot the prediction up front and to fuse the
+ * result at the end. Because per-frame predictStep keeps advancing the filter during the
+ * unlocked CV work, the measurement is time-aligned back to "now" using the VIO motion that
+ * elapsed during localization before it is fused (see measurementUpdate).
+ *
+ * CALLER CONTRACT: measurementUpdate touches base_tracker_, which is NOT mutex-guarded, so it
+ * must not be called concurrently with itself or with getBaseTracker() mutations such as
+ * configureImageSize(). Serialize those heavy/rare operations on a single background context.
  */
 class FilteredTracker {
 public:
@@ -59,7 +77,11 @@ private:
     // Timing
     std::chrono::steady_clock::time_point last_prediction_time_;
 
-    // Helper methods
+    // Guards the filter strategy, VIO pose state, timing and last_transform_result_.
+    // Deliberately NOT held during base_tracker_ localization (see measurementUpdate).
+    mutable std::mutex state_mutex_;
+
+    // Helper methods. NOTE: these assume state_mutex_ is already held by the caller.
     Eigen::Matrix4d computeMotionDelta();
     MeasurementResult computeCoordinateTransform(const Eigen::Matrix4d& T_lar_from_camera, double confidence);
 

--- a/src/tracking/filtered_tracker.cpp
+++ b/src/tracking/filtered_tracker.cpp
@@ -84,6 +84,8 @@ void FilteredTracker::updateVIOCameraPose(const Eigen::Matrix4d& T_vio_from_came
         return;
     }
 
+    std::lock_guard<std::mutex> lock(state_mutex_);
+
     // Update VIO pose tracking
     if (!has_vio_poses_) {
         // First pose - initialize both current and last
@@ -106,6 +108,8 @@ void FilteredTracker::updateVIOCameraPose(const Eigen::Matrix4d& T_vio_from_came
 // ============================================================================
 
 void FilteredTracker::predictStep() {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+
     auto current_time = std::chrono::steady_clock::now();
     double dt = std::chrono::duration<double>(current_time - last_prediction_time_).count();
     last_prediction_time_ = current_time;
@@ -140,20 +144,38 @@ FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
     result.success = false;
     result.confidence = 0.0;
 
-    // Perform LAR localization (returns camera pose in LAR world)
+    // --- Phase 1: snapshot the prediction and the capture-time VIO pose (brief lock) ---
+    // We grab the current filter prediction to seed PnP and remember the VIO pose at the
+    // moment localization begins, so we can time-align the result later. We release the lock
+    // immediately so per-frame predict/getFilteredTransform keep running during the CV work.
+    bool was_initialized;
+    Eigen::Matrix4d predicted_pose_guess = Eigen::Matrix4d::Identity();
+    Eigen::Matrix4d vio_at_capture = Eigen::Matrix4d::Identity();
+    bool had_vio_at_capture;
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        was_initialized = filter_strategy_->isInitialized();
+        if (was_initialized) {
+            predicted_pose_guess = filter_strategy_->getState().toTransform();
+        }
+        had_vio_at_capture = has_vio_poses_;
+        vio_at_capture = current_vio_camera_pose_;
+    }
+
+    // --- Phase 2: expensive LAR localization, NO lock held ---
+    // base_tracker_ is not mutex-guarded (see CALLER CONTRACT); this is the 0.5-2s CV work
+    // that must never block the per-frame thread.
     Eigen::Matrix4d T_lar_from_camera_measured;
     bool localization_success;
 
-    if (filter_strategy_->isInitialized()) {
+    if (was_initialized) {
         // Use pose prediction as initial guess for RANSAC
-        Eigen::Matrix4d predicted_pose = filter_strategy_->getState().toTransform();
-
         if (config_.enable_debug_output) {
             std::cout << "Using prediction as initial guess for PnP" << std::endl;
         }
 
         localization_success = base_tracker_->localize(
-            image, frame, query_x, query_z, query_diameter, T_lar_from_camera_measured, predicted_pose, true);
+            image, frame, query_x, query_z, query_diameter, T_lar_from_camera_measured, predicted_pose_guess, true);
     } else {
         // No prediction available, use standard localization
         localization_success = base_tracker_->localize(
@@ -171,18 +193,36 @@ FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
     result.success = true;
     result.matched_landmarks = base_tracker_->local_landmarks;
     result.inliers = base_tracker_->inliers;
+    size_t total_matches = base_tracker_->matches.size();
 
     if (config_.enable_debug_output) {
         std::cout << "LAR localization successful: " << result.inliers.size() << " inliers, "
                   << result.matched_landmarks.size() << " matches" << std::endl;
     }
 
+    // --- Phase 3: fuse the measurement into the filter (brief lock) ---
+    std::lock_guard<std::mutex> lock(state_mutex_);
+
+    // Time-align the measurement to "now". The filter kept predicting on the per-frame
+    // thread while CV ran, so its state advanced by the VIO motion that occurred during
+    // localization. Carry the measured pose forward by that same motion (assuming the
+    // VIO->LAR drift transform is ~constant over the localization window) so the measured
+    // pose and the predicted state refer to the same instant:
+    //   T_lar_from_camera(now) = T_lar_from_camera(capture) * vio(capture)^-1 * vio(now)
+    Eigen::Matrix4d measured_pose = T_lar_from_camera_measured;
+    if (had_vio_at_capture && has_vio_poses_) {
+        Eigen::Matrix4d vio_delta = vio_at_capture.inverse() * current_vio_camera_pose_;
+        if (utils::TransformUtils::validateTransformMatrix(vio_delta, "vio_delta_during_cv")) {
+            measured_pose = T_lar_from_camera_measured * vio_delta;
+        }
+    }
+
     // Create measurement context for pluggable components
     MeasurementContext context;
     context.inliers = std::make_shared<std::vector<std::pair<Landmark*, cv::KeyPoint>>>(result.inliers);
-    context.total_matches = base_tracker_->matches.size();
+    context.total_matches = total_matches;
     context.frame = &frame;
-    context.measured_pose = T_lar_from_camera_measured;
+    context.measured_pose = measured_pose;
     if (filter_strategy_->isInitialized()) {
         context.predicted_pose = filter_strategy_->getState().toTransform();
     }
@@ -194,6 +234,8 @@ FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
     // Calculate measurement noise using context (compute once, use many times)
     context.measurement_noise = confidence_estimator_->calculateMeasurementNoise(context, config_);
 
+    // Re-check initialization under the lock: a concurrent reset() may have de-initialized
+    // the filter while CV was running.
     if (!filter_strategy_->isInitialized()) {
         // Initialize filter from first measurement
         if (config_.enable_debug_output) {
@@ -207,7 +249,7 @@ FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
         Eigen::MatrixXd covariance = filter_strategy_->getCovariance();
 
         // Use enhanced outlier analysis with pattern detection
-        auto outlier_result = outlier_detector_->analyzeOutlier(T_lar_from_camera_measured, predicted_pose, covariance, result.confidence, config_);
+        auto outlier_result = outlier_detector_->analyzeOutlier(measured_pose, predicted_pose, covariance, result.confidence, config_);
 
         if (outlier_result.likely_bad_state) {
             if (config_.enable_debug_output) {
@@ -259,10 +301,12 @@ FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
 // ============================================================================
 
 Eigen::Matrix4d FilteredTracker::getFilteredTransform() const {
+	std::lock_guard<std::mutex> lock(state_mutex_);
 	return current_vio_camera_pose_ * filter_strategy_->getState().toTransform().inverse();
 }
 
 double FilteredTracker::getPositionUncertainty() const {
+    std::lock_guard<std::mutex> lock(state_mutex_);
     if (!filter_strategy_->isInitialized()) {
         return std::numeric_limits<double>::infinity();
     }
@@ -270,10 +314,13 @@ double FilteredTracker::getPositionUncertainty() const {
 }
 
 bool FilteredTracker::isInitialized() const {
+    std::lock_guard<std::mutex> lock(state_mutex_);
     return filter_strategy_->isInitialized();
 }
 
 void FilteredTracker::reset() {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+
     if (config_.enable_debug_output) {
         std::cout << "Resetting FilteredTracker (all components)" << std::endl;
     }


### PR DESCRIPTION
## Problem

The lightweight per-frame ops (`predictStep` / `updateVIOCameraPose` / `getFilteredTransform`) and the heavy `measurementUpdate` previously had to be **externally serialized** — the lar-swift ObjC bridge ran them all on a single serial dispatch queue — because `FilteredTracker` had no internal locking and shares mutable state (the filter strategy + VIO poses) between them.

Consequence: every per-frame call stalled for the **entire 0.5–2 s localization wall time**. AR tracking froze during each localization attempt (raised as a code-review finding on lar-swift PR #15).

## Change

Make `FilteredTracker` internally thread-safe with a single `state_mutex_` guarding the filter strategy, VIO pose state, timing and `last_transform_result_`.

- Per-frame methods lock for **microseconds**.
- `measurementUpdate` runs the expensive `base_tracker_` localization **without** the lock:
  1. **snapshot** the prediction (PnP seed) + capture-time VIO pose under a brief lock,
  2. **CV unlocked** (the 0.5–2 s work) — per-frame predict/getFilteredTransform run concurrently,
  3. **fuse** the result under a brief lock.

### Filter-timing correctness

Because per-frame `predictStep` now keeps advancing the filter during the unlocked CV, the measurement (from the capture-time image) would otherwise be fused against a state that has moved on — a spurious innovation equal to the camera motion during CV (→ likely outlier rejection during motion). The measured pose is **time-aligned forward** by the VIO motion that elapsed during localization before fusing:

```
T_lar_from_camera(now) = T_lar_from_camera(capture) · vio(capture)⁻¹ · vio(now)
```

Phase 3 also re-checks `isInitialized()` under the lock to handle a concurrent `reset()`.

### Caller contract

`base_tracker_` is intentionally **not** mutex-guarded (that's the point — CV runs unlocked), so `measurementUpdate` must not run concurrently with itself or with `getBaseTracker()` mutations (`configureImageSize`). Those heavy/rare ops stay serialized on a single background context. **Per-frame ops are always safe concurrently.**

## Validation

- Builds clean (Linux SuperBuild); `filtered_tracker.cpp` compiles with no new warnings.
- Full test suite passes (**111 tests**).
- Threading benefit (no per-frame stall) and the time-alignment behavior need on-device validation in the LARScan app — there is no FilteredTracker unit harness in-repo.

## Follow-up (lar-swift)

Once merged + submodule bumped, the bridge (`LARFilteredTracker.mm`) can drop its serial queue: per-frame ops call C++ directly (guarded by `state_mutex_`), and only `measurementUpdate`/`configureImageSize` stay on a background serial queue per the caller contract. This supersedes the interim `dispatch_async` mitigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)