### PR TITLE
Plain-C interop input structs for tracker interfaces

### DIFF
--- a/include/lar/core/spatial/spatial_query.h
+++ b/include/lar/core/spatial/spatial_query.h
@@ -1,0 +1,25 @@
+#ifndef LAR_CORE_SPATIAL_SPATIAL_QUERY_H
+#define LAR_CORE_SPATIAL_SPATIAL_QUERY_H
+
+// Plain-C spatial query type.
+//
+// Deliberately plain C (no C++), so the same definition can be shared verbatim across the C++
+// core, an Objective-C bridge, and Swift (where it imports as a native value type,
+// e.g. `LARSpatialQuery(x:z:diameter:)`).
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Spatial query: search center in map-local coordinates (x, z) and search diameter in meters.
+typedef struct LARSpatialQuery {
+    double x;
+    double z;
+    double diameter;
+} LARSpatialQuery;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LAR_CORE_SPATIAL_SPATIAL_QUERY_H

--- a/include/lar/tracking/filtered_tracker.h
+++ b/include/lar/tracking/filtered_tracker.h
@@ -141,6 +141,14 @@ public:
                                       double query_z,
                                       double query_diameter);
 
+    /// Interop-friendly overload: takes a grayscale image as a plain buffer view + a spatial
+    /// query struct (see lar/tracking/image_input.h and lar/core/spatial/spatial_query.h).
+    /// Wraps the buffer in a cv::Mat (no copy) and forwards to the cv::InputArray overload —
+    /// lets non-C++ callers (Obj-C/Swift) run a measurement update without touching opencv types.
+    MeasurementResult measurementUpdate(const LARImageInput& image,
+                                      const Frame& frame,
+                                      const LARSpatialQuery& query);
+
     /**
      * Get current filtered VIO → LAR map transform
      * This transform can be applied to VIO poses to get map-aligned poses

--- a/include/lar/tracking/image_input.h
+++ b/include/lar/tracking/image_input.h
@@ -1,0 +1,32 @@
+#ifndef LAR_TRACKING_IMAGE_INPUT_H
+#define LAR_TRACKING_IMAGE_INPUT_H
+
+// Plain-C image input type for the tracking/localization interface.
+//
+// Deliberately plain C (no opencv, no C++), so the same definition can be shared verbatim
+// across the C++ core, an Objective-C bridge, and Swift (where it imports as a native value
+// type, e.g. `LARImageInput(data:width:height:bytesPerRow:)`) without dragging opencv/C++
+// headers across the language boundary.
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Grayscale (single-channel, 8-bit) image input.
+///
+/// `data` points to the luma buffer; rows are `bytesPerRow`-strided. The pointer is **not**
+/// owned or copied — it must stay valid for the duration of the call that receives it.
+typedef struct LARImageInput {
+    const void *data;
+    int32_t width;
+    int32_t height;
+    int32_t bytesPerRow;
+} LARImageInput;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // LAR_TRACKING_IMAGE_INPUT_H

--- a/include/lar/tracking/tracker.h
+++ b/include/lar/tracking/tracker.h
@@ -6,7 +6,9 @@
 #include <opencv2/geometry.hpp>  // solvePnPRansac / Rodrigues (was calib3d in OpenCV 4)
 
 #include "lar/core/map.h"
+#include "lar/core/spatial/spatial_query.h"
 #include "lar/mapping/frame.h"
+#include "lar/tracking/image_input.h"
 #include "lar/tracking/vision.h"
 
 namespace lar {
@@ -30,6 +32,12 @@ namespace lar {
 
       bool localize(cv::InputArray image, const Frame &frame, double query_x, double query_z, double query_diameter, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess = Eigen::Matrix4d(), bool use_initial_guess = false);
       bool localize(cv::InputArray image, const cv::Mat& intrinsics, const cv::Mat& dist_coeffs, cv::Mat &rvec, cv::Mat &tvec, const cv::Mat &gvec, double query_x = 0.0, double query_z = 0.0, double query_diameter = 0.0);
+
+      /// Interop-friendly overload: takes a grayscale image as a plain buffer view + a spatial
+      /// query struct (see lar/tracking/image_input.h and lar/core/spatial/spatial_query.h).
+      /// Wraps the buffer in a cv::Mat (no copy) and forwards to the cv::InputArray overload —
+      /// lets non-C++ callers (Obj-C/Swift) localize without touching opencv types.
+      bool localize(const LARImageInput &image, const Frame &frame, const LARSpatialQuery &query, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess = Eigen::Matrix4d(), bool use_initial_guess = false);
 
       // Getter for gravity angle difference from last localization
       double getLastGravityAngleDifference() const;

--- a/src/tracking/filtered_tracker.cpp
+++ b/src/tracking/filtered_tracker.cpp
@@ -130,6 +130,15 @@ void FilteredTracker::predictStep() {
 // ============================================================================
 
 FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
+    const LARImageInput& image,
+    const Frame& frame,
+    const LARSpatialQuery& query) {
+    // Wrap the caller's grayscale bytes in a cv::Mat (no copy) and forward.
+    cv::Mat imageMat(image.height, image.width, CV_8UC1, const_cast<void*>(image.data), static_cast<size_t>(image.bytesPerRow));
+    return measurementUpdate(imageMat, frame, query.x, query.z, query.diameter);
+}
+
+FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
     cv::InputArray image,
     const Frame& frame,
     double query_x,

--- a/src/tracking/tracker.cpp
+++ b/src/tracking/tracker.cpp
@@ -24,6 +24,12 @@ namespace lar {
     vision.configureImageSize(imageSize);
   }
 
+  bool Tracker::localize(const LARImageInput &image, const Frame &frame, const LARSpatialQuery &query, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess, bool use_initial_guess) {
+    // Wrap the caller's grayscale bytes in a cv::Mat (no copy) and forward.
+    cv::Mat imageMat(image.height, image.width, CV_8UC1, const_cast<void*>(image.data), static_cast<size_t>(image.bytesPerRow));
+    return localize(imageMat, frame, query.x, query.z, query.diameter, result_transform, initial_guess, use_initial_guess);
+  }
+
   bool Tracker::localize(cv::InputArray image, const Frame &frame, double query_x, double query_z, double query_diameter, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess, bool use_initial_guess) {
     Eigen::Matrix3f frameIntrinsics = frame.intrinsics.cast<float>().transpose(); // transpose so that the order of data matches opencv
     cv::Mat intrinsics(3, 3, CV_32FC1, frameIntrinsics.data());


### PR DESCRIPTION
Adds two plain-C POD structs so the tracker inputs can be shared across C++, Objective-C, and Swift without dragging opencv/C++ headers across the language boundary:

- **`LARImageInput`** → `lar/tracking/image_input.h` (grayscale buffer: `data`, `width`, `height`, `bytesPerRow`)
- **`LARSpatialQuery`** → `lar/core/spatial/spatial_query.h` (`x`, `z`, `diameter`)

One struct per header so each can live in (and move between) the appropriate module — `LARSpatialQuery` sits in `core/spatial` next to `region_tree.h`.

Adds struct-taking overloads to `Tracker::localize` and `FilteredTracker::measurementUpdate` that wrap the grayscale buffer in a `cv::Mat` (no copy) and forward to the existing `cv::InputArray` methods. This moves the `cv::Mat` wrapping out of the consuming Obj-C bridge. The `cv::InputArray` methods are kept for internal callers (`lar_localize`, `colmap_refiner`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
