### PR TITLE
Rename LARImageInput → LARImage

### DIFF
--- a/include/lar/tracking/filtered_tracker.h
+++ b/include/lar/tracking/filtered_tracker.h
@@ -142,10 +142,10 @@ public:
                                       double query_diameter);
 
     /// Interop-friendly overload: takes a grayscale image as a plain buffer view + a spatial
-    /// query struct (see lar/tracking/image_input.h and lar/core/spatial/spatial_query.h).
+    /// query struct (see lar/tracking/image.h and lar/core/spatial/spatial_query.h).
     /// Wraps the buffer in a cv::Mat (no copy) and forwards to the cv::InputArray overload —
     /// lets non-C++ callers (Obj-C/Swift) run a measurement update without touching opencv types.
-    MeasurementResult measurementUpdate(const LARImageInput& image,
+    MeasurementResult measurementUpdate(const LARImage& image,
                                       const Frame& frame,
                                       const LARSpatialQuery& query);
 

--- a/include/lar/tracking/image.h
+++ b/include/lar/tracking/image.h
@@ -1,12 +1,12 @@
-#ifndef LAR_TRACKING_IMAGE_INPUT_H
-#define LAR_TRACKING_IMAGE_INPUT_H
+#ifndef LAR_TRACKING_IMAGE_H
+#define LAR_TRACKING_IMAGE_H
 
-// Plain-C image input type for the tracking/localization interface.
+// Plain-C image type for the tracking/localization interface.
 //
 // Deliberately plain C (no opencv, no C++), so the same definition can be shared verbatim
 // across the C++ core, an Objective-C bridge, and Swift (where it imports as a native value
-// type, e.g. `LARImageInput(data:width:height:bytesPerRow:)`) without dragging opencv/C++
-// headers across the language boundary.
+// type, e.g. `LARImage(data:width:height:bytesPerRow:)`) without dragging opencv/C++ headers
+// across the language boundary.
 
 #include <stdint.h>
 
@@ -14,19 +14,19 @@
 extern "C" {
 #endif
 
-/// Grayscale (single-channel, 8-bit) image input.
+/// Grayscale (single-channel, 8-bit) image — a non-owning view over a pixel buffer.
 ///
 /// `data` points to the luma buffer; rows are `bytesPerRow`-strided. The pointer is **not**
 /// owned or copied — it must stay valid for the duration of the call that receives it.
-typedef struct LARImageInput {
+typedef struct LARImage {
     const void *data;
     int32_t width;
     int32_t height;
     int32_t bytesPerRow;
-} LARImageInput;
+} LARImage;
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
 
-#endif  // LAR_TRACKING_IMAGE_INPUT_H
+#endif  // LAR_TRACKING_IMAGE_H

--- a/include/lar/tracking/tracker.h
+++ b/include/lar/tracking/tracker.h
@@ -8,7 +8,7 @@
 #include "lar/core/map.h"
 #include "lar/core/spatial/spatial_query.h"
 #include "lar/mapping/frame.h"
-#include "lar/tracking/image_input.h"
+#include "lar/tracking/image.h"
 #include "lar/tracking/vision.h"
 
 namespace lar {
@@ -34,10 +34,10 @@ namespace lar {
       bool localize(cv::InputArray image, const cv::Mat& intrinsics, const cv::Mat& dist_coeffs, cv::Mat &rvec, cv::Mat &tvec, const cv::Mat &gvec, double query_x = 0.0, double query_z = 0.0, double query_diameter = 0.0);
 
       /// Interop-friendly overload: takes a grayscale image as a plain buffer view + a spatial
-      /// query struct (see lar/tracking/image_input.h and lar/core/spatial/spatial_query.h).
+      /// query struct (see lar/tracking/image.h and lar/core/spatial/spatial_query.h).
       /// Wraps the buffer in a cv::Mat (no copy) and forwards to the cv::InputArray overload —
       /// lets non-C++ callers (Obj-C/Swift) localize without touching opencv types.
-      bool localize(const LARImageInput &image, const Frame &frame, const LARSpatialQuery &query, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess = Eigen::Matrix4d(), bool use_initial_guess = false);
+      bool localize(const LARImage &image, const Frame &frame, const LARSpatialQuery &query, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess = Eigen::Matrix4d(), bool use_initial_guess = false);
 
       // Getter for gravity angle difference from last localization
       double getLastGravityAngleDifference() const;

--- a/src/tracking/filtered_tracker.cpp
+++ b/src/tracking/filtered_tracker.cpp
@@ -130,7 +130,7 @@ void FilteredTracker::predictStep() {
 // ============================================================================
 
 FilteredTracker::MeasurementResult FilteredTracker::measurementUpdate(
-    const LARImageInput& image,
+    const LARImage& image,
     const Frame& frame,
     const LARSpatialQuery& query) {
     // Wrap the caller's grayscale bytes in a cv::Mat (no copy) and forward.

--- a/src/tracking/tracker.cpp
+++ b/src/tracking/tracker.cpp
@@ -24,7 +24,7 @@ namespace lar {
     vision.configureImageSize(imageSize);
   }
 
-  bool Tracker::localize(const LARImageInput &image, const Frame &frame, const LARSpatialQuery &query, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess, bool use_initial_guess) {
+  bool Tracker::localize(const LARImage &image, const Frame &frame, const LARSpatialQuery &query, Eigen::Matrix4d &result_transform, const Eigen::Matrix4d &initial_guess, bool use_initial_guess) {
     // Wrap the caller's grayscale bytes in a cv::Mat (no copy) and forward.
     cv::Mat imageMat(image.height, image.width, CV_8UC1, const_cast<void*>(image.data), static_cast<size_t>(image.bytesPerRow));
     return localize(imageMat, frame, query.x, query.z, query.diameter, result_transform, initial_guess, use_initial_guess);


### PR DESCRIPTION
Renames the tracking interop struct/header `LARImageInput` → `LARImage` (`image_input.h` → `image.h`). It models a non-owning grayscale image view; "Input" was noise from when it was conceived purely as the localize parameter.

Updates the `Tracker::localize` / `FilteredTracker::measurementUpdate` interop overloads accordingly. Mechanical; low churn (the type is new as of #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
