### PR TITLE
Odometry confidence tiers: capture-time signal + BA weighting

### DIFF
--- a/docs/ODOMETRY_CONFIDENCE.md
+++ b/docs/ODOMETRY_CONFIDENCE.md
@@ -1,0 +1,228 @@
+# Odometry Confidence Tiers
+
+How we tag each between-snap odometry edge with a coarse, **tuning-free** confidence
+signal at capture time, and let the **offline** refiner (and future loop closure) turn
+that into weights. This is the on-device input to the loop-closure work in
+[`RECONSTRUCTION_CLEANUP_PLAN.md`](RECONSTRUCTION_CLEANUP_PLAN.md).
+
+## Design contract
+
+- **Capture side makes no numeric decisions.** It records only categorical labels the
+  AR platform already computed (`ARCamera.trackingState` on iOS, `TrackingState` +
+  `TrackingFailureReason` on Android). No thresholds, no per-meter tuning on device.
+- **Offline side owns all tuning.** The refiner maps the categorical tier → an
+  information-matrix scale. Every number lives in `bundle_adjustment.cpp`, where tuning
+  is fine and platform-independent.
+- **Platform-neutral on disk.** `frames.json` stores one integer per frame. iOS and a
+  future Android app each supply a tiny native→neutral mapping; everything downstream
+  is identical regardless of capture platform.
+- **The signal is monitored continuously between snaps, not sampled at the snap.** An
+  odometry edge is a property of the whole interval between two keyframes, so we
+  accumulate the *worst* state seen across that interval and attach it to the edge.
+
+## The platform-neutral enum
+
+Stored as `odom_state` (int) on each `Frame`. Severity increases with the value, so a
+plain `max()` over the interval is the correct "worst-of" reduction. Values group into
+three offline tiers:
+
+| int | neutral state | tier | meaning for the odometry edge |
+| --- | --- | --- | --- |
+| 0 | `NORMAL` | **HIGH** | tracking nominal the entire interval — trust the relative pose |
+| 1 | `LIMITED_INITIALIZING` | **MEDIUM** | still initializing; noisy but continuous motion |
+| 2 | `LIMITED_EXCESSIVE_MOTION` | **MEDIUM** | motion blur / fast motion; downweight |
+| 3 | `LIMITED_INSUFFICIENT_VISUAL` | **MEDIUM** | too few features / too little light; downweight |
+| 4 | `RELOCALIZING` | **LOW** | recovered from tracking loss — edge **spans a discontinuity** |
+| 5 | `UNAVAILABLE` | **LOW** | no tracking during the interval — relative pose meaningless |
+
+The MEDIUM/LOW split is the whole point: MEDIUM = *soften* (real motion, just noisy),
+LOW = *break* (the relative pose crosses an ARKit/ARCore correction and isn't smooth
+motion). Loop closure distributes drift correction into LOW then MEDIUM edges while
+HIGH edges stay rigid.
+
+> Start-simple option: collapse to 2 tiers (`0` = HIGH, everything else = LOW) — a strict
+> subset. You can promote to 3 tiers later without recapturing, since the raw int is
+> stored, not the tier.
+
+### iOS — `ARCamera.TrackingState` → neutral int
+
+```
+.normal                          -> 0  NORMAL
+.limited(.initializing)          -> 1  LIMITED_INITIALIZING
+.limited(.excessiveMotion)       -> 2  LIMITED_EXCESSIVE_MOTION
+.limited(.insufficientFeatures)  -> 3  LIMITED_INSUFFICIENT_VISUAL
+.limited(.relocalizing)          -> 4  RELOCALIZING
+.notAvailable                    -> 5  UNAVAILABLE
+```
+
+### Android — `TrackingState` + `TrackingFailureReason` → neutral int (for the future ARCore app)
+
+```
+TRACKING                                 -> 0  NORMAL
+PAUSED + NONE                            -> 1  LIMITED_INITIALIZING   (startup pause)
+PAUSED + EXCESSIVE_MOTION                -> 2  LIMITED_EXCESSIVE_MOTION
+PAUSED + INSUFFICIENT_FEATURES           -> 3  LIMITED_INSUFFICIENT_VISUAL
+PAUSED + INSUFFICIENT_LIGHT              -> 3  LIMITED_INSUFFICIENT_VISUAL
+PAUSED + BAD_STATE                       -> 4  RELOCALIZING           (internal recovery)
+PAUSED + CAMERA_UNAVAILABLE              -> 5  UNAVAILABLE
+STOPPED                                  -> 5  UNAVAILABLE
+```
+
+Only this mapping and the accumulator below are platform-specific. Nothing else changes.
+
+## Capture accumulator (platform-agnostic logic)
+
+One integer of state, updated every frame in the existing per-frame callback, flushed at
+each snap. No allocation, no per-frame persistence.
+
+```
+// reset to the current endpoint state so the next interval starts fresh
+on each AR frame:      worst = max(worst, neutralState(frame))     // continuous monitor
+on snap(frame):        edgeState = worst
+                       worst     = neutralState(frame)             // reset for next interval
+                       addFrame(..., odomState: edgeState)
+```
+
+`odom_state` on a frame describes the edge **into** that frame (the interval from the
+previous snap up to and including this one). The refiner reads it on the destination
+vertex — consistent with how `addOdometry` builds the edge `(frame_id-1 -> frame_id)`.
+
+### iOS wiring (`Examples/LARScan/.../ViewController.swift`, in the lar-swift repo)
+
+- Add `private var odomWorstState: Int32 = 0` (MainActor-isolated, like the rest of the
+  controller state).
+- Add a pure mapping helper:
+
+  ```swift
+  private func neutralOdomState(_ s: ARCamera.TrackingState) -> Int32 {
+      switch s {
+      case .normal:                         return 0
+      case .limited(.initializing):         return 1
+      case .limited(.excessiveMotion):      return 2
+      case .limited(.insufficientFeatures): return 3
+      case .limited(.relocalizing):         return 4
+      case .notAvailable:                   return 5
+      @unknown default:                     return 0
+      }
+  }
+  ```
+
+- In `session(_:didUpdate frame:)` (ViewController.swift:533, already hops to MainActor):
+  `odomWorstState = max(odomWorstState, neutralOdomState(frame.camera.trackingState))`.
+- In `snap()` (ViewController.swift:251): capture `let state = odomWorstState`, then
+  `odomWorstState = neutralOdomState(frame.camera.trackingState)`, and pass `state` into
+  the widened `addFrame(...)` below.
+
+## Bridge change (`Sources/LocalizeAR-ObjC`, in the lar-swift repo)
+
+Widen the `CVPixelBuffer` variant that `snap()` calls (and, for parity, the `ARFrame`
+variant) with an `odomState` parameter. `LARMapper.h`:
+
+```objc
+- (void)addFramePixelBuffer:(CVPixelBufferRef)pixelBuffer
+                 intrinsics:(simd_float3x3)intrinsics
+                  timestamp:(NSTimeInterval)timestamp
+                  transform:(simd_float4x4)transform
+                  odomState:(int)odomState
+    NS_SWIFT_NAME( addFrame(pixelBuffer:intrinsics:timestamp:transform:odomState:) );
+```
+
+`LARMapper.mm` (`addFramePixelBuffer`, currently at line 79) sets one field before
+`_internal->addFrame(...)`:
+
+```objc
+aFrame.odom_state = odomState;
+```
+
+The `ARFrame` convenience `addFrame:transform:` can compute the state itself
+(`frame.camera.trackingState`) for callers that don't accumulate — but note that's the
+*instantaneous* state, not the interval worst-of. The snap path must use the accumulator.
+
+## C++ `Frame` + `frames.json` (this repo)
+
+`include/lar/mapping/frame.h`:
+
+```cpp
+class Frame {
+  public:
+    size_t id;
+    long long timestamp;
+    Eigen::Matrix3d intrinsics;
+    Eigen::Matrix4d extrinsics;
+    int odom_state{0};          // platform-neutral worst OdometryState over the interval
+    bool processed{false};
+    Frame();
+};
+// _WITH_DEFAULT so old frames.json (no odom_state) parse, defaulting to 0 = NORMAL/HIGH,
+// i.e. old captures keep today's uniform-trust behavior (no regression).
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Frame, id, timestamp, intrinsics, extrinsics, odom_state)
+```
+
+(nlohmann_json 3.11.3+ provides `..._WITH_DEFAULT`; the project already requires it.)
+
+Optional readability enum in the same header:
+
+```cpp
+enum class OdometryConfidence : int {
+  Normal = 0, LimitedInitializing = 1, LimitedExcessiveMotion = 2,
+  LimitedInsufficientVisual = 3, Relocalizing = 4, Unavailable = 5,
+};
+```
+
+## Refiner: tier → information weight (this repo)
+
+The only offline-tunable numbers. In `src/processing/bundle_adjustment.cpp`, add a small
+table and apply it in `addOdometry` (line 339), scaling the information matrix already
+built at lines 364–369:
+
+```cpp
+// Offline-tunable. HIGH = full trust; MEDIUM = downweight; LOW = near-free
+// (edge spans a tracking discontinuity, let loop closure absorb it here).
+static double odomConfidenceWeight(int odom_state) {
+  switch (odom_state) {
+    case 0:                 return 1.0;   // HIGH  (NORMAL)
+    case 1: case 2: case 3: return 0.25;  // MEDIUM (limited)
+    case 4: case 5:         return 0.02;  // LOW   (relocalizing / unavailable)
+    default:                return 1.0;
+  }
+}
+```
+
+Then, right before `e->setInformation(info);` (line 369), scale by the destination
+frame's tier (the edge runs `frame_id-1 -> frame_id`, and `odom_state` describes the
+interval into `frame2`):
+
+```cpp
+info *= odomConfidenceWeight(frame2.odom_state);
+e->setInformation(info);
+```
+
+Two policy variants (offline choice, no recapture):
+
+- **Downweight (default):** scale as above. Keeps the graph fully connected; the robust
+  chi² outlier pass (`markOutliers`, line 481) still applies.
+- **Break on LOW:** for `odom_state >= 4`, skip `addEdge`/`push_back` entirely so the
+  discontinuity contributes no odometry constraint. Use once a vision loop closure or
+  other constraint keeps that stretch connected — otherwise it can float.
+
+### Future loop closure
+
+Loop closure reads the **same** `odom_state` tiers to decide where drift correction
+lands: it should preferentially deform LOW (then MEDIUM) edges and leave HIGH rigid.
+Reuse `odomConfidenceWeight` (or a loop-closure-specific table) so capture stays the
+single categorical source of truth.
+
+## Backward compatibility
+
+- Old `frames.json` without `odom_state` → default `0` (HIGH) → identical to today's
+  behavior. No migration needed.
+- `odomConfidenceWeight(default)` returns `1.0`, so an unrecognized future value also
+  degrades to full trust rather than dropping the edge.
+
+## Tunable knobs (all offline, none on device)
+
+- The MEDIUM / LOW weights (`0.25` / `0.02`) and whether LOW breaks vs. downweights.
+- Whether to collapse to 2 or 3 tiers.
+- Whether loop closure uses a separate weight table from BA.
+
+Device-side capture has **zero** knobs — it emits ARKit/ARCore's own categorical label.

--- a/include/lar/mapping/frame.h
+++ b/include/lar/mapping/frame.h
@@ -9,6 +9,22 @@
 
 namespace lar {
 
+  // Platform-neutral confidence label for the odometry edge *into* a frame (the
+  // interval from the previous keyframe up to this one). Recorded at capture time as
+  // the worst tracking state observed over that interval; see docs/ODOMETRY_CONFIDENCE.md.
+  // iOS maps ARCamera.trackingState -> these; a future ARCore app maps TrackingState +
+  // TrackingFailureReason -> the same values. Severity increases with the value so a
+  // plain max() is the correct worst-of reduction. Offline tiers: {Normal}=HIGH,
+  // {1,2,3}=MEDIUM, {4,5}=LOW.
+  enum class OdometryConfidence : int {
+    Normal = 0,
+    LimitedInitializing = 1,
+    LimitedExcessiveMotion = 2,
+    LimitedInsufficientVisual = 3,
+    Relocalizing = 4,
+    Unavailable = 5,
+  };
+
   class Frame {
     public:
       // TODO: Make these attributes const
@@ -16,12 +32,18 @@ namespace lar {
       long long timestamp;
       Eigen::Matrix3d intrinsics;
       Eigen::Matrix4d extrinsics;
+      // Worst platform tracking state over the interval into this frame (see
+      // OdometryConfidence). Default 0 = Normal so captures predating this field keep
+      // the previous uniform-trust behavior.
+      int odom_state{0};
       // Auxilary data
       bool processed{false};
 
       Frame();
   };
-  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Frame, id, timestamp, intrinsics, extrinsics)
+  // _WITH_DEFAULT so older frames.json without odom_state still parse (missing key ->
+  // default-constructed value, i.e. 0 = Normal). No migration needed.
+  NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(Frame, id, timestamp, intrinsics, extrinsics, odom_state)
 }
 
 #endif /* LAR_MAPPING_FRAME_H */

--- a/src/processing/bundle_adjustment.cpp
+++ b/src/processing/bundle_adjustment.cpp
@@ -31,6 +31,35 @@ static constexpr double ANISOTROPY_RATIO = 2.0;           // Major/minor axis ra
 static constexpr double MIN_INFORMATION = 0.1;            // Minimum information value
 static constexpr double MAX_INFORMATION = 100.0;          // Maximum information value
 
+// --- Odometry confidence tiers -------------------------------------------------------
+// Multiplicative scale applied to an odometry edge's information matrix based on the
+// capture-time Frame::odom_state (lar::OdometryConfidence) — the worst platform tracking
+// state observed over the interval into that frame. HIGH = full trust; MEDIUM = downweight
+// (noisy but continuous motion); LOW = near-free so drift correction / loop closure is
+// absorbed on these edges (they span a tracking discontinuity). These three numbers are
+// the only tunable knobs; the capture side emits the categorical tier untouched.
+// See docs/ODOMETRY_CONFIDENCE.md.
+static constexpr double ODOM_CONFIDENCE_WEIGHT_HIGH   = 1.0;
+static constexpr double ODOM_CONFIDENCE_WEIGHT_MEDIUM = 0.25;
+static constexpr double ODOM_CONFIDENCE_WEIGHT_LOW    = 0.02;
+
+static double odomConfidenceWeight(int odom_state) {
+  using OC = lar::OdometryConfidence;
+  switch (static_cast<OC>(odom_state)) {
+    case OC::Normal:
+      return ODOM_CONFIDENCE_WEIGHT_HIGH;
+    case OC::LimitedInitializing:
+    case OC::LimitedExcessiveMotion:
+    case OC::LimitedInsufficientVisual:
+      return ODOM_CONFIDENCE_WEIGHT_MEDIUM;
+    case OC::Relocalizing:
+    case OC::Unavailable:
+      return ODOM_CONFIDENCE_WEIGHT_LOW;
+    default:
+      return ODOM_CONFIDENCE_WEIGHT_HIGH;  // unknown/future value -> full trust (no regression)
+  }
+}
+
 G2O_USE_OPTIMIZATION_LIBRARY(eigen);
 
 namespace g2o {
@@ -366,6 +395,10 @@ namespace lar {
     info.block<3,3>(0,0) = Eigen::Matrix3d::Identity() * distance_scale * distance_scale / (translation_uncertainty*translation_uncertainty);
     // Rotation information: scales as 1/distance² (drift accumulates with time/distance)
     info.block<3,3>(3,3) = Eigen::Matrix3d::Identity() * distance_scale * distance_scale / (rotation_uncertainty*rotation_uncertainty);
+    // Scale by the capture-time confidence tier for the interval into frame2. The edge runs
+    // frame_id-1 -> frame_id and odom_state describes exactly that interval, so a shaky /
+    // relocalizing stretch is down-weighted here rather than trusted like a clean one.
+    info *= odomConfidenceWeight(frame2.odom_state);
     e->setInformation(info);
     // g2o::RobustKernelHuber* rk = new g2o::RobustKernelHuber;
     // rk->setDelta(sqrt(12.592));


### PR DESCRIPTION
## What & why

ARKit gives excellent *relative* pose but drifts globally, and its tracking quality varies across a capture (excessive motion, low texture, relocalization). Until now every ARKit-derived odometry constraint in bundle adjustment was trusted equally. This adds a coarse, **capture-time confidence signal per between-snap odometry edge** and uses it to weight those edges in BA — and it's the input the upcoming vision loop-closure work needs to decide *where* drift correction should land.

Design contract: **the capture side makes no numeric decisions** (it records only the platform's own categorical tracking label), and **all tuning lives offline** in the refiner. See [`docs/ODOMETRY_CONFIDENCE.md`](docs/ODOMETRY_CONFIDENCE.md).

## Changes

- **`Frame::odom_state`** + `OdometryConfidence` enum (`frame.h`): a platform-neutral int = the *worst* tracking state observed over the interval into that frame (severity-ordered, so `max()` is the reduction). Serialized into `frames.json` via `NLOHMANN_..._WITH_DEFAULT` so older captures without the field parse as `0` (Normal) — no migration, no regression.
- **BA weighting** (`bundle_adjustment.cpp`): `addOdometry` scales the odometry information matrix by `odomConfidenceWeight(odom_state)` — HIGH (Normal)=`1.0`, MEDIUM (Limited*)=`0.25`, LOW (Relocalizing/Unavailable)=`0.02`. These three constants are the only tunable knobs; unknown values fall back to full trust.

## Platform-neutral (iOS today, Android-ready)

The on-disk enum is not ARKit-specific: iOS maps `ARCamera.trackingState` → the int; a future ARCore app maps `TrackingState + TrackingFailureReason` → the same values. Everything downstream is identical regardless of capture platform. (The capture-side accumulator + bridge lands in a companion lar-swift PR.)

## Verification

- JSON round-trip: `odom_state:4` → 4; erasing the key → default `0`.
- `make fast` builds `lar_refine_colmap` + `lar_create_map` clean.

## Not in this PR (by design)

- **Loop closure** — the reason the tiers exist. BA now *respects* the tiers, but there's no vision loop-closure constraint yet; down-weighting a LOW edge just makes BA trust it less. Tiers tell loop closure where to absorb correction once it's built.
- Weight values are placeholder defaults pending a sweep on real captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
