### PR TITLE
backbone: footprint / free-space supervision generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 # Claude Code local metadata / g2o debug dumps
 .claude/
 debug.txt
+/models

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,0 +1,93 @@
+# Handy Commands (Linux dev box)
+
+Quick reference for running the COLMAP pipeline on this machine. See
+[INSTALLATION.md](INSTALLATION.md) and [RECONSTRUCTION.md](RECONSTRUCTION.md) for the
+full workflow.
+
+> **This box has no system `colmap`.** COLMAP 4.1 (CUDA) lives in a user-space
+> micromamba env named `colmap`. Every command that touches COLMAP must run through
+> `~/bin/micromamba run -n colmap ...` so the env's binary is on `PATH`. Python deps
+> are managed with `uv`, so the pipeline is wrapped as
+> `micromamba run -n colmap uv run python ...`.
+
+## Environment
+
+```sh
+# Verify COLMAP sees CUDA (should print "... with CUDA")
+~/bin/micromamba run -n colmap colmap --version
+
+# Verify the GPU (RTX 5060, 8 GB, Blackwell sm_120)
+nvidia-smi
+```
+
+## Run the reconstruction pipeline
+
+Run from the repo root (`~/Code/lar`). The script is not executable — call it through
+`python` (running `script/colmap/colmap.py` directly gives "Permission denied").
+
+```sh
+# ARKit-covisibility matching (loop-closure connectivity)
+~/bin/micromamba run -n colmap uv run python script/colmap/colmap.py \
+    input/<session> --use_covisibility
+
+# GLOMAP global SfM (faster reconstruction)
+~/bin/micromamba run -n colmap uv run python script/colmap/colmap.py \
+    input/<session> --use_glomap
+
+# Sequential matching (best for ordered/video-like captures)
+~/bin/micromamba run -n colmap uv run python script/colmap/colmap.py \
+    input/<session> --use_sequential
+```
+
+`<session>` is a directory under `input/` containing `*_image.jpeg` files and
+`frames.json`.
+
+### GPU acceleration
+
+All heavy stages run on the GPU automatically — no flag needed:
+
+| Stage              | GPU flag (set by the script)      |
+| ------------------ | --------------------------------- |
+| SIFT extraction    | `--FeatureExtraction.use_gpu 1`   |
+| Feature matching   | `--FeatureMatching.use_gpu 1`     |
+
+**8 GB VRAM caveat:** on park-sized datasets GPU SIFT can OOM. If it crashes during
+extraction/matching, lower the feature budget:
+
+```sh
+... script/colmap/colmap.py input/<session> --use_covisibility --max_num_features 8192
+```
+
+## Pipeline options
+
+| Flag                     | Default | Purpose                                                        |
+| ------------------------ | ------- | -------------------------------------------------------------- |
+| `--use_colmap_sift`      | off     | Use COLMAP's built-in SIFT instead of OpenCV                   |
+| `--max_num_features N`   | 16384   | Max features per image (lower to fit VRAM)                     |
+| `--alignment_max_error`  | 0.1     | Max error threshold for model alignment                        |
+| `--use_vocab_tree`       | off     | Vocab-tree matching instead of exhaustive                      |
+| `--use_sequential`       | off     | Sequential/sliding-window matching + vocab-tree loop detection |
+| `--sequential_overlap N` | 10      | Images matched ahead per frame (sequential)                    |
+| `--use_glomap`           | off     | GLOMAP global SfM instead of incremental COLMAP                |
+| `--use_arkit_poses`      | off     | Triangulate against fixed ARKit poses (wide-baseline captures) |
+| `--use_covisibility`     | off     | Augment matching with ARKit-covisibility loop-closure pairs    |
+
+### Covisibility tuning (`--use_covisibility`)
+
+| Flag                   | Default | Purpose                                            |
+| ---------------------- | ------- | -------------------------------------------------- |
+| `--covis_base_radius`  | 8.0     | Covisibility radius (m) before drift slack         |
+| `--covis_drift_rate`   | 0.02    | Normal-tracking drift as fraction of arc length    |
+| `--covis_drift_cap`    | 15.0    | Max drift slack added to the radius (m)            |
+| `--covis_max_angle`    | 45.0    | Max optical-axis angle between paired frames (deg) |
+| `--covis_min_seq_gap`  | 10      | Skip pairs closer than this in capture order       |
+| `--covis_max_pairs`    | 30      | Keep only the nearest N candidates per image       |
+
+## Raw COLMAP commands
+
+Anything else you'd normally run as `colmap <cmd>`:
+
+```sh
+~/bin/micromamba run -n colmap colmap gui
+~/bin/micromamba run -n colmap colmap <subcommand> <args...>
+```

--- a/docs/RECONSTRUCTION.md
+++ b/docs/RECONSTRUCTION.md
@@ -89,6 +89,8 @@ locked environment, no manual venv activation):
 cd /path/to/lar
 # Recommended for large / low-parallax capture (e.g. a park):
 uv run python script/colmap/colmap.py input/1782302260032 --use_sequential --use_arkit_poses
+~/bin/micromamba run -n colmap uv run python script/colmap/colmap.py \
+    input/maguro-park-after-itchy-copy --use_covisibility
 ```
 
 Replace `1782302260032` with your session folder name. The pipeline:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,5 @@ gsplat = [
 # IMDF GeoJSON. shapely for robust polygonisation (validity, holes, winding, simplify).
 imdf = [
     "shapely>=2.0.0",
+    "scikit-image>=0.22.0",
 ]

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -94,6 +94,36 @@ bush, 12 bench, 11 pole, 8 sign, 5 trash-can, 4 rock; trees line the walked path
 IMDF `amenity.landmark` (trees/benches) / `unit.structure`. Knobs: `--prompt`, `--box-thr/
 --text-thr` (detector), `--eps/--min-samples` (cluster radius / min detections per object).
 
+### `--backend {moondream,gemini}` — pointing-VLM front-end
+
+Same points pipeline, different instance detector. A **pointing VLM** emits *one 2D point per
+instance* directly from a class name — no boxes. Because the VLM points at the object body
+(trunk/seat), not its base, we **drop straight down the image column to the first ground
+(DEM-finite) pixel** = the object's ground contact directly below. That contact feeds the
+*identical* `world → DBSCAN` clustering as the box path, so the backends are directly comparable.
+
+- **`gemini`** (cloud oracle) — Gemini's trained pointing via `google-genai`; needs
+  `GEMINI_API_KEY` in the env. Default `gemini-flash-lite-latest` (free-tier accessible). One
+  multi-class call per frame returns `{"point":[y,x],"label"}` at the ground contact.
+- **`moondream`** (local, Apache-2.0) — Moondream2's native `.point()`. **Currently blocked**:
+  its HF remote code is incompatible with transformers ≥ 5 (`all_tied_weights_keys`); needs a
+  transformers-4 env or the standalone `moondream` package. Weights download fine.
+
+```sh
+# cloud oracle (quality ceiling); GEMINI_API_KEY must be set, never commit it
+GEMINI_API_KEY=... uv run --extra segmentation --with google-genai python \
+  script/backbone/base_points.py --session maguro-park-after-itchy --backend gemini --sample 40
+```
+
+**Gemini vs Grounding DINO, apples-to-apples (40 frames, `--dem-source mono --min-samples 2`):**
+DINO 231 pts → **29 objects**; Gemini 828 pts → **115 objects** (77 tree, 16 bush, 9 rock, 5
+pole, 5 bench, 2 sign, 1 trash can). ~4× the recall — Gemini catches background trees, saplings,
+and occluded contacts a tiny box detector misses, and its points land on the ground contact
+without a prompt trick. Caveats: cloud API (not shippable offline; ~1 paid call/frame, free-tier
+daily caps), and `drop_to_ground` can bias a distant object's contact slightly toward the camera
+(the first ground pixel below the trunk). Natural next step: use Gemini as an **oracle to distill
+labels** into a shippable local head.
+
 ### Status / next
 
 - [x] `base_points.py`: open-vocab foot-point → BEV clustering → 109 deduped labelled objects

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -128,6 +128,14 @@ labels** into a shippable local head.
 
 ## `bev_render.py` — presentation-grade BEV for UI
 
+> **Archive.** The full 643-frame run and its renders are kept at
+> `output/maguro-park-bev-archive/` with a `REPRODUCE.md` recording exact commands and commit
+> SHAs. That run costs ~1 h of GPU time and `output/` is **gitignored**, so those files exist on
+> disk only — back them up if they matter. `--style clean3` regenerates the reference figure
+> from HEAD (99.4% pixel-identical; the remainder is the later border-speckle fix), so
+> reproducing it never requires checking out an old commit.
+
+
 `footprint2d.npz` is **evidence**: every cell is whatever the multi-view votes support, speckle
 and all. Right for a raster you compute against, wrong for a UI — a map that draws a lone
 mis-voted cell as confidently as a corridor seen 101 times reads as broken, and an object drawn

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -9,6 +9,7 @@ two separate off-the-shelf models (DA2 depth + Mask2Former seg) with one backbon
 |------|------|
 | `probe.py`            | is the frozen backbone worth building on? `pca` (feature viz) + `linprobe` (linear head vs Mask2Former pseudo-labels). Verdict: yes — ViT-S/16 hits 0.87 patch-acc on our taxonomy. |
 | `footprint_labels.py` | **generate footprint / free-space supervision** (below) for a ground head, no manual labels. |
+| `base_points.py`      | **deduped discrete object footprints** — open-vocab detection → foot points → BEV clustering (below). |
 
 ## `footprint_labels.py` — footprint / free-space supervision generator
 
@@ -66,7 +67,39 @@ Key knobs: `--depth-dir/--depth-stride/--depth-voxel` (mono source), `--cell-siz
 `--size` (render res), `--max-range`, `--clearance-lo/-hi` (occluder band),
 `--min-count`/`--solid-gap` (footprint solidity), `--occ-margin`, `--splat-radius`.
 
+## `base_points.py` — deduped discrete object footprints
+
+Semantic masks smear: the same tree, projected from 970 frames, becomes one un-separable BEV
+blob. The multi-view fix is the **foot point** — reduce each *detected instance* to its
+ground-contact (bottom-centre of the box), project to the ground, and **cluster across frames**.
+Points from one object collapse to a single landmark; a stray frame is an outlier. Instance
+detection (not semantic seg) is what makes objects separable to begin with.
+
+Per sampled frame: **Grounding DINO** (Apache-2.0, open-vocab, via `transformers`) detects the
+`--prompt` classes → foot point per box → **DEM ground depth** at that pixel (the trusted
+surface, reusing this dir's DEM render — not mono depth at the noisy object edge) → world point.
+Across frames: gravity-align → **DBSCAN per class** → one labelled footprint per object.
+
+Outputs `output/<session>-basepoints/`: `bev_footprints.png` (top-down map, camera trajectory +
+class-coloured markers sized by detection count), `objects.json` (`{class,u,v,count,score}` per
+object), `detections/` (per-frame box + foot-point overlays for QA).
+
+```sh
+uv run --extra segmentation python script/backbone/base_points.py \
+  --session maguro-park-after-itchy --dem-source mono --sample 250
+```
+
+On `maguro-park-after-itchy` (250 frames): 1364 foot points → **109 objects** — 47 tree, 22
+bush, 12 bench, 11 pole, 8 sign, 5 trash-can, 4 rock; trees line the walked paths. Drops into
+IMDF `amenity.landmark` (trees/benches) / `unit.structure`. Knobs: `--prompt`, `--box-thr/
+--text-thr` (detector), `--eps/--min-samples` (cluster radius / min detections per object).
+
 ### Status / next
+
+- [x] `base_points.py`: open-vocab foot-point → BEV clustering → 109 deduped labelled objects
+  on the park (the "occupied areas *with semantic labels*" ask, as discrete landmarks)
+- [ ] **lines** for extended objects (walls/hedges): SAM2/Grounded-SAM-2 mask → bottom contour
+  → ground polyline (vs a single point)
 
 - [x] geometry-only targets validated on `maguro-park-after-itchy` (open ground → visible,
   trunks/walls → footprint, distant occluded ground → hidden; metric depth sane 2–30 m)

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -48,20 +48,32 @@ Per frame, at a downscaled render resolution:
 ```sh
 # from repo root; --sample spreads N frames across the whole capture for QA
 uv run python script/backbone/footprint_labels.py --session maguro-park-after-itchy --sample 10
+# denser ground surface from fused mono depth (needs script/depth/mono_depth.py output)
+uv run python script/backbone/footprint_labels.py --session maguro-park-after-itchy --dem-source mono
 # full run
 uv run python script/backbone/footprint_labels.py --session maguro-park-after-itchy
 ```
 
-Key knobs: `--cell-size` (DEM), `--size` (render res), `--max-range`, `--clearance-lo/-hi`
-(occluder band), `--min-count`/`--solid-gap` (footprint solidity), `--occ-margin`,
-`--splat-radius`.
+**`--dem-source {colmap,mono}`** — where the ground *surface* comes from. `colmap` (default)
+uses the sparse SfM points; `mono` back-projects the per-view mono depth
+(`output/<session>-depth-<mono>/`, from `script/depth/mono_depth.py`) into a dense cloud for
+the DEM. **Footprint/occupancy always stays on the accurate COLMAP obstacle cloud** (the
+depth-bench hybrid: mono's vertical noise over-blocks). On `maguro-park-after-itchy`, `mono`
+lifts DEM coverage 20%→43% and *trusted* depth-target coverage 75%→98% (near-zero extrapolated
+fill under the loss) — for ~33 s reusing precomputed maps.
+
+Key knobs: `--depth-dir/--depth-stride/--depth-voxel` (mono source), `--cell-size` (DEM),
+`--size` (render res), `--max-range`, `--clearance-lo/-hi` (occluder band),
+`--min-count`/`--solid-gap` (footprint solidity), `--occ-margin`, `--splat-radius`.
 
 ### Status / next
 
 - [x] geometry-only targets validated on `maguro-park-after-itchy` (open ground → visible,
   trunks/walls → footprint, distant occluded ground → hidden; metric depth sane 2–30 m)
+- [x] `--dem-source mono` hybrid: dense mono DEM + COLMAP footprint → trusted depth-target
+  coverage 75%→98% (reconstruction poses are fine; the ground was just sparsely sampled)
 - [ ] **FOOTPRINT-SEMANTICS**: vote each obstacle point's Mask2Former class (the `MaskStore`
   cache) → footprint cells carry a class id ("occupied areas *with semantic labels*")
-- [ ] denser occluders for a stronger hidden-ground signal (extruded footprint columns, or
-  mono-depth back-projection) — sparse COLMAP gives a speckly forest-floor footprint
+- [ ] denser *footprint*: 2DGS surfels (dense **and** surface-accurate — fixes the speckly
+  forest-floor footprint that sparse COLMAP still leaves, unlike mono which over-blocks)
 - [ ] train the head on frozen LingBot patch features (semantic head + this ground head)

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -126,6 +126,47 @@ daily caps), and `drop_to_ground` can bias a distant object's contact slightly t
 (the first ground pixel below the trunk). Natural next step: use Gemini as an **oracle to distill
 labels** into a shippable local head.
 
+## Multi-view evidence: ratios, bearings, and a geometric HIDDEN
+
+Fusion used to be raw vote counts (`foot_ct >= min_foot`) over *pixels*, which has no
+denominator: 3 votes looked identical whether the cell was in view 3 times (unanimous) or 40
+(7.5%, noise). And two pixels in a single image counted as "2 votes" — not multi-view evidence
+at all.
+
+Three changes:
+
+- **Visibility denominator.** Each frame rasterises which cells had their ground in frustum
+  (`visible_cells`, a coarse raycast). Votes are now per-*frame*, thresholded as a **fraction**
+  of observing frames (`--min-free-frac`, `--min-foot-frac`).
+- **Distinct bearings** (`--min-bearings`, 32 bins packed in a `uint32`, popcount to test).
+  Ten votes from one viewpoint are ONE correlated observation; counting them individually
+  manufactures confidence from a single mistake, which is what drew the radial BEV streaks.
+- **HIDDEN is now geometric** (`--hidden-mode visibility`, default). In frustum yet never
+  observed as walkable ⇒ something stood in front of it. This replaces a morphological
+  close + occluder-proximity dilate that had to *guess* occlusion from the shape of the FREE
+  blob. The old path is kept as `--hidden-mode morphology` for comparison.
+
+**The denominator must be a superset of every numerator**, or cells get disqualified for "not
+being observed" by the very frame that observed them. The raycast alone isn't: it's
+coverage-gated and capped at `--obs-max-range`, while FREE back-projects mono depth with
+neither limit. So `obs` is seeded with the raycast and **unioned with whatever the frame
+actually voted**. Getting this wrong first time cost 19 points of FREE (24.9% → 6.0%).
+
+**This is stricter, and honestly so.** At 40 frames, 1103 of 1196 footprint-voted cells had
+exactly *one* bearing — the old 2.3% FOOTPRINT was mostly single-view claims counted per pixel.
+Evidence scales with sampling:
+
+| | 40 frames | 150 frames |
+|---|---|---|
+| cells ever in frustum | 49.7% | **72.0%** (median 2 → 4 views) |
+| FREE | 16.7% | **42.1%** |
+| FOOTPRINT | 0.2% | **1.6%** |
+| UNKNOWN | 70.5% | **41.7%** |
+| footprint cells ≥2 bearings | 93 / 1196 | **939 / 3377** |
+
+So the honest reading: multi-view corroboration is a sampling-density question, not a
+threshold-tuning one. Run denser rather than loosening the gates.
+
 ## Depth contact gate — "touches the ground in 2D" ≠ "touches it in 3D"
 
 Both footprint paths reduce an object to its **bottom-most pixel** and ray-DEM that to the

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -126,6 +126,45 @@ daily caps), and `drop_to_ground` can bias a distant object's contact slightly t
 (the first ground pixel below the trunk). Natural next step: use Gemini as an **oracle to distill
 labels** into a shippable local head.
 
+## `bev_render.py` — presentation-grade BEV for UI
+
+`footprint2d.npz` is **evidence**: every cell is whatever the multi-view votes support, speckle
+and all. Right for a raster you compute against, wrong for a UI — a map that draws a lone
+mis-voted cell as confidently as a corridor seen 101 times reads as broken, and an object drawn
+as a hollow ring of base contacts reads as a hole in the world.
+
+So this is a separate, deliberately **lossy** layer. Nothing feeds back into the npz, and
+re-rendering is instant instead of an hour.
+
+```sh
+uv run python script/backbone/bev_render.py --npz output/<session>-footprint2d/footprint2d.npz
+```
+
+Three things it does that the evidence raster must not:
+
+1. **Says "I don't know" out loud** — below `--min-views` (4) a cell renders **grey** instead of
+   committing to a class. This is what stops coverage-frontier speckle reading as real
+   structure. FREE-but-unclassified surface also goes grey, not terrain: walkable-but-unknown
+   is information, guessing is not.
+2. **Fills occupied interiors** — FOOTPRINT marks base contacts (a camera-facing rim), so
+   objects come out hollow. Enclosed holes up to `--max-fill` are filled; larger voids are real
+   (a tree-ringed courtyard) and stay open.
+3. **Drops speckle** — components under `--min-blob` are demoted to **grey**, not to a
+   neighbouring class: an isolated cell is unsupported, not evidence for its surroundings.
+
+Two tuning traps, both hit while building it:
+
+- **Occupied needs `close_only`, never `smooth`.** `smooth()` closes *then opens*, and an open
+  with a 5-cell kernel erases anything smaller than the kernel — which is every trunk and bench
+  at 0.5 m/cell. Using it dropped occupied 925 → 151 cells; close-only plus a smaller
+  `--min-blob-occupied` gives 2.6% coverage that reads as real structure.
+- **Smooth the survey masks, not just the classes.** The frontier is dithered at cell level (one
+  ray lands, its neighbour misses) and renders as salt-and-pepper along every edge. Smoothing
+  `surveyed`/`confident` changes only where we admit to knowing, never what we claim to know.
+
+Full-run output: path/paved 19.1%, terrain 24.1%, grass 7.5%, occluded 7.6%, occupied 2.6%,
+low-confidence 29.7%, not-surveyed 9.5%.
+
 ## Walkable surface: PATH separated from ground
 
 `Role.GROUND` lumps `PATH` / `PAVEMENT` / `GRASS` / `TERRAIN` / `STAIRS` into one

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -152,6 +152,16 @@ Three things it does that the evidence raster must not:
 3. **Drops speckle** — components under `--min-blob` are demoted to **grey**, not to a
    neighbouring class: an isolated cell is unsupported, not evidence for its surroundings.
 
+**Occupied is coloured by what is standing there** — `structure` gives each footprint cell a
+`Klass`, and each occupied blob takes the majority class of its voted cells (so one object is
+one colour rather than a speckled mosaic). Full run: tree/bush 2.5%, building 0.7%, wall 0.1%,
+furniture 0.1%.
+
+Walkable-vs-solid is carried by **lightness, not hue** — ground classes light and desaturated,
+occupied dark and saturated, hue distinguishing class within each group. Colouring occupied
+*tree* in the same green family and lightness as *grass* made the two read alike at a glance,
+which is the one confusion a navigation map cannot afford.
+
 Two tuning traps, both hit while building it:
 
 - **Occupied needs `close_only`, never `smooth`.** `smooth()` closes *then opens*, and an open

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -126,6 +126,29 @@ daily caps), and `drop_to_ground` can bias a distant object's contact slightly t
 (the first ground pixel below the trunk). Natural next step: use Gemini as an **oracle to distill
 labels** into a shippable local head.
 
+## Walkable surface: PATH separated from ground
+
+`Role.GROUND` lumps `PATH` / `PAVEMENT` / `GRASS` / `TERRAIN` / `STAIRS` into one
+undifferentiated FREE, so the surface distinction was computed per pixel and then thrown away.
+A navigation graph wants paved path separated from lawn.
+
+`surface` is now a per-cell ground class (exactly mirroring how `structure` works for footprint
+cells), saved in the npz and rendered three ways:
+
+- `footprint2d_bev.png` — FREE cells painted with their ground class instead of flat green
+- `footprint2d_surface.png` — the walkable-surface map alone
+- `footprint2d_path.png` — path/pavement/stairs (yellow) vs grass (green) vs terrain (grey)
+
+On `maguro-park-after-itchy` (40 frames): PATH 5.8%, TERRAIN 5.3%, GRASS 1.6%, STAIRS 0.1%,
+UNKNOWN 4.1% of the grid. The path corridors and their Y-junction come out as coherent
+connected structure, matching the walked capture.
+
+**`--min-surf-votes` (default 4).** `state` is multi-view gated but this argmax is not, so a
+cell that scraped through FREE could take its class from a couple of distant pixels — visible
+as speckle over open ground. Below the floor a cell stays walkable but **unclassified**, which
+is the honest answer rather than a coin flip. It moved PATH 8.1% → 5.8% and removed most of the
+far-field scatter.
+
 ## Multi-view evidence: ratios, bearings, and a geometric HIDDEN
 
 Fusion used to be raw vote counts (`foot_ct >= min_foot`) over *pixels*, which has no

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -1,0 +1,67 @@
+# backbone — LingBot-Vision heads for the semantic-BEV front-end
+
+Frozen [LingBot-Vision](https://github.com/robbyant/lingbot-vision) ViT (Apache-2.0 code +
+weights) as a **unified feature source** for the two things the BEV front-end needs per frame:
+dense semantics and a ground/footprint model. Cheap heads on the same patch grid replace the
+two separate off-the-shelf models (DA2 depth + Mask2Former seg) with one backbone.
+
+| file | role |
+|------|------|
+| `probe.py`            | is the frozen backbone worth building on? `pca` (feature viz) + `linprobe` (linear head vs Mask2Former pseudo-labels). Verdict: yes — ViT-S/16 hits 0.87 patch-acc on our taxonomy. |
+| `footprint_labels.py` | **generate footprint / free-space supervision** (below) for a ground head, no manual labels. |
+
+## `footprint_labels.py` — footprint / free-space supervision generator
+
+Produces the per-frame training targets a ground head needs à la Niantic's *Footprints and
+Free Space from a Single Color Image* (CVPR 2020) — the one signal plain segmentation can't
+give: **where the ground continues behind objects**, and **which ground cells an object's
+footprint occupies**. That's what tells the BEV projector which pixels map onto the ground
+plane (incl. hidden ground) and which map onto occupied area.
+
+**Why it's cleaner than Niantic's method.** They had no global model, so they manufactured
+hidden-ground labels by projecting the ground seen in *neighbouring* frames into the target
+view. We already reconstruct a gravity-aligned **global ground DEM**
+(`semantic_bev/geometry.from_reconstruction`). Rendering that DEM into a target camera yields
+the full ground extent — visible *and* occluded — in one shot, less noisy than pairwise
+reprojection. The neighbour-frame trick is subsumed by "render the global DEM".
+
+**How.** The DEM is rasterised as a triangle mesh into each posed camera (z-buffered → dense
+metric ground-depth). Body-height band points splat in as occluders (visible vs hidden split).
+Footprint cells reuse the **validated occupancy rule** from `ground_model.build_level`:
+solid-to-ground obstacles only (≥ `min_count` points whose low height-above-ground quantile
+≤ `solid_gap`), so canopy overhanging an open path stays walkable ground rather than blocking
+it.
+
+### Outputs (`output/<session>-footprint/`)
+
+Per frame, at a downscaled render resolution:
+- `<stem>.png` — uint8 class map: `0` non-ground · `1` visible-ground · `2` hidden-ground ·
+  `3` footprint (occupied) · `4` object (above-horizon structure)
+- `<stem>_depth.npy` — float32 metric depth to the DEM ground (valid on the ground extent) —
+  the "depth to (hidden) ground" regression target
+- `<stem>_cover.npy` — float32 {0,1}: ground cell DEM-observed vs extrapolated → per-pixel loss weight
+- `<stem>_preview.png` — RGB × colourised labels (eyeball check)
+- `meta.json` — class legend + params
+
+### Run
+
+```sh
+# from repo root; --sample spreads N frames across the whole capture for QA
+uv run python script/backbone/footprint_labels.py --session maguro-park-after-itchy --sample 10
+# full run
+uv run python script/backbone/footprint_labels.py --session maguro-park-after-itchy
+```
+
+Key knobs: `--cell-size` (DEM), `--size` (render res), `--max-range`, `--clearance-lo/-hi`
+(occluder band), `--min-count`/`--solid-gap` (footprint solidity), `--occ-margin`,
+`--splat-radius`.
+
+### Status / next
+
+- [x] geometry-only targets validated on `maguro-park-after-itchy` (open ground → visible,
+  trunks/walls → footprint, distant occluded ground → hidden; metric depth sane 2–30 m)
+- [ ] **FOOTPRINT-SEMANTICS**: vote each obstacle point's Mask2Former class (the `MaskStore`
+  cache) → footprint cells carry a class id ("occupied areas *with semantic labels*")
+- [ ] denser occluders for a stronger hidden-ground signal (extruded footprint columns, or
+  mono-depth back-projection) — sparse COLMAP gives a speckly forest-floor footprint
+- [ ] train the head on frozen LingBot patch features (semantic head + this ground head)

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -126,6 +126,48 @@ daily caps), and `drop_to_ground` can bias a distant object's contact slightly t
 (the first ground pixel below the trunk). Natural next step: use Gemini as an **oracle to distill
 labels** into a shippable local head.
 
+## Depth contact gate — "touches the ground in 2D" ≠ "touches it in 3D"
+
+Both footprint paths reduce an object to its **bottom-most pixel** and ray-DEM that to the
+ground. `footprint_instances`' *canopy guard* checks the pixels below are `Role.GROUND`, but
+that is a **2D** test and passes in exactly the case it needs to catch: a signboard panel or
+bench seat silhouetted against open lawn. The pixels below genuinely are ground — just ground
+ten metres behind — so the contact lands metres past the object.
+
+`--contact-depth-tol` (default `0.15`, `0` disables) settles it geometrically: if the object
+really stands there, its measured mono depth equals the range at which that ray meets the DEM;
+if it floats, it is much *nearer* than the ground its ray hits.
+
+Compared against the **DEM hit**, not the neighbouring ground pixel, on purpose — mono depth
+smooths across object boundaries, so a boundary-crossing comparison washes out the very jump
+it looks for, and spends two noisy samples instead of one. And mono depth only ever *vetoes*
+a contact; placement stays ray-DEM. A relative comparison at one pixel is what mono depth is
+reliable for; metric placement at an object edge is what it is not.
+
+**It is measured against the frame's median depth ratio, not against 1.0.** `MonoDepth.metric`
+fits scale+shift per frame from that frame's SfM points, and a poor fit skews the whole map by
+a constant. On maguro-park frame 0 the fit is off 2.3× (d_mono median 1.31 m vs z_dem 3.04 m):
+an absolute test keeps **4 of 960** contacts and silently deletes the frame; the median-relative
+test keeps **693**. Healthy frames sit at 0.91–1.02, so normalising costs them nothing. Same
+trick as `base_points.py`'s relative ground datum — absorb the systematic bias, test the
+outlier. Frames whose median lands outside 0.7–1.4 are flagged `<< depth scale suspect` rather
+than quietly normalised, since that indicates a depth fit worth fixing at the source.
+
+Measured on `maguro-park-after-itchy` (40 frames, `--dem-source mono`):
+
+| | contacts | FOOTPRINT cells |
+|---|---|---|
+| gate off | 24108 | 3.0% |
+| gate on (`0.15`) | **18664** (−23%) | 2.2% |
+
+Debug overlays mark kept contacts **red** and gate-rejected ones **magenta** — on frame 3 the
+magenta traces the underside of a signboard panel while red sits on its two post bases and the
+tree trunk. Eyeballing those is how you tune the tolerance.
+
+Caveat: normalising assumes most bottom-most pixels in a frame are genuine contacts (true here
+— ground is everywhere, floating silhouettes are the minority). A frame of nothing but floating
+objects would normalise to its own wrong consensus.
+
 ## `ade20k_eval.py` — the frozen backbone vs real ground truth
 
 `probe.py --task linprobe` trains **and** scores against Mask2Former output, so its 0.87 is

--- a/script/backbone/README.md
+++ b/script/backbone/README.md
@@ -7,9 +7,11 @@ two separate off-the-shelf models (DA2 depth + Mask2Former seg) with one backbon
 
 | file | role |
 |------|------|
-| `probe.py`            | is the frozen backbone worth building on? `pca` (feature viz) + `linprobe` (linear head vs Mask2Former pseudo-labels). Verdict: yes — ViT-S/16 hits 0.87 patch-acc on our taxonomy. |
+| `probe.py`            | is the frozen backbone worth building on? `pca` (feature viz) + `linprobe` (linear head vs Mask2Former pseudo-labels). Verdict: yes — ViT-S/16 hits 0.87 patch-acc on our taxonomy. **Caveat: that 0.87 is agreement with the teacher, not accuracy — see `ade20k_eval.py`.** |
 | `footprint_labels.py` | **generate footprint / free-space supervision** (below) for a ground head, no manual labels. |
 | `base_points.py`      | **deduped discrete object footprints** — open-vocab detection → foot points → BEV clustering (below). |
+| `ade20k_eval.py`      | **score the frozen backbone against real ADE20K ground truth** — semantic linear probe + instance separability (below). |
+| `relabel.py`          | **browser BEV relabeler** — hand-correct `footprint2d` rasters + place semantic ground-contact keypoints (below). |
 
 ## `footprint_labels.py` — footprint / free-space supervision generator
 
@@ -123,6 +125,119 @@ without a prompt trick. Caveats: cloud API (not shippable offline; ~1 paid call/
 daily caps), and `drop_to_ground` can bias a distant object's contact slightly toward the camera
 (the first ground pixel below the trunk). Natural next step: use Gemini as an **oracle to distill
 labels** into a shippable local head.
+
+## `ade20k_eval.py` — the frozen backbone vs real ground truth
+
+`probe.py --task linprobe` trains **and** scores against Mask2Former output, so its 0.87 is
+*agreement with the teacher*, silently capped by the teacher's own errors. ADE20K supplies
+real labels in a matching label space (the cached Mask2Former is ADE-trained), so the two
+can finally be separated.
+
+Data — no registration, ~1 GB + 90 MB, extracted to `/home/play/Code/datasets/ade20k`:
+
+```sh
+curl -fLO http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip   # 20210 train / 2000 val
+curl -fLO http://sceneparsing.csail.mit.edu/data/ChallengeData2017/annotations_instance.tar
+```
+
+```sh
+uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+  python script/backbone/ade20k_eval.py semantic --num 120 --val-num 60
+uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+  python script/backbone/ade20k_eval.py instance --num 40
+```
+
+**Measured (LingBot ViT-S/16, 512², 120 train / 60 val images):**
+
+| | mIoU | pixel-acc |
+|---|---|---|
+| LingBot-small + **linear** head | **57.3** | 82.8 |
+| Mask2Former-Swin-**L** (the `probe.py` teacher) | 65.6 | 88.9 |
+
+A *linear* probe on a frozen ViT-S lands **8.4 mIoU** behind a fully-supervised Swin-Large —
+good for the compute, and it reframes the 0.87: the teacher probe.py measured against is
+itself only 65.6 mIoU vs GT. Per class, LingBot wins **FURNITURE 24.6 vs 9.0** — the class
+holding our park objects (bench, pole, sign, trash can, streetlight). Distilling the teacher
+would make the classes we care about *worse*, not better.
+
+Caveats, stated plainly: teacher predictions are mapped to our taxonomy through
+`taxonomy.keyword_klass` while GT uses this file's explicit table, so part of the 8.4 gap is
+mapping mismatch, not model quality — the gap is an **upper bound** on the teacher's real
+advantage. GRASS scores badly for both (7.8 / 9.2), which smells like a label-mapping
+artifact (grass/field/flower folded together) rather than model failure.
+
+**Instance separability** (`instance`, 40 val images) asks the question the BEV pipeline
+chokes on — "the same tree from 970 frames becomes one un-separable blob". It scores how well
+cosine similarity ranks same-instance patch pairs above different-instance-same-class pairs:
+
+```
+same-instance      mean cos 0.655   |   diff-instance same-class  mean cos 0.484
+ROC AUC 0.734  -> instance identity is weakly present; a trained head may separate instances
+```
+
+So the frozen features do carry instance identity beyond semantics — enough to be worth a
+head, not enough to expect it for free.
+
+### ⚠ `taxonomy.keyword_klass` mislabels real classes
+
+The mapper does unanchored substring matching, which produces genuine errors:
+
+| ADE class | maps to | because |
+|---|---|---|
+| `seat` | WATER | contains "sea" |
+| `streetlight` | TREE | contains "s**tree**t" |
+| `carpet` | VEHICLE | contains "car" |
+| `kitchen island` | TERRAIN | contains "**land**" |
+| `skyscraper` | SKY | prefix match |
+| `pool table` | WATER | contains "pool" |
+
+This is **live**: `footprint2d.py`'s `SegKlass` builds its LUT the same way, and
+`maguro-park-after-itchy`'s structure raster carries **9 WATER cells in a park with no
+water**. `ade20k_eval.py` therefore uses a hand-written `_ADE_KLASS` table and offers
+`--mapping keyword` to reproduce the buggy behaviour for comparison.
+
+Note that **mIoU is the wrong instrument** for this bug — it barely moves (57.3 → 56.2),
+because when GT and predictions share the same wrong LUT the head just learns the wrong label
+consistently. The damage shows in the class populations: FURNITURE training patches collapse
+**3031 → 815** (−73%, as bench/pole/sign/streetlight scatter) while WATER inflates
+**1842 → 3776** (2×, absorbing seats and pool tables). Downstream consumers eat that, which is
+exactly what the 9 phantom WATER cells are.
+
+## `relabel.py` — BEV relabeler (hand-correct + keypoints)
+
+`footprint2d.py` gets the broad BEV structure right and the *edges* wrong: footprint
+boundaries bleed where the bottom-most obstacle pixel is a shadow or a leaf, HIDDEN
+over/under-claims, thin structures come out speckled. Fixing that per-frame would mean
+painting 970 images; **fixing it in BEV means painting once** — the park is a single
+201×230 grid — and every frame that sees a cell inherits the correction when the raster is
+rendered back into that camera. That asymmetry is why the editor works in BEV.
+
+```sh
+uv run python script/backbone/relabel.py \
+  --npz output/maguro-park-after-itchy-footprint2d-mono2/footprint2d.npz
+```
+
+Opens a local browser editor (stdlib http.server, no new deps). DEM hillshade underneath for
+terrain context — uncovered cells render near-black, so extrapolated guesswork is visibly
+distinct from observed ground.
+
+- **Ground** tool — paint FREE / FOOTPRINT / HIDDEN / UNKNOWN
+- **Class** tool — assign a `Klass` to footprint cells (fixes the structure raster)
+- **Keypoint** tool — drop semantic **ground-contact points**: the signal `base_points.py`
+  triangulates for. Hand-placed points are both the ground truth to *score* that pipeline
+  against and the target for a contact-point head on frozen LingBot features.
+- wheel zoom, space/middle-drag pan, `1`/`2`/`3` tools, `[`/`]` brush, `z` undo,
+  "Highlight my edits" to see the diff vs the original
+
+Writes `relabel.npz` (corrected `state` + `structure`, with `state_orig`/`structure_orig`
+kept for diffing) and `keypoints.json` next to the input. The original npz is never
+overwritten and re-running resumes.
+
+**Grid registration caveat:** `footprint2d`'s npz stores `cell_size` but not the DEM origin,
+so edits are registered to *that grid*, not world coordinates. Consumers must rebuild the
+GroundField with the same session/cell-size/dem-source (deterministic) and apply edits
+cell-wise. Adding `origin_u`/`origin_v` to `footprint2d`'s `np.savez` would make this
+self-describing, and let keypoints carry true world (u, v).
 
 ### Status / next
 

--- a/script/backbone/ade20k_eval.py
+++ b/script/backbone/ade20k_eval.py
@@ -127,8 +127,10 @@ def ade_to_klass(names: list[str], mapping: str = "explicit") -> np.ndarray:
     lut = np.zeros(151, dtype=np.uint8)
     if mapping == "keyword":
         for i, n in enumerate(names):
-            lut[i] = int(Klass.UNKNOWN) if i == 0 else \
-                int(max((keyword_klass(s.strip()) for s in n.split(",")), key=int))
+            # keyword_klass matches on word boundaries across the whole synonym list now, so
+            # the old per-synonym max() tie-break (which just picked the highest Klass id) is
+            # gone -- it had no principled basis.
+            lut[i] = int(Klass.UNKNOWN) if i == 0 else int(keyword_klass(n))
         return lut
     for i, k in _ADE_KLASS.items():
         lut[i] = int(k)

--- a/script/backbone/ade20k_eval.py
+++ b/script/backbone/ade20k_eval.py
@@ -1,0 +1,439 @@
+"""Evaluate the frozen LingBot-Vision backbone against ADE20K **ground truth**.
+
+`probe.py --task linprobe` trains *and* scores its head on `Mask2Former` output, so its
+headline 0.87 is **agreement with the teacher**, not accuracy. A head can only look good
+there by copying Mask2Former's mistakes, and the number is silently capped by them. This
+script swaps in real ADE20K labels so three things become separable:
+
+  * **LingBot + linear head vs GT**  — what the frozen features actually support
+  * **Mask2Former vs GT**            — the teacher's own error, i.e. the ceiling
+                                       `probe.py` was unknowingly measuring against
+  * the gap between them             — whether distilling the teacher is worth it, or
+                                       whether a linear head on LingBot already beats it
+
+ADE20K is the right corpus for this: its label set covers our taxonomy far better than
+COCO (tree, plant, bush, bench, pole, signboard, rock are all present, outdoors), and the
+Mask2Former checkpoint already cached here is ADE-trained — so teacher and GT share a
+label space and the comparison is apples-to-apples.
+
+Two tasks:
+
+  semantic — patch-level linear probe in our `Klass` taxonomy. Reports per-class IoU,
+             mIoU and pixel accuracy for LingBot and for Mask2Former on the same images.
+
+  instance — the question the BEV pipeline actually chokes on. `base_points.py`'s README
+             notes "the same tree, projected from 970 frames, becomes one un-separable
+             BEV blob"; instance separation is what fixes it. This measures whether the
+             frozen features carry instance identity *at all*: sample patch pairs drawn
+             from the same class, and score how well cosine similarity ranks
+             same-instance pairs above different-instance ones (ROC AUC). 0.5 = features
+             are purely semantic and no head can split touching instances from them; high
+             = the information is present and a head can recover it.
+
+Data (no registration needed, ~1 GB + 90 MB):
+  http://data.csail.mit.edu/places/ADEchallenge/ADEChallengeData2016.zip
+  http://sceneparsing.csail.mit.edu/data/ChallengeData2017/annotations_instance.tar
+
+Run (from repo root):
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/ade20k_eval.py semantic --root /home/play/Code/datasets/ade20k --num 200
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/ade20k_eval.py instance --root /home/play/Code/datasets/ade20k --num 60
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+
+from lingbot_vision import extract_patch_tokens, load_image, load_pretrained_backbone  # noqa: E402
+from taxonomy import Klass, keyword_klass  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# ADE20K -> our taxonomy
+# ---------------------------------------------------------------------------
+def ade_root(root: Path) -> Path:
+    """Accept either the extract dir or its ADEChallengeData2016 parent."""
+    return root if (root / "images").is_dir() else root / "ADEChallengeData2016"
+
+
+def load_class_names(base: Path) -> list[str]:
+    """objectInfo150 -> index-aligned names; index 0 is ADE's 'ignore'."""
+    info = next((p for p in (base / "objectInfo150.txt", base / "objectInfo150.csv")
+                 if p.exists()), None)
+    if info is None:
+        raise SystemExit(f"objectInfo150 not found under {base}")
+    names = ["ignore"] * 151
+    for line in info.read_text().splitlines()[1:]:
+        parts = line.split("\t") if "\t" in line else line.split(",")
+        if len(parts) < 5:
+            continue
+        try:
+            idx = int(parts[0])
+        except ValueError:
+            continue
+        if 1 <= idx <= 150:
+            names[idx] = parts[-1].strip()
+    return names
+
+
+# Explicit ADE-150 -> Klass. NOT derived from `taxonomy.keyword_klass`: that mapper does
+# unanchored substring matching and mislabels real classes --
+#   "seat" -> WATER ("sea")            "carpet"      -> VEHICLE ("car")
+#   "streetlight" -> TREE ("s-TREE-t") "kitchen island" -> TERRAIN ("land")
+#   "skyscraper" -> SKY                "pool table"  -> WATER
+# Those errors are live in the park pipeline (footprint2d's SegKlass builds its LUT the
+# same way): maguro-park's structure raster carries 9 WATER cells in a park with no water.
+# Ground truth has to be exact, so this table is hand-written. Classes absent here stay
+# UNKNOWN and are excluded from the metric rather than guessed at.
+_ADE_KLASS: dict[int, Klass] = {
+    1: Klass.WALL, 2: Klass.BUILDING, 3: Klass.SKY, 5: Klass.TREE, 7: Klass.PATH,
+    10: Klass.GRASS, 12: Klass.PATH, 13: Klass.PERSON, 14: Klass.TERRAIN,
+    17: Klass.TERRAIN, 18: Klass.TREE, 21: Klass.VEHICLE, 22: Klass.WATER,
+    26: Klass.BUILDING, 27: Klass.WATER, 30: Klass.GRASS, 32: Klass.FURNITURE,
+    33: Klass.WALL, 35: Klass.TERRAIN, 39: Klass.WALL, 41: Klass.FURNITURE,
+    43: Klass.FURNITURE, 44: Klass.FURNITURE, 47: Klass.TERRAIN, 49: Klass.BUILDING,
+    52: Klass.BUILDING, 53: Klass.PATH, 54: Klass.STAIRS, 55: Klass.PATH,
+    60: Klass.STAIRS, 61: Klass.WATER, 67: Klass.GRASS, 69: Klass.TERRAIN,
+    70: Klass.FURNITURE, 73: Klass.TREE, 77: Klass.VEHICLE, 80: Klass.BUILDING,
+    81: Klass.VEHICLE, 83: Klass.FURNITURE, 84: Klass.VEHICLE, 85: Klass.BUILDING,
+    88: Klass.FURNITURE, 89: Klass.BUILDING, 91: Klass.VEHICLE, 92: Klass.TERRAIN,
+    94: Klass.FURNITURE, 95: Klass.TERRAIN, 96: Klass.WALL, 97: Klass.STAIRS,
+    103: Klass.VEHICLE, 104: Klass.VEHICLE, 105: Klass.WATER, 110: Klass.WATER,
+    114: Klass.WATER, 117: Klass.VEHICLE, 122: Klass.STAIRS, 126: Klass.FURNITURE,
+    128: Klass.VEHICLE, 129: Klass.WATER, 133: Klass.FURNITURE, 136: Klass.FURNITURE,
+    137: Klass.FURNITURE, 139: Klass.FURNITURE, 145: Klass.FURNITURE,
+}
+
+
+def ade_to_klass(names: list[str], mapping: str = "explicit") -> np.ndarray:
+    """LUT: ADE id (0..150) -> our Klass.
+
+    mapping='keyword' reproduces the buggy substring mapper on purpose, so the damage it
+    does can be measured against the same GT rather than argued about.
+    """
+    lut = np.zeros(151, dtype=np.uint8)
+    if mapping == "keyword":
+        for i, n in enumerate(names):
+            lut[i] = int(Klass.UNKNOWN) if i == 0 else \
+                int(max((keyword_klass(s.strip()) for s in n.split(",")), key=int))
+        return lut
+    for i, k in _ADE_KLASS.items():
+        lut[i] = int(k)
+    return lut
+
+
+def list_split(base: Path, split: str, num: int, seed: int = 0):
+    img_dir = base / "images" / split
+    ann_dir = base / "annotations" / split
+    imgs = sorted(img_dir.glob("*.jpg"))
+    if not imgs:
+        raise SystemExit(f"no images in {img_dir}")
+    rng = np.random.default_rng(seed)
+    if num and num < len(imgs):
+        imgs = [imgs[i] for i in sorted(rng.choice(len(imgs), num, replace=False))]
+    return [(p, ann_dir / f"{p.stem}.png") for p in imgs if (ann_dir / f"{p.stem}.png").exists()]
+
+
+# ---------------------------------------------------------------------------
+# frozen features — same recipe as probe.py so numbers stay comparable
+# ---------------------------------------------------------------------------
+def load_backbone(variant: str):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    backbone, embed_dim = load_pretrained_backbone(variant=variant, device=device, dtype=dtype)
+    return backbone, embed_dim, device, dtype
+
+
+@torch.no_grad()
+def feature_grid(backbone, path: Path, size: int, mode: str, device, dtype):
+    img_norm, rgb, _ = load_image(str(path), size=size, patch_size=backbone.patch_size, mode=mode)
+    tokens, (h, w) = extract_patch_tokens(backbone, img_norm, device, dtype)
+    return tokens[0].float().cpu().numpy().reshape(h, w, -1), rgb, (h, w)
+
+
+def patch_labels(mask_hw: np.ndarray, h: int, w: int, nvals: int) -> np.ndarray:
+    """Majority label per patch block (probe.py's rule)."""
+    H, W = mask_hw.shape
+    ph, pw = H // h, W // w
+    out = np.empty(h * w, dtype=np.int64)
+    k = 0
+    for i in range(h):
+        for j in range(w):
+            block = mask_hw[i * ph:(i + 1) * ph, j * pw:(j + 1) * pw].ravel()
+            out[k] = np.bincount(block, minlength=nvals).argmax()
+            k += 1
+    return out
+
+
+def resize_label(mask: np.ndarray, rgb_shape) -> np.ndarray:
+    """GT is at native resolution; the backbone saw a resized/snapped crop. Nearest-resize
+    the label to exactly what the backbone consumed so patches and labels align."""
+    H, W = rgb_shape[:2]
+    return cv2.resize(mask, (W, H), interpolation=cv2.INTER_NEAREST)
+
+
+# ---------------------------------------------------------------------------
+# metrics
+# ---------------------------------------------------------------------------
+def iou_report(inter, union, correct, total, names, tag):
+    valid = union > 0
+    ious = np.divide(inter, np.maximum(union, 1e-9))
+    miou = float(ious[valid].mean()) if valid.any() else 0.0
+    acc = float(correct / max(total, 1))
+    print(f"\n[{tag}]  mIoU {miou*100:.1f}   pixel-acc {acc*100:.1f}   "
+          f"({int(valid.sum())} classes present)")
+    for i in np.argsort(-union):
+        if union[i] <= 0:
+            continue
+        print(f"    {names[i]:<10s} IoU {ious[i]*100:5.1f}   support {int(union[i]):>9d}")
+    return {"miou": miou, "acc": acc,
+            "per_class": {names[i]: float(ious[i]) for i in range(len(names)) if union[i] > 0}}
+
+
+def accumulate(pred, gt, n, inter, union, ignore):
+    m = gt != ignore
+    pred, gt = pred[m], gt[m]
+    for k in range(n):
+        p, g = pred == k, gt == k
+        inter[k] += np.logical_and(p, g).sum()
+        union[k] += np.logical_or(p, g).sum()
+    return int((pred == gt).sum()), int(m.sum())
+
+
+# ---------------------------------------------------------------------------
+# task: semantic
+# ---------------------------------------------------------------------------
+def run_semantic(args):
+    base = ade_root(Path(args.root).expanduser())
+    names_ade = load_class_names(base)
+    lut = ade_to_klass(names_ade, args.mapping)
+    n_klass = int(max(Klass)) + 1
+    klass_names = [k.name for k in sorted(Klass, key=int)]
+    ignore = int(Klass.UNKNOWN)
+
+    backbone, embed_dim, device, dtype = load_backbone(args.variant)
+    train = list_split(base, "training", args.num, seed=0)
+    val = list_split(base, "validation", args.val_num, seed=1)
+    print(f"[semantic] {len(train)} train / {len(val)} val images  size={args.size} "
+          f"embed_dim={embed_dim} device={device}")
+
+    Xtr, ytr = [], []
+    for i, (ip, ap) in enumerate(train):
+        f, rgb, (h, w) = feature_grid(backbone, ip, args.size, args.mode, device, dtype)
+        gt = lut[resize_label(cv2.imread(str(ap), cv2.IMREAD_GRAYSCALE), rgb.shape)]
+        y = patch_labels(gt, h, w, n_klass)
+        Xtr.append(f.reshape(-1, embed_dim)); ytr.append(y)
+        if (i + 1) % 25 == 0:
+            print(f"  train feat {i+1}/{len(train)}")
+    Xtr = np.concatenate(Xtr); ytr = np.concatenate(ytr)
+    keep = ytr != ignore
+    Xtr, ytr = Xtr[keep], ytr[keep]
+    print(f"  {len(Xtr)} labelled patches "
+          f"({', '.join(f'{klass_names[c]}:{n}' for c, n in zip(*np.unique(ytr, return_counts=True)))})")
+
+    mu, sd = Xtr.mean(0), Xtr.std(0) + 1e-6
+    Xn = torch.tensor((Xtr - mu) / sd, dtype=torch.float32, device=device)
+    yn = torch.tensor(ytr, device=device)
+    head = torch.nn.Linear(embed_dim, n_klass).to(device)
+    opt = torch.optim.Adam(head.parameters(), lr=1e-2, weight_decay=1e-4)
+    lossf = torch.nn.CrossEntropyLoss()
+    for step in range(args.steps):
+        opt.zero_grad()
+        loss = lossf(head(Xn), yn)
+        loss.backward(); opt.step()
+        if (step + 1) % max(1, args.steps // 5) == 0:
+            print(f"  step {step+1}/{args.steps} loss={loss.item():.3f}")
+    head.eval()
+
+    seg = None
+    if not args.no_teacher:
+        from segmentation import make_segmenter
+        seg = make_segmenter(args.teacher)
+        print(f"  teacher: {args.teacher}")
+
+    li, lu = np.zeros(n_klass), np.zeros(n_klass)
+    ti, tu = np.zeros(n_klass), np.zeros(n_klass)
+    lc = lt = tc = tt = 0
+    for i, (ip, ap) in enumerate(val):
+        f, rgb, (h, w) = feature_grid(backbone, ip, args.size, args.mode, device, dtype)
+        gt_full = lut[resize_label(cv2.imread(str(ap), cv2.IMREAD_GRAYSCALE), rgb.shape)]
+        with torch.no_grad():
+            Xv = torch.tensor((f.reshape(-1, embed_dim) - mu) / sd, dtype=torch.float32, device=device)
+            pred_patch = head(Xv).argmax(1).cpu().numpy().reshape(h, w)
+        # score at full image resolution: upsample patch predictions, as any real
+        # consumer would. Patch-grid scoring flatters the head by hiding boundary error.
+        pred = cv2.resize(pred_patch.astype(np.uint8), (rgb.shape[1], rgb.shape[0]),
+                          interpolation=cv2.INTER_NEAREST)
+        c, t = accumulate(pred.ravel(), gt_full.ravel(), n_klass, li, lu, ignore)
+        lc += c; lt += t
+        if seg is not None:
+            tpred = seg.segment(cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+            c, t = accumulate(tpred.ravel(), gt_full.ravel(), n_klass, ti, tu, ignore)
+            tc += c; tt += t
+        if (i + 1) % 25 == 0:
+            print(f"  val {i+1}/{len(val)}")
+
+    res = {"lingbot": iou_report(li, lu, lc, lt, klass_names, f"LingBot-{args.variant} + linear  vs GT")}
+    if seg is not None:
+        res["teacher"] = iou_report(ti, tu, tc, tt, klass_names, f"{args.teacher}  vs GT")
+        d = (res["lingbot"]["miou"] - res["teacher"]["miou"]) * 100
+        print(f"\n  => LingBot linear {'beats' if d > 0 else 'trails'} the teacher by "
+              f"{abs(d):.1f} mIoU. probe.py's 0.87 was agreement with that teacher, "
+              f"whose own mIoU vs GT is {res['teacher']['miou']*100:.1f}.")
+
+    out = Path(args.out or (_SCRIPT_ROOT.parent / "output" / "ade20k-eval"))
+    out.mkdir(parents=True, exist_ok=True)
+    (out / f"semantic_{args.variant}.json").write_text(json.dumps(
+        {"config": vars(args), "results": res}, indent=2, default=str))
+    print(f"\n  wrote {out}/semantic_{args.variant}.json")
+
+
+# ---------------------------------------------------------------------------
+# task: instance
+# ---------------------------------------------------------------------------
+def decode_instance(png: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """ADE20K instance PNG -> (class, instance-id).
+
+    Verified against the released val set: R = class id (index into the 100 *thing*
+    classes, NOT the 150 semantic ids), G = per-image instance index, B unused (always 0).
+    cv2 hands back BGR, so R is channel 2 and G is channel 1. Images whose channels are
+    all zero are simply images with no countable things -- skipped by the caller.
+    """
+    if png.ndim == 2:
+        return png.astype(np.int32), np.zeros_like(png, np.int32)
+    cls = png[:, :, 2].astype(np.int32)
+    inst = png[:, :, 1].astype(np.int32)
+    return cls, inst
+
+
+def run_instance(args):
+    base = ade_root(Path(args.root).expanduser())
+    inst_dir = Path(args.root).expanduser() / "annotations_instance" / "validation"
+    if not inst_dir.is_dir():
+        raise SystemExit(f"instance annotations not found: {inst_dir}\n"
+                         "  extract annotations_instance.tar next to ADEChallengeData2016")
+    backbone, embed_dim, device, dtype = load_backbone(args.variant)
+
+    imgs = sorted((base / "images" / "validation").glob("*.jpg"))
+    rng = np.random.default_rng(0)
+    if args.num and args.num < len(imgs):
+        imgs = [imgs[i] for i in sorted(rng.choice(len(imgs), args.num, replace=False))]
+
+    same, diff = [], []
+    used = 0
+    for ip in imgs:
+        ap = inst_dir / f"{ip.stem}.png"
+        if not ap.exists():
+            continue
+        f, rgb, (h, w) = feature_grid(backbone, ip, args.size, args.mode, device, dtype)
+        png = cv2.imread(str(ap), cv2.IMREAD_COLOR)
+        if png is None:
+            continue
+        cls, inst = decode_instance(png)
+        cls = resize_label(cls.astype(np.int32), rgb.shape)
+        inst = resize_label(inst.astype(np.int32), rgb.shape)
+        # patch-level majority for both channels; a patch is usable only if it sits
+        # cleanly inside one instance (mixed patches would blur the comparison)
+        cl = patch_labels(cls, h, w, int(cls.max()) + 1).reshape(h, w)
+        il = patch_labels(inst, h, w, int(inst.max()) + 1).reshape(h, w)
+        feats = f.reshape(-1, embed_dim)
+        feats = feats / (np.linalg.norm(feats, axis=1, keepdims=True) + 1e-9)
+        cl, il = cl.ravel(), il.ravel()
+
+        for c in np.unique(cl):
+            if c == 0:
+                continue
+            m = (cl == c) & (il > 0)
+            ids = np.unique(il[m])
+            if len(ids) < 2:                     # need >= 2 instances of a class to compare
+                continue
+            idx = np.where(m)[0]
+            if len(idx) > args.max_patches:
+                idx = rng.choice(idx, args.max_patches, replace=False)
+            sub, sid = feats[idx], il[idx]
+            sim = sub @ sub.T
+            eq = sid[:, None] == sid[None, :]
+            triu = np.triu(np.ones_like(sim, bool), 1)
+            same.append(sim[triu & eq]); diff.append(sim[triu & ~eq])
+        used += 1
+        if used % 20 == 0:
+            print(f"  {used} images, {sum(len(s) for s in same)} same / "
+                  f"{sum(len(d) for d in diff)} diff pairs")
+
+    same = np.concatenate([s for s in same if len(s)]) if same else np.array([])
+    diff = np.concatenate([d for d in diff if len(d)]) if diff else np.array([])
+    if not len(same) or not len(diff):
+        raise SystemExit("no usable instance pairs — try a larger --num")
+
+    # rank-based AUC: P(sim(same-instance) > sim(different-instance-same-class))
+    allv = np.concatenate([same, diff])
+    order = allv.argsort()
+    ranks = np.empty(len(allv), float)
+    ranks[order] = np.arange(1, len(allv) + 1)
+    n1, n0 = len(same), len(diff)
+    auc = float((ranks[:n1].sum() - n1 * (n1 + 1) / 2) / (n1 * n0))
+
+    print(f"\n[instance separability — LingBot-{args.variant}, {used} images]")
+    print(f"  same-instance pairs      {n1:>9d}   mean cos {same.mean():.4f}")
+    print(f"  diff-instance same-class {n0:>9d}   mean cos {diff.mean():.4f}")
+    print(f"  ROC AUC                  {auc:.4f}")
+    verdict = ("features are essentially semantic-only — a head cannot split touching "
+               "instances from them; you need an instance-aware signal (detector/VLM points)"
+               if auc < 0.60 else
+               "instance identity is weakly present — a trained head may separate instances"
+               if auc < 0.75 else
+               "instance identity is strongly present — worth training an instance head on "
+               "these frozen features")
+    print(f"  => {verdict}")
+
+    out = Path(args.out or (_SCRIPT_ROOT.parent / "output" / "ade20k-eval"))
+    out.mkdir(parents=True, exist_ok=True)
+    (out / f"instance_{args.variant}.json").write_text(json.dumps({
+        "config": vars(args), "images": used, "auc": auc,
+        "same_mean": float(same.mean()), "diff_mean": float(diff.mean()),
+        "n_same": n1, "n_diff": n0, "verdict": verdict}, indent=2, default=str))
+    print(f"  wrote {out}/instance_{args.variant}.json")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    sub = ap.add_subparsers(dest="task", required=True)
+    for name in ("semantic", "instance"):
+        p = sub.add_parser(name)
+        p.add_argument("--root", default="/home/play/Code/datasets/ade20k")
+        p.add_argument("--variant", default="small", help="small/base/large/giant")
+        p.add_argument("--size", type=int, default=512)
+        p.add_argument("--mode", default="square", choices=["square", "shortest"])
+        p.add_argument("--num", type=int, default=200)
+        p.add_argument("--out", default=None)
+    s = sub.choices["semantic"]
+    s.add_argument("--val-num", type=int, default=100)
+    s.add_argument("--steps", type=int, default=600)
+    s.add_argument("--teacher", default="mask2former-large",
+                   help="teacher to score against the same GT (the probe.py ceiling)")
+    s.add_argument("--no-teacher", action="store_true")
+    s.add_argument("--mapping", default="explicit", choices=["explicit", "keyword"],
+                   help="ADE->Klass LUT. 'keyword' reproduces taxonomy.keyword_klass's "
+                        "buggy substring matching, to measure what it costs.")
+    i = sub.choices["instance"]
+    i.add_argument("--max-patches", type=int, default=400,
+                   help="patch cap per class per image (pair count grows quadratically)")
+    args = ap.parse_args()
+    (run_semantic if args.task == "semantic" else run_instance)(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/base_points.py
+++ b/script/backbone/base_points.py
@@ -164,6 +164,121 @@ def cluster_footprints(pts_uv: np.ndarray, labels: list[str], scores: np.ndarray
 
 
 # --------------------------------------------------------------------------- #
+# mask-contour mode: SAM masks -> ground-contact silhouette -> footprint polygons
+# --------------------------------------------------------------------------- #
+def load_sam(model_id: str, device: str):
+    from transformers import SamModel, SamProcessor
+    proc = SamProcessor.from_pretrained(model_id)
+    model = SamModel.from_pretrained(model_id).to(device).eval()
+    return proc, model
+
+
+@torch.no_grad()
+def sam_masks(proc, model, pil: Image.Image, boxes: list, device: str):
+    """One boolean mask (original image res) per input box, best of SAM's 3 proposals."""
+    if not boxes:
+        return []
+    inputs = proc(pil, input_boxes=[[list(map(float, b)) for b in boxes]],
+                  return_tensors="pt").to(device)
+    out = model(**inputs)
+    masks = proc.image_processor.post_process_masks(
+        out.pred_masks.cpu(), inputs["original_sizes"].cpu(),
+        inputs["reshaped_input_sizes"].cpu())[0]          # (N, 3, H, W) bool
+    best = out.iou_scores.cpu().numpy()[0].argmax(1)      # (N,) best proposal per box
+    return [masks[i, best[i]].numpy().astype(bool) for i in range(len(boxes))]
+
+
+def bottom_silhouette(mask: np.ndarray, stride: int = 2):
+    """Lowest mask pixel per column = the object's ground-facing silhouette."""
+    h = mask.shape[0]
+    rows = np.arange(h)[:, None]
+    has = mask.any(0)
+    bottom = (mask * rows).argmax(0)          # largest True row index per column
+    cols = np.where(has)[0][::stride]
+    return cols, bottom[cols]
+
+
+def backproject_pixels(px, py, depth, cam, im, scale):
+    """(px,py) render-res pixels + per-pixel depth -> (N,3) world points."""
+    fx, fy, cx, cy = (v * scale for v in pinhole_params(cam))
+    cam_pts = np.stack([(px - cx) / fx * depth, (py - cy) / fy * depth, depth], axis=1)
+    R = qvec2rotmat(im.qvec)
+    return cam_pts @ R + (-R.T @ im.tvec)
+
+
+def extract_polygons(accum_count, accum_weight, spec, accum_cell, cls,
+                     min_hits, min_area, approx_eps):
+    """Per-class BEV accumulator -> footprint polygons via connected components.
+
+    Multi-view denoises: a real contact (e.g. a bench leg) projects to the SAME world cell
+    from every view and accumulates; a floating silhouette edge (seat underside) projects to
+    whatever ground is behind it, scatters, and stays below threshold.
+    """
+    binary = (accum_count >= min_hits).astype(np.uint8)
+    if not binary.any():
+        return []
+    binary = cv2.morphologyEx(binary, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))
+    n, labels, stats, cents = cv2.connectedComponentsWithStats(binary, connectivity=8)
+    cell_area = accum_cell * accum_cell
+    out = []
+    for i in range(1, n):
+        area = stats[i, cv2.CC_STAT_AREA] * cell_area
+        if area < min_area:
+            continue
+        comp = (labels == i).astype(np.uint8)
+        cnts, _ = cv2.findContours(comp, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        cnt = max(cnts, key=cv2.contourArea)
+        eps = approx_eps * cv2.arcLength(cnt, True)
+        poly = cv2.approxPolyDP(cnt, eps, True).reshape(-1, 2)
+        verts = [[float(spec.origin_u + c * accum_cell), float(spec.origin_v + r * accum_cell)]
+                 for c, r in poly]
+        cu = spec.origin_u + cents[i, 0] * accum_cell
+        cv_ = spec.origin_v + cents[i, 1] * accum_cell
+        out.append({"class": cls, "area_m2": round(float(area), 2),
+                    "hits": int(accum_count[labels == i].sum()),
+                    "centroid": [float(cu), float(cv_)], "polygon": verts})
+    return out
+
+
+def render_bev_polygons(gf, polygons, traj_uv, out_path: Path, ppm: float = 6.0):
+    spec = gf.spec
+    origin_u, origin_v, cs = spec.origin_u, spec.origin_v, spec.cell_size
+    W = int(spec.cols * cs * ppm) + 40
+    H = int(spec.rows * cs * ppm) + 40
+
+    def to_px(u, v):
+        return int((u - origin_u) * ppm) + 20, int((v - origin_v) * ppm) + 20
+
+    img = np.full((H, W, 3), 248, np.uint8)
+    cov = cv2.resize(gf.coverage.astype(np.uint8) * 255, (W - 40, H - 40),
+                     interpolation=cv2.INTER_NEAREST)
+    img[20:H - 20, 20:W - 20][cov > 0] = (233, 233, 233)
+    if len(traj_uv) > 1:
+        pts = np.array([to_px(u, v) for u, v in traj_uv], np.int32)
+        cv2.polylines(img, [pts], False, (170, 170, 170), 1, cv2.LINE_AA)
+
+    classes = sorted({p["class"] for p in polygons})
+    cidx = {c: i for i, c in enumerate(classes)}
+    overlay = img.copy()
+    for p in polygons:
+        col = colour_for(p["class"], cidx[p["class"]])
+        poly = np.array([to_px(u, v) for u, v in p["polygon"]], np.int32)
+        cv2.fillPoly(overlay, [poly], col)
+        cv2.polylines(img, [poly], True, tuple(int(c * 0.6) for c in col), 1, cv2.LINE_AA)
+    img = cv2.addWeighted(overlay, 0.45, img, 0.55, 0)
+
+    y = 30
+    for c in classes:
+        col = colour_for(c, cidx[c])
+        k = sum(1 for p in polygons if p["class"] == c)
+        cv2.rectangle(img, (24, y - 7), (36, y + 5), col, -1)
+        cv2.putText(img, f"{c}: {k}", (44, y + 4), cv2.FONT_HERSHEY_SIMPLEX, 0.42,
+                    (30, 30, 30), 1, cv2.LINE_AA)
+        y += 20
+    cv2.imwrite(str(out_path), img)
+
+
+# --------------------------------------------------------------------------- #
 # BEV render
 # --------------------------------------------------------------------------- #
 def colour_for(cls: str, i: int):
@@ -224,7 +339,16 @@ def main() -> None:
     ap.add_argument("--out", help="output dir (default: output/<session>-basepoints)")
     ap.add_argument("--dem-source", choices=["colmap", "mono"], default="colmap")
     ap.add_argument("--depth-dir", help="mono depth dir (default: session.depth_dir('mono'))")
+    ap.add_argument("--mode", choices=["points", "mask-contour"], default="points",
+                    help="points = foot point per object (thin objects); "
+                         "mask-contour = SAM mask -> ground silhouette -> footprint polygon "
+                         "(multi-contact objects: benches, signs)")
     ap.add_argument("--detector", default="IDEA-Research/grounding-dino-tiny")
+    ap.add_argument("--sam-model", default="facebook/sam-vit-base",
+                    help="SAM checkpoint for mask-contour (SAM2 is a drop-in)")
+    ap.add_argument("--accum-cell", type=float, default=0.25, help="BEV accumulator cell (m)")
+    ap.add_argument("--min-area", type=float, default=0.1, help="min footprint polygon area (m^2)")
+    ap.add_argument("--approx-eps", type=float, default=0.02, help="polygon simplify (frac of perimeter)")
     ap.add_argument("--prompt", default=DEFAULT_PROMPT, help="open-vocab classes, '.'-separated")
     ap.add_argument("--box-thr", type=float, default=0.30)
     ap.add_argument("--text-thr", type=float, default=0.25)
@@ -269,60 +393,109 @@ def main() -> None:
     classes = [c.strip().lower() for c in args.prompt.split(".") if c.strip()]
     print(f"classes: {classes}")
     proc, det_model = load_detector(args.detector, device)
+    sam_proc = sam_model = None
+    if args.mode == "mask-contour":
+        print(f"loading SAM {args.sam_model}")
+        sam_proc, sam_model = load_sam(args.sam_model, device)
 
     ims = sorted(recon.images.values(), key=lambda im: im.name)
     if args.sample and args.sample < len(ims):
         idx = np.linspace(0, len(ims) - 1, args.sample).round().astype(int)
         ims = [ims[i] for i in idx]
 
-    all_uv, all_lab, all_score = [], [], []
-    traj_uv = []
-    n_det = 0
+    spec = gf.spec
+    acols = int(spec.cols * spec.cell_size / args.accum_cell) + 1
+    arows = int(spec.rows * spec.cell_size / args.accum_cell) + 1
+    accum_count: dict[str, np.ndarray] = {}
+    accum_weight: dict[str, np.ndarray] = {}
+
+    def accum_add(cls, uv, score):
+        col = int((uv[0] - spec.origin_u) / args.accum_cell)
+        row = int((uv[1] - spec.origin_v) / args.accum_cell)
+        if 0 <= col < acols and 0 <= row < arows:
+            if cls not in accum_count:
+                accum_count[cls] = np.zeros((arows, acols), np.int32)
+                accum_weight[cls] = np.zeros((arows, acols), np.float32)
+            accum_count[cls][row, col] += 1
+            accum_weight[cls][row, col] += score
+
+    all_uv, all_lab, all_score, traj_uv = [], [], [], []
+    n_pts = 0
     for fi, im in enumerate(ims):
         cam = recon.cameras[im.camera_id]
         R = qvec2rotmat(im.qvec)
-        cam_centre = -R.T @ im.tvec                 # camera centre in world
-        traj_uv.append((cam_centre @ gf.R.T)[:2])   # -> gravity-local (u, v)
+        traj_uv.append(((-R.T @ im.tvec) @ gf.R.T)[:2])   # camera centre -> gravity-local
         res = make_frame_labels(mesh, occ_world, im, cam, args.size,
                                 args.max_range, 0.5, 0)
         if res is None:
             continue
         ground_depth = res["depth"]
+        gh, gw = ground_depth.shape
         scale = args.size / max(cam.width, cam.height)
         pil = Image.open(images / im.name).convert("RGB")
         dets = detect(proc, det_model, pil, args.prompt, device, args.box_thr, args.text_thr)
-
+        masks = (sam_masks(sam_proc, sam_model, pil, [d[0] for d in dets], device)
+                 if args.mode == "mask-contour" else [None] * len(dets))
         overlay = cv2.imread(str(images / im.name)) if fi < args.save_detections else None
-        for box, label, score in dets:
+
+        for di, (box, label, score) in enumerate(dets):
             cls = canonical(label, classes)
-            w = foot_world(box, ground_depth, scale, cam, im)
-            if w is None:
-                continue
-            local = w @ gf.R.T
-            all_uv.append(local[:2]); all_lab.append(cls); all_score.append(float(score))
-            n_det += 1
+            col = colour_for(cls, classes.index(cls) if cls in classes else 0)
+            if args.mode == "points":
+                w = foot_world(box, ground_depth, scale, cam, im)
+                if w is None:
+                    continue
+                all_uv.append((w @ gf.R.T)[:2]); all_lab.append(cls)
+                all_score.append(float(score)); n_pts += 1
+                if overlay is not None:
+                    x0, y0, x1, y1 = box.astype(int)
+                    cv2.rectangle(overlay, (x0, y0), (x1, y1), col, 2)
+                    cv2.circle(overlay, (int((x0 + x1) / 2), y1), 6, (0, 0, 255), -1)
+            else:  # mask-contour
+                mask_r = cv2.resize(masks[di].astype(np.uint8), (gw, gh),
+                                    interpolation=cv2.INTER_NEAREST).astype(bool)
+                cols, brows = bottom_silhouette(mask_r, stride=2)
+                if len(cols) == 0:
+                    continue
+                d = ground_depth[brows, cols]
+                ok = np.isfinite(d) & (d > 0.5)
+                if not ok.any():
+                    continue
+                world = backproject_pixels(cols[ok].astype(float), brows[ok].astype(float),
+                                           d[ok], cam, im, scale)
+                for uv in (world @ gf.R.T)[:, :2]:
+                    accum_add(cls, uv, float(score)); n_pts += 1
+                if overlay is not None:
+                    cnts, _ = cv2.findContours(masks[di].astype(np.uint8),
+                                               cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+                    cv2.drawContours(overlay, cnts, -1, col, 2)
             if overlay is not None:
-                x0, y0, x1, y1 = box.astype(int)
-                col = colour_for(cls, classes.index(cls) if cls in classes else 0)
-                cv2.rectangle(overlay, (x0, y0), (x1, y1), col, 2)
-                cv2.circle(overlay, (int((x0 + x1) / 2), y1), 6, (0, 0, 255), -1)
+                x0, y0 = box[:2].astype(int)
                 cv2.putText(overlay, f"{cls} {score:.2f}", (x0, max(y0 - 5, 12)),
                             cv2.FONT_HERSHEY_SIMPLEX, 0.5, col, 2, cv2.LINE_AA)
         if overlay is not None:
             cv2.imwrite(str(det_dir / f"{Path(im.name).stem}.jpg"), overlay)
         if (fi + 1) % 20 == 0:
-            print(f"  {fi + 1}/{len(ims)} frames, {n_det} foot points")
+            print(f"  {fi + 1}/{len(ims)} frames, {n_pts} points")
 
     traj_uv = [(t[0], t[1]) for t in traj_uv]
-    print(f"detected {n_det} foot points over {len(ims)} frames")
-    if not all_uv:
-        raise SystemExit("no foot points landed on the ground — check detector/prompt/DEM")
+    print(f"collected {n_pts} contact points over {len(ims)} frames (mode={args.mode})")
 
-    objects = cluster_footprints(
-        np.array(all_uv), all_lab, np.array(all_score), classes,
-        args.eps, args.min_samples)
+    if args.mode == "points":
+        if not all_uv:
+            raise SystemExit("no foot points landed on the ground — check detector/prompt/DEM")
+        objects = cluster_footprints(np.array(all_uv), all_lab, np.array(all_score),
+                                     classes, args.eps, args.min_samples)
+        render_bev(gf, objects, traj_uv, out / "bev_footprints.png")
+    else:
+        objects = []
+        for cls in accum_count:
+            objects += extract_polygons(accum_count[cls], accum_weight[cls], spec,
+                                        args.accum_cell, cls, args.min_samples,
+                                        args.min_area, args.approx_eps)
+        objects.sort(key=lambda o: -o["area_m2"])
+        render_bev_polygons(gf, objects, traj_uv, out / "bev_footprints.png")
 
-    render_bev(gf, objects, traj_uv, out / "bev_footprints.png")
     (out / "objects.json").write_text(json.dumps(objects, indent=2))
     print(f"\n{len(objects)} objects -> {out}/bev_footprints.png")
     by_cls: dict[str, int] = {}

--- a/script/backbone/base_points.py
+++ b/script/backbone/base_points.py
@@ -28,7 +28,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import re
 import sys
+import time
 from pathlib import Path
 
 import cv2
@@ -92,21 +95,150 @@ def canonical(label: str, classes: list[str]) -> str:
 
 
 # --------------------------------------------------------------------------- #
+# VLM pointing backend (Moondream2, Apache-2.0 — native .point() per class)
+# --------------------------------------------------------------------------- #
+def load_pointer(model_id: str, revision: str, device: str):
+    """A pointing VLM: emits a 2D point per instance from a class name (no boxes)."""
+    from transformers import AutoModelForCausalLM
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id, revision=revision, trust_remote_code=True,
+        torch_dtype=torch.float16).to(device).eval()
+    return model
+
+
+@torch.no_grad()
+def vlm_points(model, pil: Image.Image, classes: list[str]):
+    """Query the VLM once per class -> list of (x_px, y_px, class, score) in original px.
+
+    Moondream `.point(image, "<class>")` returns {"points": [{"x":0..1,"y":0..1}, ...]},
+    one entry per detected instance (normalised coords). No per-point confidence, so score=1.
+    """
+    W, H = pil.size
+    out = []
+    for c in classes:
+        res = model.point(pil, c)
+        pts = res.get("points", res) if isinstance(res, dict) else res
+        for p in pts:
+            x = (p["x"] if isinstance(p, dict) else p[0]) * W
+            y = (p["y"] if isinstance(p, dict) else p[1]) * H
+            out.append((float(x), float(y), c, 1.0))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Gemini pointing backend (cloud oracle — needs $GEMINI_API_KEY). Not shippable
+# as an offline model; used to measure the quality ceiling above the local pointers.
+# --------------------------------------------------------------------------- #
+def load_gemini(model_id: str):
+    from google import genai
+    key = os.environ.get("GEMINI_API_KEY")
+    if not key:
+        raise SystemExit("--backend gemini needs GEMINI_API_KEY in the environment")
+    return genai.Client(api_key=key), model_id
+
+
+def _parse_gemini(txt: str, W: int, H: int):
+    """Tolerant parse of Gemini's pointing reply -> [(x_px, y_px, label, score)].
+
+    Slice to the outermost JSON array; if that won't parse, regex each {...} object. Accepts
+    'point'/'point_2d'/'box_2d' [y,x] (0-1000). Robust to stray prose or code fences."""
+    i, j = txt.find("["), txt.rfind("]")
+    data = None
+    if 0 <= i < j:
+        try:
+            data = json.loads(txt[i:j + 1])
+        except Exception:
+            data = None
+    if data is None:
+        data = []
+        for m in re.finditer(r"\{[^{}]*\}", txt):
+            try:
+                data.append(json.loads(m.group()))
+            except Exception:
+                pass
+    out = []
+    for d in data:
+        if not isinstance(d, dict):
+            continue
+        p = d.get("point") or d.get("point_2d") or d.get("box_2d")
+        if not isinstance(p, (list, tuple)) or len(p) < 2:
+            continue
+        y, x = float(p[0]), float(p[1])
+        out.append((x / 1000 * W, y / 1000 * H, str(d.get("label", "")).lower(), 1.0))
+    return out
+
+
+def gemini_points(client_model, pil: Image.Image, classes: list[str], retries: int = 4):
+    """One multi-class call per frame -> list of (x_px, y_px, class, score). Gemini returns
+    ground-contact points as {"point": [y, x], "label"} normalised 0-1000. Retries only on
+    rate-limit / transient network errors (content errors just yield whatever parsed)."""
+    client, model_id = client_model
+    W, H = pil.size
+    prompt = ("Point to each " + ", ".join(classes) + " in this image, at the spot where the "
+              "object meets the ground. Respond with ONLY a JSON list of "
+              '{"point": [y, x], "label": "<class>"}, where class is exactly one of the listed '
+              "names and [y, x] are normalised to 0-1000. No prose, no code fences.")
+    for attempt in range(retries):
+        try:
+            resp = client.models.generate_content(model=model_id, contents=[pil, prompt])
+        except Exception as e:
+            msg = str(e)
+            transient = any(t in msg for t in ("429", "RESOURCE_EXHAUSTED", "503",
+                                               "UNAVAILABLE", "name resolution", "timed out"))
+            if transient and attempt < retries - 1:
+                time.sleep(15 * (attempt + 1)); continue
+            print(f"  gemini call error: {msg[:110]}")
+            return []
+        return _parse_gemini(resp.text or "", W, H)
+    return []
+
+
+# --------------------------------------------------------------------------- #
 # foot point -> ground world point
 # --------------------------------------------------------------------------- #
-def foot_world(box, ground_depth, scale, cam, im, min_depth=0.5):
-    """Bottom-centre of the box -> world point on the DEM ground (or None if off-ground)."""
-    x0, y0, x1, y1 = box
+def world_from_render_px(c, r, d, scale, cam, im):
+    """Render-res pixel (c,r) + its ground depth -> world point."""
+    fx, fy, cx, cy = (v * scale for v in pinhole_params(cam))
+    cam_pt = np.array([(c - cx) / fx * d, (r - cy) / fy * d, d])
+    R = qvec2rotmat(im.qvec)
+    return cam_pt @ R + (-R.T @ im.tvec)  # world = cam @ R + C
+
+
+def pixel_world(px, py, ground_depth, scale, cam, im, min_depth=0.5):
+    """A single original-image pixel -> world point on the DEM ground (None if off-ground).
+
+    `px,py` are in original image coordinates; `scale` maps them into the render-res
+    ground-depth buffer. Shared by the box foot-point path and the VLM point path.
+    """
     h, w = ground_depth.shape
-    fx_px = int(round(np.clip((x0 + x1) * 0.5 * scale, 0, w - 1)))
-    fy_px = int(round(np.clip(y1 * scale, 0, h - 1)))
+    fx_px = int(round(np.clip(px * scale, 0, w - 1)))
+    fy_px = int(round(np.clip(py * scale, 0, h - 1)))
     d = ground_depth[fy_px, fx_px]
     if not np.isfinite(d) or d < min_depth:
         return None
-    fx, fy, cx, cy = (v * scale for v in pinhole_params(cam))
-    cam_pt = np.array([(fx_px - cx) / fx * d, (fy_px - cy) / fy * d, d])
-    R = qvec2rotmat(im.qvec)
-    return cam_pt @ R + (-R.T @ im.tvec)  # world = cam @ R + C
+    return world_from_render_px(fx_px, fy_px, d, scale, cam, im)
+
+
+def foot_world(box, ground_depth, scale, cam, im, min_depth=0.5):
+    """Bottom-centre of the box -> world point on the DEM ground (or None if off-ground)."""
+    x0, y0, x1, y1 = box
+    return pixel_world((x0 + x1) * 0.5, y1, ground_depth, scale, cam, im, min_depth)
+
+
+def drop_to_ground(px, py, ground_depth, scale, min_depth=0.5):
+    """A VLM object point lands mid-object (trunk/seat), where DEM depth is NaN. Walk DOWN
+    that image column to the first ground pixel = the object's ground contact directly below.
+    Returns (col, row, depth) in render-res, or None if no ground below the point."""
+    h, w = ground_depth.shape
+    c = int(round(np.clip(px * scale, 0, w - 1)))
+    r0 = int(round(np.clip(py * scale, 0, h - 1)))
+    col = ground_depth[:, c]
+    finite = np.where(np.isfinite(col) & (col >= min_depth))[0]
+    finite = finite[finite >= r0]
+    if len(finite) == 0:
+        return None
+    r = int(finite[0])
+    return c, r, float(col[r])
 
 
 # --------------------------------------------------------------------------- #
@@ -343,7 +475,16 @@ def main() -> None:
                     help="points = foot point per object (thin objects); "
                          "mask-contour = SAM mask -> ground silhouette -> footprint polygon "
                          "(multi-contact objects: benches, signs)")
+    ap.add_argument("--backend", choices=["gdino", "moondream", "gemini"], default="gdino",
+                    help="gdino = Grounding DINO boxes (foot point / mask-contour); "
+                         "moondream = local VLM pointing (Apache-2.0); "
+                         "gemini = cloud VLM pointing oracle (needs $GEMINI_API_KEY). "
+                         "Both VLM backends emit one point per instance, then drop to the "
+                         "ground contact. Force --mode points.")
     ap.add_argument("--detector", default="IDEA-Research/grounding-dino-tiny")
+    ap.add_argument("--vlm-model", default="vikhyatk/moondream2")
+    ap.add_argument("--vlm-revision", default="2025-06-21")
+    ap.add_argument("--gemini-model", default="gemini-flash-lite-latest")
     ap.add_argument("--sam-model", default="facebook/sam-vit-base",
                     help="SAM checkpoint for mask-contour (SAM2 is a drop-in)")
     ap.add_argument("--accum-cell", type=float, default=0.25, help="BEV accumulator cell (m)")
@@ -392,11 +533,22 @@ def main() -> None:
 
     classes = [c.strip().lower() for c in args.prompt.split(".") if c.strip()]
     print(f"classes: {classes}")
-    proc, det_model = load_detector(args.detector, device)
-    sam_proc = sam_model = None
-    if args.mode == "mask-contour":
-        print(f"loading SAM {args.sam_model}")
-        sam_proc, sam_model = load_sam(args.sam_model, device)
+    proc = det_model = pointer = gemini = sam_proc = sam_model = None
+    is_vlm = args.backend in ("moondream", "gemini")
+    if is_vlm and args.mode != "points":
+        print(f"{args.backend} backend -> forcing --mode points")
+        args.mode = "points"
+    if args.backend == "moondream":
+        print(f"loading pointer VLM {args.vlm_model}@{args.vlm_revision}")
+        pointer = load_pointer(args.vlm_model, args.vlm_revision, device)
+    elif args.backend == "gemini":
+        print(f"gemini pointing oracle: {args.gemini_model}")
+        gemini = load_gemini(args.gemini_model)
+    else:
+        proc, det_model = load_detector(args.detector, device)
+        if args.mode == "mask-contour":
+            print(f"loading SAM {args.sam_model}")
+            sam_proc, sam_model = load_sam(args.sam_model, device)
 
     ims = sorted(recon.images.values(), key=lambda im: im.name)
     if args.sample and args.sample < len(ims):
@@ -433,6 +585,35 @@ def main() -> None:
         gh, gw = ground_depth.shape
         scale = args.size / max(cam.width, cam.height)
         pil = Image.open(images / im.name).convert("RGB")
+
+        if is_vlm:
+            vpts = (vlm_points(pointer, pil, classes) if args.backend == "moondream"
+                    else gemini_points(gemini, pil, classes))
+            overlay = cv2.imread(str(images / im.name)) if fi < args.save_detections else None
+            for (x, y, cls_raw, score) in vpts:
+                cls = canonical(cls_raw, classes)
+                hit = drop_to_ground(x, y, ground_depth, scale)   # object point -> ground contact
+                if hit is None:
+                    continue
+                c, r, d = hit
+                w = world_from_render_px(c, r, d, scale, cam, im)
+                all_uv.append((w @ gf.R.T)[:2]); all_lab.append(cls)
+                all_score.append(score); n_pts += 1
+                if overlay is not None:
+                    col = colour_for(cls, classes.index(cls) if cls in classes else 0)
+                    ox, oy = int(x), int(y)                        # VLM object point
+                    gx, gy = int(c / scale), int(r / scale)        # ground contact (orig px)
+                    cv2.circle(overlay, (ox, oy), 5, col, 2, cv2.LINE_AA)
+                    cv2.line(overlay, (ox, oy), (gx, gy), col, 1, cv2.LINE_AA)
+                    cv2.circle(overlay, (gx, gy), 6, (0, 0, 255), -1, cv2.LINE_AA)
+                    cv2.putText(overlay, cls, (ox + 6, max(oy - 6, 12)),
+                                cv2.FONT_HERSHEY_SIMPLEX, 0.5, col, 2, cv2.LINE_AA)
+            if overlay is not None:
+                cv2.imwrite(str(det_dir / f"{Path(im.name).stem}.jpg"), overlay)
+            if (fi + 1) % 20 == 0:
+                print(f"  {fi + 1}/{len(ims)} frames, {n_pts} points")
+            continue
+
         dets = detect(proc, det_model, pil, args.prompt, device, args.box_thr, args.text_thr)
         masks = (sam_masks(sam_proc, sam_model, pil, [d[0] for d in dets], device)
                  if args.mode == "mask-contour" else [None] * len(dets))

--- a/script/backbone/base_points.py
+++ b/script/backbone/base_points.py
@@ -1,0 +1,336 @@
+"""Object footprint *points/lines* from open-vocab detection + BEV foot-point clustering.
+
+The dedup problem with semantic masks: the same tree, projected from 970 frames, smears into
+one un-separable blob. The fix multi-view BEV localization uses is the **foot point** — reduce
+each detected object to a single ground-contact point (bottom-centre of its box), project that
+to the ground plane, and **cluster across frames**. Points from the same object collapse to one
+landmark; a stray bad frame is an outlier that doesn't cluster. Instance detection (not semantic
+segmentation) is what makes objects separable in the first place.
+
+Pipeline (per sampled frame):
+  1. **Grounding DINO** (Apache-2.0, open-vocab) detects `tree / bench / pole / sign / ...` →
+     one box per instance from a text prompt.
+  2. **Foot point** = bottom-centre of the box.
+  3. Look up the **DEM ground depth** at that pixel (the ground surface we trust — reuses the
+     footprint_labels DEM render — instead of mono depth at the noisy object edge) and
+     back-project → a single world point on the ground.
+Then across all frames: gravity-align, **DBSCAN per class** → one deduped footprint per object,
+with an open-vocab label. Drops straight into IMDF `amenity.landmark` (trees) / `unit.structure`.
+
+Geometry-only DEM by default; pass `--dem-source mono` (same as footprint_labels) for a denser
+ground surface so more foot pixels resolve to a ground depth.
+
+Run (from repo root; needs the `segmentation` extra for transformers/torch):
+  uv run --extra segmentation python script/backbone/base_points.py --session maguro-park-after-itchy --sample 80
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+from PIL import Image
+from scipy.spatial import cKDTree
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+sys.path.insert(0, str(_HERE.parent / "semantic_bev"))
+
+from colmap_io import qvec2rotmat, read_model  # noqa: E402
+from lar_session import Session  # noqa: E402
+from footprint_labels import (  # noqa: E402
+    backproject_positions, build_ground_mesh, make_frame_labels, pinhole_params,
+)
+
+DEFAULT_PROMPT = "tree. bench. pole. sign. trash can. street lamp. rock. bush."
+# stable BGR colours per canonical class (fallback cycles for unknowns)
+CLASS_COLORS = {
+    "tree": (60, 170, 60), "bench": (200, 150, 40), "pole": (40, 140, 220),
+    "sign": (40, 40, 220), "trash can": (180, 60, 200), "street lamp": (60, 200, 200),
+    "rock": (120, 120, 120), "bush": (80, 200, 140),
+}
+_FALLBACK = [(200, 100, 60), (60, 100, 200), (100, 200, 60), (200, 60, 160)]
+
+
+# --------------------------------------------------------------------------- #
+# detection
+# --------------------------------------------------------------------------- #
+def load_detector(model_id: str, device: str):
+    from transformers import AutoModelForZeroShotObjectDetection, AutoProcessor
+    proc = AutoProcessor.from_pretrained(model_id)
+    model = AutoModelForZeroShotObjectDetection.from_pretrained(model_id).to(device).eval()
+    return proc, model
+
+
+@torch.no_grad()
+def detect(proc, model, pil: Image.Image, prompt: str, device: str,
+           box_thr: float, text_thr: float):
+    """Return list of (box xyxy in original px, label str, score)."""
+    inputs = proc(images=pil, text=prompt, return_tensors="pt").to(device)
+    outputs = model(**inputs)
+    res = proc.post_process_grounded_object_detection(
+        outputs, inputs.input_ids, threshold=box_thr, text_threshold=text_thr,
+        target_sizes=[pil.size[::-1]])[0]
+    boxes = res["boxes"].cpu().numpy()
+    scores = res["scores"].cpu().numpy()
+    labels = res.get("text_labels", res.get("labels"))
+    return list(zip(boxes, labels, scores))
+
+
+def canonical(label: str, classes: list[str]) -> str:
+    """Map a (possibly multi-word / partial) detection phrase to a prompt class."""
+    lab = str(label).lower().strip()
+    for c in classes:
+        if c in lab or lab in c:
+            return c
+    return lab or "object"
+
+
+# --------------------------------------------------------------------------- #
+# foot point -> ground world point
+# --------------------------------------------------------------------------- #
+def foot_world(box, ground_depth, scale, cam, im, min_depth=0.5):
+    """Bottom-centre of the box -> world point on the DEM ground (or None if off-ground)."""
+    x0, y0, x1, y1 = box
+    h, w = ground_depth.shape
+    fx_px = int(round(np.clip((x0 + x1) * 0.5 * scale, 0, w - 1)))
+    fy_px = int(round(np.clip(y1 * scale, 0, h - 1)))
+    d = ground_depth[fy_px, fx_px]
+    if not np.isfinite(d) or d < min_depth:
+        return None
+    fx, fy, cx, cy = (v * scale for v in pinhole_params(cam))
+    cam_pt = np.array([(fx_px - cx) / fx * d, (fy_px - cy) / fy * d, d])
+    R = qvec2rotmat(im.qvec)
+    return cam_pt @ R + (-R.T @ im.tvec)  # world = cam @ R + C
+
+
+# --------------------------------------------------------------------------- #
+# clustering (DBSCAN via KDTree; no sklearn)
+# --------------------------------------------------------------------------- #
+def dbscan(points: np.ndarray, eps: float, min_samples: int) -> np.ndarray:
+    n = len(points)
+    labels = np.full(n, -1, np.int64)
+    if n == 0:
+        return labels
+    tree = cKDTree(points)
+    visited = np.zeros(n, bool)
+    cid = 0
+    for i in range(n):
+        if visited[i]:
+            continue
+        visited[i] = True
+        seeds = tree.query_ball_point(points[i], eps)
+        if len(seeds) < min_samples:
+            continue  # provisional noise; may still be absorbed into a cluster below
+        labels[i] = cid
+        k = 0
+        while k < len(seeds):
+            j = seeds[k]; k += 1
+            if labels[j] == -1:
+                labels[j] = cid
+            if not visited[j]:
+                visited[j] = True
+                nj = tree.query_ball_point(points[j], eps)
+                if len(nj) >= min_samples:
+                    seeds.extend(nj)
+        cid += 1
+    return labels
+
+
+def cluster_footprints(pts_uv: np.ndarray, labels: list[str], scores: np.ndarray,
+                       classes: list[str], eps: float, min_samples: int, log=print):
+    """Per-class DBSCAN -> one landmark per cluster (score-weighted centroid)."""
+    out = []
+    labels = np.asarray(labels)
+    for c in sorted(set(labels)):
+        m = labels == c
+        p = pts_uv[m]; sc = scores[m]
+        cl = dbscan(p, eps, min_samples)
+        for k in sorted(set(cl) - {-1}):
+            sel = cl == k
+            w = sc[sel]
+            centre = np.average(p[sel], axis=0, weights=w)
+            out.append({"class": str(c), "u": float(centre[0]), "v": float(centre[1]),
+                        "count": int(sel.sum()), "score": float(w.mean())})
+    out.sort(key=lambda d: -d["count"])
+    log(f"  clustered {len(pts_uv)} foot points -> {len(out)} objects "
+        f"({len(set(labels))} classes)")
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# BEV render
+# --------------------------------------------------------------------------- #
+def colour_for(cls: str, i: int):
+    return CLASS_COLORS.get(cls, _FALLBACK[i % len(_FALLBACK)])
+
+
+def render_bev(gf, objects, traj_uv, out_path: Path, ppm: float = 6.0):
+    spec = gf.spec
+    origin_u, origin_v, cs = spec.origin_u, spec.origin_v, spec.cell_size
+    W = int(spec.cols * cs * ppm) + 40
+    H = int(spec.rows * cs * ppm) + 40
+
+    def to_px(u, v):
+        return int((u - origin_u) * ppm) + 20, int((v - origin_v) * ppm) + 20
+
+    img = np.full((H, W, 3), 248, np.uint8)
+    # faint observed-DEM coverage as background context
+    cov = cv2.resize(gf.coverage.astype(np.uint8) * 255, (W - 40, H - 40),
+                     interpolation=cv2.INTER_NEAREST)
+    img[20:H - 20, 20:W - 20][cov > 0] = (233, 233, 233)
+
+    # camera trajectory
+    if len(traj_uv) > 1:
+        pts = np.array([to_px(u, v) for u, v in traj_uv], np.int32)
+        cv2.polylines(img, [pts], False, (170, 170, 170), 1, cv2.LINE_AA)
+
+    classes = sorted({o["class"] for o in objects})
+    cidx = {c: i for i, c in enumerate(classes)}
+    for o in objects:
+        col = colour_for(o["class"], cidx[o["class"]])
+        px, py = to_px(o["u"], o["v"])
+        r = int(np.clip(3 + o["count"] * 0.5, 4, 18))
+        cv2.circle(img, (px, py), r, col, -1, cv2.LINE_AA)
+        cv2.circle(img, (px, py), r, (40, 40, 40), 1, cv2.LINE_AA)
+
+    # legend
+    y = 30
+    for c in classes:
+        col = colour_for(c, cidx[c])
+        n = sum(o["count"] for o in objects if o["class"] == c)
+        k = sum(1 for o in objects if o["class"] == c)
+        cv2.circle(img, (30, y), 6, col, -1, cv2.LINE_AA)
+        cv2.putText(img, f"{c}: {k} objs ({n} det)", (44, y + 4),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.42, (30, 30, 30), 1, cv2.LINE_AA)
+        y += 20
+    cv2.imwrite(str(out_path), img)
+
+
+# --------------------------------------------------------------------------- #
+# driver
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session")
+    ap.add_argument("--model", help="COLMAP text model dir (default: session.best_model())")
+    ap.add_argument("--images", help="image dir (default: session.images)")
+    ap.add_argument("--out", help="output dir (default: output/<session>-basepoints)")
+    ap.add_argument("--dem-source", choices=["colmap", "mono"], default="colmap")
+    ap.add_argument("--depth-dir", help="mono depth dir (default: session.depth_dir('mono'))")
+    ap.add_argument("--detector", default="IDEA-Research/grounding-dino-tiny")
+    ap.add_argument("--prompt", default=DEFAULT_PROMPT, help="open-vocab classes, '.'-separated")
+    ap.add_argument("--box-thr", type=float, default=0.30)
+    ap.add_argument("--text-thr", type=float, default=0.25)
+    ap.add_argument("--eps", type=float, default=1.2, help="DBSCAN cluster radius (m)")
+    ap.add_argument("--min-samples", type=int, default=3, help="min detections to accept an object")
+    ap.add_argument("--cell-size", type=float, default=0.5)
+    ap.add_argument("--size", type=int, default=512, help="DEM render resolution for depth lookup")
+    ap.add_argument("--max-range", type=float, default=30.0)
+    ap.add_argument("--sample", type=int, default=80, help="frames spaced evenly across the capture")
+    ap.add_argument("--save-detections", type=int, default=8, help="save N per-frame detection overlays")
+    args = ap.parse_args()
+
+    s = Session(args.session) if args.session else None
+    if s:
+        model = Path(args.model) if args.model else s.best_model()
+        images = Path(args.images) if args.images else s.images
+        out = Path(args.out) if args.out else s.root / "output" / f"{s.name}-basepoints"
+        depth_dir = Path(args.depth_dir) if args.depth_dir else s.depth_dir("mono")
+    else:
+        if not (args.model and args.images and args.out):
+            ap.error("without --session, pass --model, --images and --out")
+        model, images, out = Path(args.model), Path(args.images), Path(args.out)
+        depth_dir = Path(args.depth_dir) if args.depth_dir else None
+    out.mkdir(parents=True, exist_ok=True)
+    det_dir = out / "detections"
+    det_dir.mkdir(exist_ok=True)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"model {model}\nimages {images}\nout {out}\ndevice {device}")
+    recon = read_model(str(model))
+
+    dem_world = None
+    if args.dem_source == "mono":
+        if depth_dir is None:
+            ap.error("--dem-source mono needs --depth-dir (or --session)")
+        print(f"DEM source: mono depth <- {depth_dir}")
+        dem_world = backproject_positions(recon, depth_dir, list(recon.images), 8, 0.1)
+    mesh, occ_world = build_ground_mesh(
+        recon, args.cell_size, (0.4, 2.0), 3, 0.8, dem_world=dem_world)
+    gf = mesh.gf
+
+    classes = [c.strip().lower() for c in args.prompt.split(".") if c.strip()]
+    print(f"classes: {classes}")
+    proc, det_model = load_detector(args.detector, device)
+
+    ims = sorted(recon.images.values(), key=lambda im: im.name)
+    if args.sample and args.sample < len(ims):
+        idx = np.linspace(0, len(ims) - 1, args.sample).round().astype(int)
+        ims = [ims[i] for i in idx]
+
+    all_uv, all_lab, all_score = [], [], []
+    traj_uv = []
+    n_det = 0
+    for fi, im in enumerate(ims):
+        cam = recon.cameras[im.camera_id]
+        R = qvec2rotmat(im.qvec)
+        cam_centre = -R.T @ im.tvec                 # camera centre in world
+        traj_uv.append((cam_centre @ gf.R.T)[:2])   # -> gravity-local (u, v)
+        res = make_frame_labels(mesh, occ_world, im, cam, args.size,
+                                args.max_range, 0.5, 0)
+        if res is None:
+            continue
+        ground_depth = res["depth"]
+        scale = args.size / max(cam.width, cam.height)
+        pil = Image.open(images / im.name).convert("RGB")
+        dets = detect(proc, det_model, pil, args.prompt, device, args.box_thr, args.text_thr)
+
+        overlay = cv2.imread(str(images / im.name)) if fi < args.save_detections else None
+        for box, label, score in dets:
+            cls = canonical(label, classes)
+            w = foot_world(box, ground_depth, scale, cam, im)
+            if w is None:
+                continue
+            local = w @ gf.R.T
+            all_uv.append(local[:2]); all_lab.append(cls); all_score.append(float(score))
+            n_det += 1
+            if overlay is not None:
+                x0, y0, x1, y1 = box.astype(int)
+                col = colour_for(cls, classes.index(cls) if cls in classes else 0)
+                cv2.rectangle(overlay, (x0, y0), (x1, y1), col, 2)
+                cv2.circle(overlay, (int((x0 + x1) / 2), y1), 6, (0, 0, 255), -1)
+                cv2.putText(overlay, f"{cls} {score:.2f}", (x0, max(y0 - 5, 12)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, col, 2, cv2.LINE_AA)
+        if overlay is not None:
+            cv2.imwrite(str(det_dir / f"{Path(im.name).stem}.jpg"), overlay)
+        if (fi + 1) % 20 == 0:
+            print(f"  {fi + 1}/{len(ims)} frames, {n_det} foot points")
+
+    traj_uv = [(t[0], t[1]) for t in traj_uv]
+    print(f"detected {n_det} foot points over {len(ims)} frames")
+    if not all_uv:
+        raise SystemExit("no foot points landed on the ground — check detector/prompt/DEM")
+
+    objects = cluster_footprints(
+        np.array(all_uv), all_lab, np.array(all_score), classes,
+        args.eps, args.min_samples)
+
+    render_bev(gf, objects, traj_uv, out / "bev_footprints.png")
+    (out / "objects.json").write_text(json.dumps(objects, indent=2))
+    print(f"\n{len(objects)} objects -> {out}/bev_footprints.png")
+    by_cls: dict[str, int] = {}
+    for o in objects:
+        by_cls[o["class"]] = by_cls.get(o["class"], 0) + 1
+    for c, k in sorted(by_cls.items(), key=lambda x: -x[1]):
+        print(f"  {c:14s} {k}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/base_points.py
+++ b/script/backbone/base_points.py
@@ -61,6 +61,69 @@ _FALLBACK = [(200, 100, 60), (60, 100, 200), (100, 200, 60), (200, 60, 160)]
 
 
 # --------------------------------------------------------------------------- #
+# 2DGS surfel ground surface: the trained surfels are surface-aligned, so their
+# centres are a dense, accurate surface cloud (same COLMAP frame gsplat trained on).
+# Feed as `dem_world` — build_ground_mesh extracts ground as the low per-cell quantile.
+# --------------------------------------------------------------------------- #
+def read_gsplat_ply(path: Path, opacity_min: float = 0.1, log=print) -> np.ndarray:
+    """Read a 3DGS/2DGS point_cloud.ply -> (N,3) surfel centres, opacity-filtered.
+
+    Minimal binary_little_endian reader: parses the property list (all float32 in this
+    format) to locate x/y/z/opacity by name, so it survives field-count changes."""
+    raw = path.read_bytes()
+    hdr_end = raw.index(b"end_header\n") + len(b"end_header\n")
+    header = raw[:hdr_end].decode("ascii", "replace").splitlines()
+    props, n = [], 0
+    for line in header:
+        if line.startswith("element vertex"):
+            n = int(line.split()[-1])
+        elif line.startswith("property"):
+            props.append(line.split()[-1])          # property float <name>
+    assert {"x", "y", "z"} <= set(props), f"ply missing xyz: {props[:6]}"
+    arr = np.frombuffer(raw[hdr_end:hdr_end + n * len(props) * 4],
+                        dtype=np.float32).reshape(n, len(props))
+    xyz = arr[:, [props.index("x"), props.index("y"), props.index("z")]].astype(np.float64)
+    if opacity_min and "opacity" in props:
+        alpha = 1.0 / (1.0 + np.exp(-arr[:, props.index("opacity")]))   # gsplat stores logit
+        keep = alpha >= opacity_min
+        xyz = xyz[keep]
+        log(f"  2DGS surfels: {n} -> {len(xyz)} kept (opacity sigmoid >= {opacity_min})")
+    else:
+        log(f"  2DGS surfels: {n}")
+    return xyz
+
+
+def adapt_cameras_to_images(recon, images_dir, log=print):
+    """Rescale COLMAP intrinsics to the actual image resolution.
+
+    Common gotcha (e.g. mip-NeRF 360): COLMAP is solved on full-res but the provided images
+    are a downsampled ``images_N`` dir, so detection pixels (image space) and the projection
+    intrinsics (full-res) disagree by the downscale factor. No-op when sizes already match."""
+    for cam in recon.cameras.values():
+        name = next((im.name for im in recon.images.values() if im.camera_id == cam.id), None)
+        if not name:
+            continue
+        p = Path(images_dir) / name
+        if not p.exists():
+            continue
+        with Image.open(p) as im0:
+            w, h = im0.size
+        if (w, h) == (cam.width, cam.height):
+            continue
+        rx, ry = w / cam.width, h / cam.height
+        q = cam.params.astype(float).copy()
+        if cam.model == "PINHOLE":              # [fx, fy, cx, cy]
+            q[0] *= rx; q[1] *= ry; q[2] *= rx; q[3] *= ry
+        elif cam.model in ("SIMPLE_PINHOLE", "SIMPLE_RADIAL", "RADIAL"):  # [f, cx, cy, ...]
+            q[0] *= rx; q[1] *= rx; q[2] *= ry
+        else:                                    # OPENCV etc.: scale the [fx,fy,cx,cy] head
+            q[:4] = q[:4] * [rx, ry, rx, ry]
+        cam.params, cam.width, cam.height = q, w, h
+        log(f"  adapted camera {cam.id}: {int(cam.width/rx)}x{int(cam.height/ry)} -> {w}x{h}")
+    return recon
+
+
+# --------------------------------------------------------------------------- #
 # detection
 # --------------------------------------------------------------------------- #
 def load_detector(model_id: str, device: str):
@@ -191,6 +254,54 @@ def gemini_points(client_model, pil: Image.Image, classes: list[str], retries: i
             return []
         return _parse_gemini(resp.text or "", W, H)
     return []
+
+
+# --------------------------------------------------------------------------- #
+# Moondream3 cloud pointing backend (needs $MOONDREAM_API_KEY). Same oracle role
+# as gemini: Moondream3 is 9B-MoE (2B active) — the whole 9B (~18 GB bf16) must be
+# resident, so it does NOT fit local 8 GB VRAM; the hosted API exposes the identical
+# .point() interface. BSL-1.1 + Additional Use Grant (commercial internal use OK).
+# --------------------------------------------------------------------------- #
+def load_moondream_cloud(model_id: str):
+    """Moondream cloud client (moondream3-preview by default). Needs $MOONDREAM_API_KEY."""
+    import moondream as md
+    key = os.environ.get("MOONDREAM_API_KEY")
+    if not key:
+        raise SystemExit("--backend moondream3 needs MOONDREAM_API_KEY in the environment")
+    return md.vl(api_key=key, model=model_id) if model_id else md.vl(api_key=key)
+
+
+def moondream_cloud_points(model, pil: Image.Image, classes: list[str], retries: int = 4):
+    """One cloud .point() call per class -> [(x_px, y_px, class, 1.0)] in original px.
+
+    Cloud .point() returns the SAME normalised {"points":[{"x":0..1,"y":0..1}]} shape as the
+    local moondream backend, but each call is a network round-trip -> retry on transient errors
+    (mirrors gemini_points). API returns no per-point confidence, so score=1."""
+    W, H = pil.size
+    out = []
+    for c in classes:
+        res = None
+        for attempt in range(retries):
+            try:
+                res = model.point(pil, c)
+            except Exception as e:
+                msg = str(e)
+                transient = any(t in msg for t in ("429", "RESOURCE_EXHAUSTED", "503", "502",
+                                                   "timeout", "timed out", "Connection",
+                                                   "name resolution"))
+                if transient and attempt < retries - 1:
+                    time.sleep(10 * (attempt + 1)); continue
+                print(f"  moondream cloud error [{c}]: {msg[:110]}")
+                res = None
+            break
+        if not res:
+            continue
+        pts = res.get("points", res) if isinstance(res, dict) else res
+        for p in pts:
+            x = (p["x"] if isinstance(p, dict) else p[0]) * W
+            y = (p["y"] if isinstance(p, dict) else p[1]) * H
+            out.append((float(x), float(y), c, 1.0))
+    return out
 
 
 # --------------------------------------------------------------------------- #
@@ -325,7 +436,7 @@ def cluster_footprints(pts_uv: np.ndarray, labels: list[str], scores: np.ndarray
 
 
 def cluster_triangulate(pts_uv, ray_o, ray_d, labels, scores, gf,
-                        eps, min_samples, max_cond=5e3, log=print):
+                        eps, min_samples, ground_tol=0.75, max_cond=5e3, log=print):
     """Per-class DBSCAN on the rough (DEM) positions to *group*, then multi-view **triangulate**
     each cluster's 3D contact from its member rays on the trusted poses — placement no longer
     rides on single-view depth. Singletons / near-parallel bundles fall back to the DEM centroid.
@@ -349,12 +460,24 @@ def cluster_triangulate(pts_uv, ray_o, ray_d, labels, scores, gf,
                     uv = local[:2]                           # axes 0,1 horizontal
                     hag = float(local[2] - gf.height_at(uv[None, :])[0])   # height above DEM ground
                     rec.update(u=float(uv[0]), v=float(uv[1]), method="triangulated",
-                               resid_m=round(resid, 3), cond=round(cond, 1),
-                               hag_m=round(hag, 3))
+                               resid_m=round(resid, 3), cond=round(cond, 1), hag_m=round(hag, 3))
                     out.append(rec); n_tri += 1
                     continue
-            rec.update(u=float(centroid[0]), v=float(centroid[1]), method="dem_fallback")
+            # singleton / ill-conditioned: no reliable 3D -> DEM centroid, ground unknown
+            rec.update(u=float(centroid[0]), v=float(centroid[1]), method="dem_fallback",
+                       on_ground=True)
             out.append(rec); n_fallback += 1
+    # The DEM is not a trustworthy ABSOLUTE ground datum (systematic vertical bias), so classify
+    # ground-vs-elevated RELATIVE to the object population's own ground level: on-ground objects
+    # pile up at the median hag; a vase-on-table sits a table-height above it. Absorbs DEM bias.
+    hags = [o["hag_m"] for o in out if o.get("method") == "triangulated"]
+    datum = float(np.median(hags)) if hags else 0.0
+    for o in out:
+        if "hag_m" in o:
+            o["hag_rel"] = round(o["hag_m"] - datum, 3)
+            o["on_ground"] = bool(o["hag_rel"] <= ground_tol)   # above the local ground = elevated
+    log(f"  ground datum (median hag vs DEM) = {datum:+.2f} units; "
+        f"elevated = hag_rel > {ground_tol}")
     out.sort(key=lambda d: -d["count"])
     resids = [o["resid_m"] for o in out if o.get("method") == "triangulated"]
     med = float(np.median(resids)) if resids else float("nan")
@@ -537,22 +660,35 @@ def main() -> None:
     ap.add_argument("--model", help="COLMAP text model dir (default: session.best_model())")
     ap.add_argument("--images", help="image dir (default: session.images)")
     ap.add_argument("--out", help="output dir (default: output/<session>-basepoints)")
-    ap.add_argument("--dem-source", choices=["colmap", "mono"], default="colmap")
+    ap.add_argument("--dem-source", choices=["colmap", "mono", "gsplat2d"], default="colmap",
+                    help="ground-surface cloud for the DEM: colmap (sparse) / mono (dense but "
+                         "vertically noisy) / gsplat2d (dense AND surface-aligned surfels). "
+                         "Occupancy always stays on the COLMAP obstacle cloud.")
     ap.add_argument("--depth-dir", help="mono depth dir (default: session.depth_dir('mono'))")
+    ap.add_argument("--gsplat-ply", help="2DGS point_cloud.ply (default: session gsplat2d out)")
+    ap.add_argument("--gsplat-opacity", type=float, default=0.1,
+                    help="drop 2DGS surfels below this sigmoid opacity (floaters)")
     ap.add_argument("--mode", choices=["points", "mask-contour"], default="points",
                     help="points = foot point per object (thin objects); "
                          "mask-contour = SAM mask -> ground silhouette -> footprint polygon "
                          "(multi-contact objects: benches, signs)")
-    ap.add_argument("--backend", choices=["gdino", "moondream", "gemini"], default="gdino",
+    ap.add_argument("--backend", choices=["gdino", "moondream", "moondream3", "gemini"],
+                    default="gdino",
                     help="gdino = Grounding DINO boxes (foot point / mask-contour); "
-                         "moondream = local VLM pointing (Apache-2.0); "
+                         "moondream = local Moondream2 VLM pointing (Apache-2.0); "
+                         "moondream3 = Moondream3 cloud pointing (needs $MOONDREAM_API_KEY; "
+                         "9B-MoE, too big for local 8 GB VRAM); "
                          "gemini = cloud VLM pointing oracle (needs $GEMINI_API_KEY). "
-                         "Both VLM backends emit one point per instance, then drop to the "
+                         "All VLM backends emit one point per instance, then drop to the "
                          "ground contact. Force --mode points.")
     ap.add_argument("--detector", default="IDEA-Research/grounding-dino-tiny")
     ap.add_argument("--vlm-model", default="vikhyatk/moondream2")
     ap.add_argument("--vlm-revision", default="2025-06-21")
     ap.add_argument("--gemini-model", default="gemini-flash-lite-latest")
+    ap.add_argument("--moondream-model", default="",
+                    help="Moondream cloud model id for --backend moondream3; empty (default) = "
+                         "client/server default, which is moondream3-preview. Pin a finetune "
+                         "via 'moondream3-preview/ft_id@step'.")
     ap.add_argument("--sam-model", default="facebook/sam-vit-base",
                     help="SAM checkpoint for mask-contour (SAM2 is a drop-in)")
     ap.add_argument("--accum-cell", type=float, default=0.25, help="BEV accumulator cell (m)")
@@ -568,6 +704,14 @@ def main() -> None:
                          "triangulate = group by DEM position, then multi-view ray "
                          "triangulation on the poses (drops single-view depth for the final "
                          "position). points mode only.")
+    ap.add_argument("--min-depression", type=float, default=7.0,
+                    help="reject a detection whose contact ray is shallower than this many "
+                         "degrees below horizontal (grazing near-horizon rays carry ~no range "
+                         "info; a walking cam sees most distant objects this way).")
+    ap.add_argument("--ground-tol", type=float, default=0.75,
+                    help="triangulated anchor within this height (scene units) of the DEM "
+                         "ground = a ground obstacle; higher = elevated (vase-on-table, hung "
+                         "sign) and flagged on_ground=false. Scale with the scene.")
     ap.add_argument("--cell-size", type=float, default=0.5)
     ap.add_argument("--size", type=int, default=512, help="DEM render resolution for depth lookup")
     ap.add_argument("--max-range", type=float, default=30.0)
@@ -581,11 +725,14 @@ def main() -> None:
         images = Path(args.images) if args.images else s.images
         out = Path(args.out) if args.out else s.root / "output" / f"{s.name}-basepoints"
         depth_dir = Path(args.depth_dir) if args.depth_dir else s.depth_dir("mono")
+        gsplat_ply = (Path(args.gsplat_ply) if args.gsplat_ply
+                      else s.gsplat_out(mode="2dgs") / "point_cloud.ply")
     else:
         if not (args.model and args.images and args.out):
             ap.error("without --session, pass --model, --images and --out")
         model, images, out = Path(args.model), Path(args.images), Path(args.out)
         depth_dir = Path(args.depth_dir) if args.depth_dir else None
+        gsplat_ply = Path(args.gsplat_ply) if args.gsplat_ply else None
     out.mkdir(parents=True, exist_ok=True)
     det_dir = out / "detections"
     det_dir.mkdir(exist_ok=True)
@@ -593,6 +740,7 @@ def main() -> None:
     device = "cuda" if torch.cuda.is_available() else "cpu"
     print(f"model {model}\nimages {images}\nout {out}\ndevice {device}")
     recon = read_model(str(model))
+    adapt_cameras_to_images(recon, images)   # handle downsampled images_N dirs (no-op if matched)
 
     dem_world = None
     if args.dem_source == "mono":
@@ -600,6 +748,18 @@ def main() -> None:
             ap.error("--dem-source mono needs --depth-dir (or --session)")
         print(f"DEM source: mono depth <- {depth_dir}")
         dem_world = backproject_positions(recon, depth_dir, list(recon.images), 8, 0.1)
+    elif args.dem_source == "gsplat2d":
+        if gsplat_ply is None or not gsplat_ply.exists():
+            ap.error(f"--dem-source gsplat2d needs a 2DGS ply (--gsplat-ply); got {gsplat_ply}")
+        print(f"DEM source: 2DGS surfels <- {gsplat_ply}")
+        dem_world = read_gsplat_ply(gsplat_ply, args.gsplat_opacity)
+        # 3DGS/2DGS park a few background surfels at extreme coords -> clip to the scene
+        # (camera-trajectory bbox + object range) or they blow up the DEM grid.
+        cams = np.array([-qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
+        lo, hi = cams.min(0) - args.max_range, cams.max(0) + args.max_range
+        inside = np.all((dem_world >= lo) & (dem_world <= hi), axis=1)
+        print(f"  clipped to scene bbox: {len(dem_world)} -> {int(inside.sum())} surfels")
+        dem_world = dem_world[inside]
     mesh, occ_world = build_ground_mesh(
         recon, args.cell_size, (0.4, 2.0), 3, 0.8, dem_world=dem_world)
     gf = mesh.gf
@@ -607,13 +767,16 @@ def main() -> None:
     classes = [c.strip().lower() for c in args.prompt.split(".") if c.strip()]
     print(f"classes: {classes}")
     proc = det_model = pointer = gemini = sam_proc = sam_model = None
-    is_vlm = args.backend in ("moondream", "gemini")
+    is_vlm = args.backend in ("moondream", "moondream3", "gemini")
     if is_vlm and args.mode != "points":
         print(f"{args.backend} backend -> forcing --mode points")
         args.mode = "points"
     if args.backend == "moondream":
         print(f"loading pointer VLM {args.vlm_model}@{args.vlm_revision}")
         pointer = load_pointer(args.vlm_model, args.vlm_revision, device)
+    elif args.backend == "moondream3":
+        print(f"moondream3 cloud pointing: {args.moondream_model or '(client default)'}")
+        pointer = load_moondream_cloud(args.moondream_model)
     elif args.backend == "gemini":
         print(f"gemini pointing oracle: {args.gemini_model}")
         gemini = load_gemini(args.gemini_model)
@@ -646,6 +809,7 @@ def main() -> None:
 
     all_uv, all_lab, all_score, traj_uv = [], [], [], []
     all_ray_o, all_ray_d = [], []          # per-detection world ray (origin, unit dir) for triangulation
+    all_dep = []                            # sin(depression below horizontal) of each contact ray
     n_pts = 0
     for fi, im in enumerate(ims):
         cam = recon.cameras[im.camera_id]
@@ -661,8 +825,12 @@ def main() -> None:
         pil = Image.open(images / im.name).convert("RGB")
 
         if is_vlm:
-            vpts = (vlm_points(pointer, pil, classes) if args.backend == "moondream"
-                    else gemini_points(gemini, pil, classes))
+            if args.backend == "moondream":
+                vpts = vlm_points(pointer, pil, classes)
+            elif args.backend == "moondream3":
+                vpts = moondream_cloud_points(pointer, pil, classes)
+            else:
+                vpts = gemini_points(gemini, pil, classes)
             overlay = cv2.imread(str(images / im.name)) if fi < args.save_detections else None
             for (x, y, cls_raw, score) in vpts:
                 cls = canonical(cls_raw, classes)
@@ -671,9 +839,10 @@ def main() -> None:
                     continue
                 c, r, d = hit
                 w = world_from_render_px(c, r, d, scale, cam, im)
-                ro, rd = pixel_ray(c, r, scale, cam, im)
+                ro, rd = pixel_ray(x * scale, y * scale, scale, cam, im)   # ray through the anchor
                 all_uv.append((w @ gf.R.T)[:2]); all_lab.append(cls)
-                all_score.append(score); all_ray_o.append(ro); all_ray_d.append(rd); n_pts += 1
+                all_score.append(score); all_ray_o.append(ro); all_ray_d.append(rd)
+                all_dep.append(float(-np.dot(rd, gf.up))); n_pts += 1
                 if overlay is not None:
                     col = colour_for(cls, classes.index(cls) if cls in classes else 0)
                     ox, oy = int(x), int(y)                        # VLM object point
@@ -707,7 +876,7 @@ def main() -> None:
                 ro, rd = pixel_ray(cg, rg, scale, cam, im)
                 all_uv.append((w @ gf.R.T)[:2]); all_lab.append(cls)
                 all_score.append(float(score)); all_ray_o.append(ro); all_ray_d.append(rd)
-                n_pts += 1
+                all_dep.append(float(-np.dot(rd, gf.up))); n_pts += 1
                 if overlay is not None:
                     x0, y0, x1, y1 = box.astype(int)
                     cv2.rectangle(overlay, (x0, y0), (x1, y1), col, 2)
@@ -745,14 +914,28 @@ def main() -> None:
     if args.mode == "points":
         if not all_uv:
             raise SystemExit("no foot points landed on the ground — check detector/prompt/DEM")
+        uv = np.array(all_uv); ro = np.array(all_ray_o); rd = np.array(all_ray_d)
+        lab = np.array(all_lab); sc = np.array(all_score); dep = np.array(all_dep)
+        # depression-angle gate: drop grazing near-horizon rays (no usable range; a walking cam
+        # sees most distant objects this way). Steep/close observations are what localise.
+        keep = dep >= np.sin(np.radians(args.min_depression))
+        print(f"  depression gate (>= {args.min_depression:.0f} deg): "
+              f"{len(uv)} -> {int(keep.sum())} contacts kept")
+        uv, ro, rd, lab, sc = uv[keep], ro[keep], rd[keep], lab[keep], sc[keep]
+        if len(uv) == 0:
+            raise SystemExit("no contacts survived the depression gate — lower --min-depression")
         if args.placement == "triangulate":
-            objects = cluster_triangulate(
-                np.array(all_uv), all_ray_o, all_ray_d, all_lab, np.array(all_score),
-                gf, args.eps, args.min_samples)
+            objects = cluster_triangulate(uv, ro, rd, lab, sc, gf,
+                                          args.eps, args.min_samples, ground_tol=args.ground_tol)
+            ground = [o for o in objects if o.get("on_ground", True)]
+            print(f"  {len(ground)}/{len(objects)} on-ground obstacles "
+                  f"(rest elevated: hag > {args.ground_tol} units)")
         else:
-            objects = cluster_footprints(np.array(all_uv), all_lab, np.array(all_score),
-                                         classes, args.eps, args.min_samples)
-        render_bev(gf, objects, traj_uv, out / "bev_footprints.png")
+            objects = cluster_footprints(uv, lab, sc, classes, args.eps, args.min_samples)
+        # BEV shows the walkable-footprint layer = on-ground obstacles only (elevated objects
+        # stay in objects.json flagged on_ground=false for downstream use).
+        render_bev(gf, [o for o in objects if o.get("on_ground", True)], traj_uv,
+                   out / "bev_footprints.png")
     else:
         objects = []
         for cls in accum_count:

--- a/script/backbone/base_points.py
+++ b/script/backbone/base_points.py
@@ -241,6 +241,35 @@ def drop_to_ground(px, py, ground_depth, scale, min_depth=0.5):
     return c, r, float(col[r])
 
 
+def pixel_ray(c, r, scale, cam, im):
+    """Render-res pixel (c,r) -> world-space ray (origin = camera centre, unit direction).
+
+    The metric placement's reliable half: uses only the (trusted) pose, no ground depth."""
+    fx, fy, cx, cy = (v * scale for v in pinhole_params(cam))
+    cam_dir = np.array([(c - cx) / fx, (r - cy) / fy, 1.0])
+    R = qvec2rotmat(im.qvec)
+    C = -R.T @ im.tvec                       # camera centre in world
+    d = cam_dir @ R                          # camera dir -> world (world = cam @ R + C)
+    return C, d / (np.linalg.norm(d) + 1e-12)
+
+
+def triangulate_rays(origins: np.ndarray, dirs: np.ndarray):
+    """Least-squares 3D point nearest a bundle of world rays (o_i, unit d_i).
+
+    Solves (Σ Pᵢ) p = Σ Pᵢ oᵢ with Pᵢ = I - dᵢdᵢᵀ (projector onto the plane ⟂ the ray).
+    Returns (point, mean_perp_residual_m, condition_number). A narrow-baseline cluster (all
+    rays near-parallel) yields a high condition number -> triangulation is untrustworthy there."""
+    A = np.zeros((3, 3)); b = np.zeros(3)
+    Ps = []
+    for o, d in zip(origins, dirs):
+        P = np.eye(3) - np.outer(d, d)
+        A += P; b += P @ o; Ps.append(P)
+    cond = float(np.linalg.cond(A))
+    p = np.linalg.solve(A + 1e-6 * np.eye(3), b)
+    resid = float(np.mean([np.linalg.norm(P @ (p - o)) for P, o in zip(Ps, origins)]))
+    return p, resid, cond
+
+
 # --------------------------------------------------------------------------- #
 # clustering (DBSCAN via KDTree; no sklearn)
 # --------------------------------------------------------------------------- #
@@ -292,6 +321,45 @@ def cluster_footprints(pts_uv: np.ndarray, labels: list[str], scores: np.ndarray
     out.sort(key=lambda d: -d["count"])
     log(f"  clustered {len(pts_uv)} foot points -> {len(out)} objects "
         f"({len(set(labels))} classes)")
+    return out
+
+
+def cluster_triangulate(pts_uv, ray_o, ray_d, labels, scores, gf,
+                        eps, min_samples, max_cond=5e3, log=print):
+    """Per-class DBSCAN on the rough (DEM) positions to *group*, then multi-view **triangulate**
+    each cluster's 3D contact from its member rays on the trusted poses — placement no longer
+    rides on single-view depth. Singletons / near-parallel bundles fall back to the DEM centroid.
+    Also reports the triangulated point's height above the DEM ground (should be ~0 if the
+    contacts are consistent) as a built-in quality check."""
+    labels = np.asarray(labels); scores = np.asarray(scores)
+    ray_o = np.asarray(ray_o); ray_d = np.asarray(ray_d)
+    out = []
+    n_tri = n_fallback = 0
+    for c in sorted(set(labels)):
+        m = np.where(labels == c)[0]
+        cl = dbscan(pts_uv[m], eps, min_samples)
+        for k in sorted(set(cl) - {-1}):
+            sel = m[cl == k]
+            centroid = np.average(pts_uv[sel], axis=0, weights=scores[sel])
+            rec = {"class": str(c), "count": int(len(sel)), "score": float(scores[sel].mean())}
+            if len(sel) >= 2:
+                P, resid, cond = triangulate_rays(ray_o[sel], ray_d[sel])
+                if cond <= max_cond:
+                    local = P @ gf.R.T                       # world -> gravity-local
+                    uv = local[:2]                           # axes 0,1 horizontal
+                    hag = float(local[2] - gf.height_at(uv[None, :])[0])   # height above DEM ground
+                    rec.update(u=float(uv[0]), v=float(uv[1]), method="triangulated",
+                               resid_m=round(resid, 3), cond=round(cond, 1),
+                               hag_m=round(hag, 3))
+                    out.append(rec); n_tri += 1
+                    continue
+            rec.update(u=float(centroid[0]), v=float(centroid[1]), method="dem_fallback")
+            out.append(rec); n_fallback += 1
+    out.sort(key=lambda d: -d["count"])
+    resids = [o["resid_m"] for o in out if o.get("method") == "triangulated"]
+    med = float(np.median(resids)) if resids else float("nan")
+    log(f"  clustered {len(pts_uv)} pts -> {len(out)} objects "
+        f"({n_tri} triangulated, {n_fallback} DEM-fallback); median ray residual {med:.2f} m")
     return out
 
 
@@ -495,6 +563,11 @@ def main() -> None:
     ap.add_argument("--text-thr", type=float, default=0.25)
     ap.add_argument("--eps", type=float, default=1.2, help="DBSCAN cluster radius (m)")
     ap.add_argument("--min-samples", type=int, default=3, help="min detections to accept an object")
+    ap.add_argument("--placement", choices=["dem", "triangulate"], default="dem",
+                    help="dem = single-view back-projection to the DEM ground (default); "
+                         "triangulate = group by DEM position, then multi-view ray "
+                         "triangulation on the poses (drops single-view depth for the final "
+                         "position). points mode only.")
     ap.add_argument("--cell-size", type=float, default=0.5)
     ap.add_argument("--size", type=int, default=512, help="DEM render resolution for depth lookup")
     ap.add_argument("--max-range", type=float, default=30.0)
@@ -572,6 +645,7 @@ def main() -> None:
             accum_weight[cls][row, col] += score
 
     all_uv, all_lab, all_score, traj_uv = [], [], [], []
+    all_ray_o, all_ray_d = [], []          # per-detection world ray (origin, unit dir) for triangulation
     n_pts = 0
     for fi, im in enumerate(ims):
         cam = recon.cameras[im.camera_id]
@@ -597,8 +671,9 @@ def main() -> None:
                     continue
                 c, r, d = hit
                 w = world_from_render_px(c, r, d, scale, cam, im)
+                ro, rd = pixel_ray(c, r, scale, cam, im)
                 all_uv.append((w @ gf.R.T)[:2]); all_lab.append(cls)
-                all_score.append(score); n_pts += 1
+                all_score.append(score); all_ray_o.append(ro); all_ray_d.append(rd); n_pts += 1
                 if overlay is not None:
                     col = colour_for(cls, classes.index(cls) if cls in classes else 0)
                     ox, oy = int(x), int(y)                        # VLM object point
@@ -626,8 +701,13 @@ def main() -> None:
                 w = foot_world(box, ground_depth, scale, cam, im)
                 if w is None:
                     continue
+                x0b, y0b, x1b, y1b = box
+                cg = int(round(np.clip((x0b + x1b) * 0.5 * scale, 0, gw - 1)))
+                rg = int(round(np.clip(y1b * scale, 0, gh - 1)))
+                ro, rd = pixel_ray(cg, rg, scale, cam, im)
                 all_uv.append((w @ gf.R.T)[:2]); all_lab.append(cls)
-                all_score.append(float(score)); n_pts += 1
+                all_score.append(float(score)); all_ray_o.append(ro); all_ray_d.append(rd)
+                n_pts += 1
                 if overlay is not None:
                     x0, y0, x1, y1 = box.astype(int)
                     cv2.rectangle(overlay, (x0, y0), (x1, y1), col, 2)
@@ -665,8 +745,13 @@ def main() -> None:
     if args.mode == "points":
         if not all_uv:
             raise SystemExit("no foot points landed on the ground — check detector/prompt/DEM")
-        objects = cluster_footprints(np.array(all_uv), all_lab, np.array(all_score),
-                                     classes, args.eps, args.min_samples)
+        if args.placement == "triangulate":
+            objects = cluster_triangulate(
+                np.array(all_uv), all_ray_o, all_ray_d, all_lab, np.array(all_score),
+                gf, args.eps, args.min_samples)
+        else:
+            objects = cluster_footprints(np.array(all_uv), all_lab, np.array(all_score),
+                                         classes, args.eps, args.min_samples)
         render_bev(gf, objects, traj_uv, out / "bev_footprints.png")
     else:
         objects = []

--- a/script/backbone/bev_render.py
+++ b/script/backbone/bev_render.py
@@ -45,21 +45,36 @@ from taxonomy import Klass  # noqa: E402
 UNKNOWN, FREE, FOOTPRINT, HIDDEN = 0, 1, 2, 3
 
 # presentation labels (priority order matters when classes overlap after morphology)
-L_UNSURVEYED, L_LOWCONF, L_GRASS, L_TERRAIN, L_PATH, L_HIDDEN, L_OCCUPIED = range(7)
+(L_UNSURVEYED, L_LOWCONF, L_GRASS, L_TERRAIN, L_PATH, L_HIDDEN,
+ L_OCC_TREE, L_OCC_WALL, L_OCC_BUILDING, L_OCC_FURNITURE, L_OCC_OTHER) = range(11)
+OCC_LABELS = (L_OCC_TREE, L_OCC_WALL, L_OCC_BUILDING, L_OCC_FURNITURE, L_OCC_OTHER)
+# structure Klass -> presentation label
+OCC_OF_KLASS = {int(Klass.TREE): L_OCC_TREE, int(Klass.WALL): L_OCC_WALL,
+                int(Klass.BUILDING): L_OCC_BUILDING, int(Klass.FURNITURE): L_OCC_FURNITURE}
 
+# The load-bearing distinction in this map is walkable vs solid, so that is carried by
+# LIGHTNESS, not hue: ground classes are light and desaturated, occupied classes dark and
+# saturated. Hue then says which class within each group. Colouring occupied tree the same
+# green family as grass at similar lightness made the two read alike at a glance -- the one
+# confusion a navigation map cannot afford.
 PALETTE = {                      # RGB
-    L_UNSURVEYED: (24, 26, 30),
-    L_LOWCONF:    (105, 108, 115),
-    L_GRASS:      (104, 152, 92),
-    L_TERRAIN:    (150, 132, 106),
-    L_PATH:       (238, 220, 170),
-    L_HIDDEN:     (72, 88, 104),
-    L_OCCUPIED:   (188, 74, 62),
+    L_UNSURVEYED:    (24, 26, 30),
+    L_LOWCONF:       (108, 112, 120),
+    L_GRASS:         (154, 188, 130),
+    L_TERRAIN:       (178, 160, 132),
+    L_PATH:          (242, 228, 190),
+    L_HIDDEN:        (92, 108, 126),
+    L_OCC_TREE:      (20, 76, 42),
+    L_OCC_WALL:      (92, 60, 46),
+    L_OCC_BUILDING:  (138, 44, 92),
+    L_OCC_FURNITURE: (200, 112, 24),
+    L_OCC_OTHER:     (168, 48, 40),
 }
 NAMES = {
     L_UNSURVEYED: "not surveyed", L_LOWCONF: "low confidence", L_GRASS: "grass",
     L_TERRAIN: "terrain", L_PATH: "path / paved", L_HIDDEN: "occluded ground",
-    L_OCCUPIED: "occupied",
+    L_OCC_TREE: "tree / bush", L_OCC_WALL: "wall / fence", L_OCC_BUILDING: "building",
+    L_OCC_FURNITURE: "furniture", L_OCC_OTHER: "occupied (unclassed)",
 }
 
 
@@ -150,14 +165,21 @@ def surroundedness(mask: np.ndarray, radius: int) -> np.ndarray:
     return hits
 
 
-def fill_surrounded(mask: np.ndarray, radius: int, min_dirs: int, rounds: int = 3) -> np.ndarray:
-    """Grow `mask` into cells walled in on >= min_dirs of 8 sides. Iterated, because each
-    round makes the next concavity shallower."""
+def fill_surrounded(mask, radius, min_dirs, allowed=None, rounds: int = 3):
+    """Grow `mask` into cells walled in on >= min_dirs of 8 sides, restricted to `allowed`.
+
+    The allow-mask is not optional in spirit: without it the fill walks straight over PATH,
+    because a path pixel between two tree clumps genuinely is surrounded by occupied on most
+    sides. It is still a path. Never claim occupied where ground was directly OBSERVED
+    walkable -- an obstacle cannot be standing where we watched people walk.
+    """
     if min_dirs > 8 or radius < 1:
         return mask
     out = mask.copy()
     for _ in range(rounds):
         grow = (surroundedness(out, radius) >= min_dirs) & ~out
+        if allowed is not None:
+            grow &= allowed
         if not grow.any():
             break
         out |= grow
@@ -303,13 +325,18 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
     occupied = absorb_walled(hidden, occupied, args.surround_radius, args.enclose_dirs)
     hidden = hidden & ~occupied
 
-    layers = {L_OCCUPIED: occupied, L_PATH: path, L_TERRAIN: terrain,
+    # Everything the fill is permitted to claim. Observed walkable ground is excluded outright:
+    # a path pinched between two tree clumps is surrounded by occupied on most sides and is
+    # still a path -- that is what let the fill eat the walkways.
+    growable = ~(path | grass | terrain)
+
+    layers = {"occ": occupied, L_PATH: path, L_TERRAIN: terrain,
               L_GRASS: grass, L_HIDDEN: hidden}
 
     stats = {}
     for lid, m in layers.items():
         before = int(m.sum())
-        if lid == L_OCCUPIED:
+        if lid == "occ":
             # Occupied is the sparsest layer by construction -- FOOTPRINT marks base contacts,
             # a camera-facing rim, and at 0.5 m a bench or trunk is one or two cells. The blob
             # filter tuned for area classes deletes exactly those, so occupied gets its own
@@ -318,18 +345,32 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
             m = remove_small_blobs(m, args.min_blob_occupied)
             m = close_only(m, args.occupied_close)
             m = fill_small_holes(m, args.max_fill)
-            m = fill_surrounded(m, args.surround_radius, args.surround_dirs)
+            m = fill_surrounded(m, args.surround_radius, args.surround_dirs, growable)
         else:
             m = remove_small_blobs(m, args.min_blob)
             m = smooth(m, args.smooth)
         layers[lid] = m
-        stats[NAMES[lid]] = (before, int(m.sum()))
+        stats["occupied" if lid == "occ" else NAMES[lid]] = (before, int(m.sum()))
 
     out = np.full(state.shape, L_UNSURVEYED, np.uint8)
     out[surveyed] = L_LOWCONF                      # surveyed but not confident -> grey
     out[unclassified] = L_LOWCONF
-    for lid in (L_HIDDEN, L_GRASS, L_TERRAIN, L_PATH, L_OCCUPIED):   # last wins
+    for lid in (L_HIDDEN, L_GRASS, L_TERRAIN, L_PATH):
         out[layers[lid]] = lid
+
+    # Occupied carries WHAT is standing there. `structure` only labels cells that actually won
+    # a class vote, so morphology/fill leaves holes; each connected blob takes the majority
+    # class of its voted cells, which keeps one object one colour instead of a speckled mosaic.
+    occ_m = layers["occ"]
+    struct = z["structure"] if "structure" in z else np.zeros_like(state)
+    n, lab = cv2.connectedComponents(occ_m.astype(np.uint8), 8)
+    for i in range(1, n):
+        comp = lab == i
+        votes = struct[comp & (struct != int(Klass.UNKNOWN))]
+        lid = L_OCC_OTHER
+        if votes.size:
+            lid = OCC_OF_KLASS.get(int(np.bincount(votes).argmax()), L_OCC_OTHER)
+        out[comp] = lid
     return out, stats
 
 
@@ -341,7 +382,7 @@ def colorize(labels, scale, legend, cell_size=0.5, outline=True):
     pct = {lid: 100.0 * float((labels == lid).sum()) / total for lid in NAMES}
 
     rgb = np.flipud(lut[labels])                          # north-up, as footprint2d renders
-    occ = np.flipud(labels == L_OCCUPIED)
+    occ = np.flipud(np.isin(labels, OCC_LABELS))
     if scale > 1:
         rgb = cv2.resize(rgb, None, fx=scale, fy=scale, interpolation=cv2.INTER_NEAREST)
         occ = cv2.resize(occ.astype(np.uint8), None, fx=scale, fy=scale,
@@ -350,7 +391,7 @@ def colorize(labels, scale, legend, cell_size=0.5, outline=True):
         # A dark keyline round occupied regions. Obstacles are the one class a user must not
         # misread as ground, and at small sizes a fill alone reads as a colour blotch.
         cnts, _ = cv2.findContours(occ.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
-        cv2.drawContours(rgb, cnts, -1, (70, 22, 18), max(1, scale // 3))
+        cv2.drawContours(rgb, cnts, -1, (16, 14, 16), max(1, scale // 3))
 
     # scale bar: a map without one cannot be measured, and this is metric
     h, w = rgb.shape[:2]

--- a/script/backbone/bev_render.py
+++ b/script/backbone/bev_render.py
@@ -116,6 +116,90 @@ def smooth(mask: np.ndarray, k: int) -> np.ndarray:
     return m.astype(bool)
 
 
+
+def surroundedness(mask: np.ndarray, radius: int) -> np.ndarray:
+    """For each cell, how many of the 8 compass directions hit `mask` within `radius`.
+
+    `fill_small_holes` only closes *fully enclosed* voids, so an object whose base contacts
+    were seen from one side stays a C-shaped rim with its middle open to the outside -- the
+    hollow-object look. "Nearly surrounded" is the missing test: a cell walled in on 6 of 8
+    sides is inside the object even though a gap technically connects it to the exterior.
+
+    Direction-counting rather than a bigger morphological close, because a close with a kernel
+    wide enough to bridge the gap also welds together neighbouring objects that merely pass
+    near each other.
+    """
+    h, w = mask.shape
+    hits = np.zeros((h, w), np.uint8)
+    for dy, dx in ((-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (-1, 1), (1, -1), (1, 1)):
+        seen = np.zeros((h, w), bool)
+        cur = mask.copy()
+        for _ in range(radius):
+            cur = np.roll(cur, (dy, dx), (0, 1))
+            # a roll wraps; kill the wrapped edge so the far side of the map cannot vote
+            if dy > 0:
+                cur[0, :] = False
+            elif dy < 0:
+                cur[-1, :] = False
+            if dx > 0:
+                cur[:, 0] = False
+            elif dx < 0:
+                cur[:, -1] = False
+            seen |= cur
+        hits += seen.astype(np.uint8)
+    return hits
+
+
+def fill_surrounded(mask: np.ndarray, radius: int, min_dirs: int, rounds: int = 3) -> np.ndarray:
+    """Grow `mask` into cells walled in on >= min_dirs of 8 sides. Iterated, because each
+    round makes the next concavity shallower."""
+    if min_dirs > 8 or radius < 1:
+        return mask
+    out = mask.copy()
+    for _ in range(rounds):
+        grow = (surroundedness(out, radius) >= min_dirs) & ~out
+        if not grow.any():
+            break
+        out |= grow
+    return out
+
+
+def range_limit_true(near: np.ndarray, max_m: float) -> np.ndarray:
+    """Keep cells the camera actually came within `max_m` of (from `near_range` in the npz).
+
+    Strictly better than the distance-from-core proxy below: view COUNT cannot distinguish a
+    cell seen 60 times from 30 m away at a grazing angle from one seen 6 times at 4 m, and it
+    is the former that is noisy. -1 marks cells never raycast."""
+    if max_m <= 0:
+        return np.ones_like(near, bool)
+    return (near >= 0) & (near <= max_m)
+
+
+def range_limit(confident: np.ndarray, cell_size: float, max_m: float) -> np.ndarray:
+    """Cells within `max_m` of the well-observed core.
+
+    Noise is not spread evenly -- it lives at the coverage frontier, far from where the camera
+    actually went, where a cell has one or two grazing observations. Rather than trusting a
+    vote threshold to sort that out, cut on distance from the confident core outright. The
+    trajectory itself is not in the npz (no DEM origin is stored), but the set of
+    well-observed cells is a faithful stand-in for where the camera was.
+    """
+    if max_m <= 0 or not confident.any():
+        return np.ones_like(confident, bool)
+    d = cv2.distanceTransform((~confident).astype(np.uint8), cv2.DIST_L2, 5)
+    return d * cell_size <= max_m
+
+
+def crop_to_content(labels: np.ndarray, margin: int = 3) -> np.ndarray:
+    """Trim the dead border so the map fills its frame."""
+    ys, xs = np.where(labels != L_UNSURVEYED)
+    if not len(ys):
+        return labels
+    y0, y1 = max(0, ys.min() - margin), min(labels.shape[0], ys.max() + margin + 1)
+    x0, x1 = max(0, xs.min() - margin), min(labels.shape[1], xs.max() + margin + 1)
+    return labels[y0:y1, x0:x1]
+
+
 def build_labels(z, args) -> tuple[np.ndarray, dict]:
     state = z["state"]
     surface = z["surface"] if "surface" in z else np.zeros_like(state)
@@ -125,10 +209,29 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
     # The survey frontier is dithered at cell level (one ray lands, its neighbour misses), which
     # renders as salt-and-pepper along every edge. Smooth the *masks* so the boundary reads as a
     # boundary; this changes only where we admit to knowing, never what we claim to know.
-    surveyed = smooth(obs > 0, args.smooth)
-    confident = smooth(obs >= args.min_views, args.smooth)
+    # De-speckle BEFORE smoothing: a lone surveyed cell survives the close as a plus-shaped
+    # nub (the kernel's own footprint), which is why crosses were littering the border.
+    surveyed = smooth(remove_small_blobs(obs > 0, args.min_blob), args.smooth)
+    confident = smooth(remove_small_blobs(obs >= args.min_views, args.min_blob), args.smooth)
 
-    occupied = (state == FOOTPRINT) & (bearings >= args.min_bearings)
+    # Range is measured from the WELL-travelled core, not merely the confident set: obs peaks
+    # along the walked route, so a high threshold approximates the trajectory the npz does not
+    # store. Measuring from `confident` (>=4 views) made the core so broad that 25 m reached
+    # the frontier it was meant to exclude.
+    if "near_range" in z:
+        in_range = range_limit_true(z["near_range"], args.max_range)
+    else:
+        # Older npz: fall back to distance from the well-travelled core. Weak here, because the
+        # park is uniformly well-observed -- obs>=12 covers half the grid and every surveyed
+        # cell sits within 12 m of it, so the proxy has almost nothing to cut.
+        core = remove_small_blobs(obs >= args.core_views, args.min_blob)
+        if not core.any():
+            core = confident
+        in_range = range_limit(core, float(z["cell_size"]), args.max_range)
+    surveyed &= in_range
+    confident &= in_range
+
+    occupied = (state == FOOTPRINT) & (bearings >= args.min_bearings) & in_range
     hidden = (state == HIDDEN) & confident
     free = (state == FREE) & confident
 
@@ -154,6 +257,7 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
             m = remove_small_blobs(m, args.min_blob_occupied)
             m = close_only(m, args.occupied_close)
             m = fill_small_holes(m, args.max_fill)
+            m = fill_surrounded(m, args.surround_radius, args.surround_dirs)
         else:
             m = remove_small_blobs(m, args.min_blob)
             m = smooth(m, args.smooth)
@@ -168,24 +272,55 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
     return out, stats
 
 
-def colorize(labels: np.ndarray, scale: int, legend: bool) -> np.ndarray:
+def colorize(labels, scale, legend, cell_size=0.5, outline=True):
     lut = np.zeros((len(PALETTE), 3), np.uint8)
     for k, v in PALETTE.items():
         lut[k] = v
-    rgb = lut[labels]
-    rgb = np.flipud(rgb)                                  # north-up, as footprint2d renders
+    total = labels.size
+    pct = {lid: 100.0 * float((labels == lid).sum()) / total for lid in NAMES}
+
+    rgb = np.flipud(lut[labels])                          # north-up, as footprint2d renders
+    occ = np.flipud(labels == L_OCCUPIED)
     if scale > 1:
         rgb = cv2.resize(rgb, None, fx=scale, fy=scale, interpolation=cv2.INTER_NEAREST)
+        occ = cv2.resize(occ.astype(np.uint8), None, fx=scale, fy=scale,
+                         interpolation=cv2.INTER_NEAREST).astype(bool)
+    if outline:
+        # A dark keyline round occupied regions. Obstacles are the one class a user must not
+        # misread as ground, and at small sizes a fill alone reads as a colour blotch.
+        cnts, _ = cv2.findContours(occ.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
+        cv2.drawContours(rgb, cnts, -1, (70, 22, 18), max(1, scale // 3))
+
+    # scale bar: a map without one cannot be measured, and this is metric
+    h, w = rgb.shape[:2]
+    px_per_m = scale / cell_size
+    target = max(5.0, round((w * 0.18) / px_per_m / 5.0) * 5.0)      # ~18% of width, round 5 m
+    bar = int(target * px_per_m)
+    x0, y0 = 18, h - 26
+    cv2.rectangle(rgb, (x0, y0), (x0 + bar, y0 + 6), (245, 245, 245), -1)
+    cv2.rectangle(rgb, (x0, y0), (x0 + bar, y0 + 6), (20, 20, 20), 1)
+    cv2.putText(rgb, f"{target:.0f} m", (x0, y0 - 7), cv2.FONT_HERSHEY_SIMPLEX,
+                0.5, (245, 245, 245), 1, cv2.LINE_AA)
+    # north arrow (rows increase northward before the flip, so up is north here)
+    nx, ny = w - 34, 34
+    cv2.arrowedLine(rgb, (nx, ny + 20), (nx, ny - 12), (245, 245, 245), 2, tipLength=0.4)
+    cv2.putText(rgb, "N", (nx - 6, ny + 38), cv2.FONT_HERSHEY_SIMPLEX,
+                0.5, (245, 245, 245), 1, cv2.LINE_AA)
+
     if not legend:
         return rgb
-    pad, sw, lh = 14, 18, 26
-    bar = np.full((rgb.shape[0], 210, 3), PALETTE[L_UNSURVEYED], np.uint8)
+    pad, sw, lh = 14, 18, 27
+    bar_w = 232
+    panel = np.full((h, bar_w, 3), PALETTE[L_UNSURVEYED], np.uint8)
     for i, (lid, name) in enumerate(NAMES.items()):
         y = pad + i * lh
-        bar[y:y + sw, pad:pad + sw] = PALETTE[lid]
-        cv2.putText(bar, name, (pad + sw + 9, y + sw - 4), cv2.FONT_HERSHEY_SIMPLEX,
+        panel[y:y + sw, pad:pad + sw] = PALETTE[lid]
+        cv2.rectangle(panel, (pad, y), (pad + sw, y + sw), (20, 20, 20), 1)
+        cv2.putText(panel, name, (pad + sw + 9, y + sw - 5), cv2.FONT_HERSHEY_SIMPLEX,
                     0.42, (235, 238, 242), 1, cv2.LINE_AA)
-    return np.hstack([rgb, bar])
+        cv2.putText(panel, f"{pct[lid]:4.1f}%", (pad + sw + 9, y + sw + 9),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.34, (150, 155, 165), 1, cv2.LINE_AA)
+    return np.hstack([rgb, panel])
 
 
 def main():
@@ -199,6 +334,22 @@ def main():
                     help="distinct bearings required to draw a cell as occupied")
     ap.add_argument("--min-blob", type=int, default=4,
                     help="drop connected components smaller than this many cells (speckle)")
+    ap.add_argument("--core-views", type=int, default=12,
+                    help="views defining the well-travelled core that --max-range is measured "
+                         "from; obs peaks along the walked route, so this approximates the "
+                         "trajectory (which the npz does not store)")
+    ap.add_argument("--max-range", type=float, default=18.0,
+                    help="metres from the well-observed core beyond which cells are dropped "
+                         "entirely. Noise lives at the coverage frontier, so cut on distance "
+                         "rather than hoping a vote threshold sorts it out. 0 disables.")
+    ap.add_argument("--surround-radius", type=int, default=6,
+                    help="how far (cells) the 8 direction probes look when deciding a cell is "
+                         "inside an object")
+    ap.add_argument("--surround-dirs", type=int, default=6,
+                    help="of 8 directions, how many must hit occupied before an interior cell "
+                         "is filled. 8 = fully enclosed only; 6 tolerates a C-shaped rim. "
+                         "Lower bleeds objects outward.")
+    ap.add_argument("--no-crop", action="store_true", help="keep the empty border")
     ap.add_argument("--min-blob-occupied", type=int, default=2,
                     help="separate, smaller speckle threshold for occupied cells (base "
                          "contacts are sparse; the area-class threshold would erase objects)")
@@ -226,8 +377,11 @@ def main():
         n = int((labels == lid).sum())
         print(f"  final {name:<16s} {100*n/total:5.1f}%")
 
+    if not args.no_crop:
+        labels = crop_to_content(labels)
     out = Path(args.out) if args.out else npz.parent / "bev_clean.png"
-    cv2.imwrite(str(out), colorize(labels, args.scale, not args.no_legend)[:, :, ::-1])
+    img = colorize(labels, args.scale, not args.no_legend, float(z["cell_size"]))
+    cv2.imwrite(str(out), img[:, :, ::-1])
     print(f"  wrote {out}")
 
 

--- a/script/backbone/bev_render.py
+++ b/script/backbone/bev_render.py
@@ -200,6 +200,61 @@ def crop_to_content(labels: np.ndarray, margin: int = 3) -> np.ndarray:
     return labels[y0:y1, x0:x1]
 
 
+def absorb_enclosed(occluded: np.ndarray, occupied: np.ndarray,
+                    min_frac: float, max_area: int, log=None) -> np.ndarray:
+    """Occluded pockets whose BORDER is mostly occupied are interior, not walkable ground.
+
+    HIDDEN means "in frustum but never seen walkable" -- which covers two physically different
+    things. A pocket ringed by base contacts is the middle of a tree clump or hedge mass: the
+    ground is invisible because the object stands on it, and a router must treat it as solid.
+    A pocket open on one side is merely that object's occlusion shadow, and the ground there is
+    genuinely unknown -- claiming it is occupied would over-block, the failure this pipeline has
+    rejected repeatedly (it is why mono depth was dropped for occupancy).
+
+    So enclosure is measured per connected component as the fraction of its dilated border that
+    is occupied, and only components above `min_frac` are absorbed. A convex hull would not
+    distinguish the two cases: the hull of a curved hedge sweeps straight across the path it
+    borders.
+    """
+    if min_frac <= 0 or not occluded.any():
+        return occupied
+    n, lab, stats, _ = cv2.connectedComponentsWithStats(occluded.astype(np.uint8), 8)
+    ker = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
+    out = occupied.copy()
+    absorbed = 0
+    for i in range(1, n):
+        comp = lab == i
+        area = int(stats[i, cv2.CC_STAT_AREA])
+        if area > max_area:
+            continue                                  # too big to be an object interior
+        border = cv2.dilate(comp.astype(np.uint8), ker).astype(bool) & ~comp
+        nb = int(border.sum())
+        if nb == 0:
+            continue
+        if int((border & occupied).sum()) / nb >= min_frac:
+            out |= comp
+            absorbed += 1
+    if log:
+        log(f"  absorbed {absorbed} enclosed occluded pockets into occupied")
+    return out
+
+
+def absorb_walled(occluded: np.ndarray, occupied: np.ndarray, radius: int,
+                  min_dirs: int) -> np.ndarray:
+    """Absorb occluded cells walled in by occupied on >= min_dirs of 8 compass directions.
+
+    Looser than the component test: it fires per cell, so it catches the deep part of a
+    concave shadow without needing the whole pocket to be ringed. Measured on the full park
+    run at radius 6: >=5 dirs absorbs 179 of 4414 occluded cells (4%), >=6 only 41 (0.9%) --
+    small, because occupied is a CRESCENT not a ring. Base contacts come from the path-facing
+    side, so red rarely encircles anything, and most blue is genuine occlusion shadow whose
+    ground is unknown rather than object interior. Kept conservative for that reason.
+    """
+    if min_dirs > 8 or min_dirs <= 0 or not occluded.any() or not occupied.any():
+        return occupied
+    return occupied | (occluded & (surroundedness(occupied, radius) >= min_dirs))
+
+
 def build_labels(z, args) -> tuple[np.ndarray, dict]:
     state = z["state"]
     surface = z["surface"] if "surface" in z else np.zeros_like(state)
@@ -241,6 +296,12 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
     # FREE but unclassified surface -> walkable yet we cannot say what it is: that is
     # low-confidence information, not terrain. Rendering it as terrain would be a guess.
     unclassified = free & ~(path | grass | terrain)
+
+    # do this before the per-layer morphology, so absorbed pockets get the same
+    # close/fill treatment as the rest of the occupied mask
+    occupied = absorb_enclosed(hidden, occupied, args.enclose_frac, args.enclose_max_area)
+    occupied = absorb_walled(hidden, occupied, args.surround_radius, args.enclose_dirs)
+    hidden = hidden & ~occupied
 
     layers = {L_OCCUPIED: occupied, L_PATH: path, L_TERRAIN: terrain,
               L_GRASS: grass, L_HIDDEN: hidden}
@@ -342,6 +403,18 @@ def main():
                     help="metres from the well-observed core beyond which cells are dropped "
                          "entirely. Noise lives at the coverage frontier, so cut on distance "
                          "rather than hoping a vote threshold sorts it out. 0 disables.")
+    ap.add_argument("--enclose-frac", type=float, default=0.65,
+                    help="fraction of an occluded pocket's border that must be occupied before "
+                         "the pocket is absorbed as occupied (it is the inside of an object, "
+                         "not walkable ground). 0 disables; high values keep occlusion "
+                         "shadows -- which are genuinely unknown -- out of it.")
+    ap.add_argument("--enclose-dirs", type=int, default=5,
+                    help="absorb an occluded cell into occupied when this many of 8 compass "
+                         "directions hit occupied within --surround-radius. 9 disables. "
+                         "Conservative on purpose: most occluded ground is a one-sided "
+                         "occlusion shadow, and calling that solid would over-block.")
+    ap.add_argument("--enclose-max-area", type=int, default=400,
+                    help="occluded pockets larger than this many cells are never absorbed")
     ap.add_argument("--surround-radius", type=int, default=6,
                     help="how far (cells) the 8 direction probes look when deciding a cell is "
                          "inside an object")

--- a/script/backbone/bev_render.py
+++ b/script/backbone/bev_render.py
@@ -70,6 +70,23 @@ PALETTE = {                      # RGB
     L_OCC_FURNITURE: (200, 112, 24),
     L_OCC_OTHER:     (168, 48, 40),
 }
+# The cf3d965 palette, kept because that render is the reference the project judged the map
+# against. Reproducing a past figure must not require checking out a past commit — the script
+# should be able to draw its own history.
+PALETTE_V1 = {
+    L_UNSURVEYED:    (24, 26, 30),
+    L_LOWCONF:       (105, 108, 115),
+    L_GRASS:         (104, 152, 92),
+    L_TERRAIN:       (150, 132, 106),
+    L_PATH:          (238, 220, 170),
+    L_HIDDEN:        (72, 88, 104),
+    L_OCC_TREE:      (188, 74, 62),
+    L_OCC_WALL:      (188, 74, 62),
+    L_OCC_BUILDING:  (188, 74, 62),
+    L_OCC_FURNITURE: (188, 74, 62),
+    L_OCC_OTHER:     (188, 74, 62),
+}
+
 NAMES = {
     L_UNSURVEYED: "not surveyed", L_LOWCONF: "low confidence", L_GRASS: "grass",
     L_TERRAIN: "terrain", L_PATH: "path / paved", L_HIDDEN: "occluded ground",
@@ -374,12 +391,14 @@ def build_labels(z, args) -> tuple[np.ndarray, dict]:
     return out, stats
 
 
-def colorize(labels, scale, legend, cell_size=0.5, outline=True):
-    lut = np.zeros((len(PALETTE), 3), np.uint8)
-    for k, v in PALETTE.items():
+def colorize(labels, scale, legend, cell_size=0.5, outline=True, palette=None,
+             furniture=True, pct=True):
+    palette = palette or PALETTE
+    lut = np.zeros((max(palette) + 1, 3), np.uint8)
+    for k, v in palette.items():
         lut[k] = v
     total = labels.size
-    pct = {lid: 100.0 * float((labels == lid).sum()) / total for lid in NAMES}
+    shares = {lid: 100.0 * float((labels == lid).sum()) / total for lid in NAMES}
 
     rgb = np.flipud(lut[labels])                          # north-up, as footprint2d renders
     occ = np.flipud(np.isin(labels, OCC_LABELS))
@@ -387,14 +406,15 @@ def colorize(labels, scale, legend, cell_size=0.5, outline=True):
         rgb = cv2.resize(rgb, None, fx=scale, fy=scale, interpolation=cv2.INTER_NEAREST)
         occ = cv2.resize(occ.astype(np.uint8), None, fx=scale, fy=scale,
                          interpolation=cv2.INTER_NEAREST).astype(bool)
-    if outline:
+    if outline and furniture:
         # A dark keyline round occupied regions. Obstacles are the one class a user must not
         # misread as ground, and at small sizes a fill alone reads as a colour blotch.
         cnts, _ = cv2.findContours(occ.astype(np.uint8), cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
         cv2.drawContours(rgb, cnts, -1, (16, 14, 16), max(1, scale // 3))
 
-    # scale bar: a map without one cannot be measured, and this is metric
     h, w = rgb.shape[:2]
+    if not furniture:
+        return rgb if not legend else _legend(rgb, palette, shares, pct, not furniture)
     px_per_m = scale / cell_size
     target = max(5.0, round((w * 0.18) / px_per_m / 5.0) * 5.0)      # ~18% of width, round 5 m
     bar = int(target * px_per_m)
@@ -411,17 +431,31 @@ def colorize(labels, scale, legend, cell_size=0.5, outline=True):
 
     if not legend:
         return rgb
+    return _legend(rgb, palette, shares, pct)
+
+
+def _legend(rgb, palette, shares, pct, merge_occ=False):
+    h = rgb.shape[0]
     pad, sw, lh = 14, 18, 27
     bar_w = 232
-    panel = np.full((h, bar_w, 3), PALETTE[L_UNSURVEYED], np.uint8)
-    for i, (lid, name) in enumerate(NAMES.items()):
+    panel = np.full((h, bar_w, 3), palette[L_UNSURVEYED], np.uint8)
+    items = list(NAMES.items())
+    if merge_occ:
+        # v1 painted every occupied sub-class the same red; listing five identical swatches
+        # would be noise, so they collapse to the single row the reference figure had.
+        items = [(l, n) for l, n in items if l not in OCC_LABELS]
+        items.append((L_OCC_OTHER, "occupied"))
+        shares = dict(shares)
+        shares[L_OCC_OTHER] = sum(shares.get(l, 0.0) for l in OCC_LABELS)
+    for i, (lid, name) in enumerate(items):
         y = pad + i * lh
-        panel[y:y + sw, pad:pad + sw] = PALETTE[lid]
+        panel[y:y + sw, pad:pad + sw] = palette[lid]
         cv2.rectangle(panel, (pad, y), (pad + sw, y + sw), (20, 20, 20), 1)
         cv2.putText(panel, name, (pad + sw + 9, y + sw - 5), cv2.FONT_HERSHEY_SIMPLEX,
                     0.42, (235, 238, 242), 1, cv2.LINE_AA)
-        cv2.putText(panel, f"{pct[lid]:4.1f}%", (pad + sw + 9, y + sw + 9),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.34, (150, 155, 165), 1, cv2.LINE_AA)
+        if pct:
+            cv2.putText(panel, f"{shares[lid]:4.1f}%", (pad + sw + 9, y + sw + 9),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.34, (150, 155, 165), 1, cv2.LINE_AA)
     return np.hstack([rgb, panel])
 
 
@@ -476,7 +510,19 @@ def main():
     ap.add_argument("--smooth", type=int, default=3, help="morphological kernel (cells), <3 off")
     ap.add_argument("--scale", type=int, default=4, help="upscale factor")
     ap.add_argument("--no-legend", action="store_true")
+    ap.add_argument("--style", default="current", choices=["current", "clean3"],
+                    help="'clean3' reproduces the cf3d965 reference render exactly: flat-red "
+                         "occupied, v1 palette, no range limit, no surrounded/enclosed fill, "
+                         "no crop or map furniture. Kept so that figure stays reproducible "
+                         "from HEAD instead of requiring a checkout of an old commit.")
     args = ap.parse_args()
+
+    if args.style == "clean3":
+        args.max_range = 0.0
+        args.surround_dirs = 9
+        args.enclose_dirs = 9
+        args.enclose_frac = 0.0
+        args.no_crop = True
 
     npz = Path(args.npz).expanduser().resolve()
     z = np.load(npz)
@@ -494,7 +540,9 @@ def main():
     if not args.no_crop:
         labels = crop_to_content(labels)
     out = Path(args.out) if args.out else npz.parent / "bev_clean.png"
-    img = colorize(labels, args.scale, not args.no_legend, float(z["cell_size"]))
+    v1 = args.style == "clean3"
+    img = colorize(labels, args.scale, not args.no_legend, float(z["cell_size"]),
+                   palette=PALETTE_V1 if v1 else PALETTE, furniture=not v1, pct=not v1)
     cv2.imwrite(str(out), img[:, :, ::-1])
     print(f"  wrote {out}")
 

--- a/script/backbone/bev_render.py
+++ b/script/backbone/bev_render.py
@@ -1,0 +1,235 @@
+"""Presentation-grade BEV map from a footprint2d raster.
+
+`footprint2d.npz` is *evidence*: every cell is whatever the multi-view votes actually support,
+speckle and all. That is the right thing for a raster you compute against, and the wrong thing
+to put in a UI -- a map that renders a lone mis-voted cell as confidently as a corridor seen
+101 times reads as broken, and an object drawn as a hollow ring of base-contacts reads as a
+hole in the world.
+
+So this is a separate, deliberately **lossy** layer. Nothing here feeds back into the npz; the
+evidence stays untouched and re-rendering is instant instead of an hour.
+
+Three things it does that the evidence raster must not:
+
+1. **Says "I don't know" out loud.** A cell seen twice and a cell seen 101 times are both just
+   FREE in the raster. Here anything below `--min-views` renders **grey** rather than
+   committing to a class, so thin evidence looks uncertain instead of authoritative. This is
+   what stops the coverage-frontier speckle from reading as real structure.
+2. **Fills occupied interiors.** FOOTPRINT marks *base contacts* -- the camera-facing rim of an
+   object -- so a building or hedge comes out as an outline around unobserved middle. Small
+   enclosed holes are filled so objects render solid. Only *small* ones: a courtyard ringed by
+   trees is a real hole and stays open (`--max-fill`).
+3. **Drops speckle.** Connected components below `--min-blob` cells are demoted to grey, not to
+   a neighbouring class -- an isolated cell is unsupported, not evidence for whatever surrounds
+   it.
+
+Run (from repo root):
+  uv run python script/backbone/bev_render.py --npz output/<session>-footprint2d/footprint2d.npz
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE.parent))
+sys.path.insert(0, str(_HERE.parent / "semantic_bev"))
+
+from taxonomy import Klass  # noqa: E402
+
+UNKNOWN, FREE, FOOTPRINT, HIDDEN = 0, 1, 2, 3
+
+# presentation labels (priority order matters when classes overlap after morphology)
+L_UNSURVEYED, L_LOWCONF, L_GRASS, L_TERRAIN, L_PATH, L_HIDDEN, L_OCCUPIED = range(7)
+
+PALETTE = {                      # RGB
+    L_UNSURVEYED: (24, 26, 30),
+    L_LOWCONF:    (105, 108, 115),
+    L_GRASS:      (104, 152, 92),
+    L_TERRAIN:    (150, 132, 106),
+    L_PATH:       (238, 220, 170),
+    L_HIDDEN:     (72, 88, 104),
+    L_OCCUPIED:   (188, 74, 62),
+}
+NAMES = {
+    L_UNSURVEYED: "not surveyed", L_LOWCONF: "low confidence", L_GRASS: "grass",
+    L_TERRAIN: "terrain", L_PATH: "path / paved", L_HIDDEN: "occluded ground",
+    L_OCCUPIED: "occupied",
+}
+
+
+def remove_small_blobs(mask: np.ndarray, min_area: int) -> np.ndarray:
+    """Drop connected components smaller than min_area cells."""
+    if min_area <= 1 or not mask.any():
+        return mask
+    n, lab, stats, _ = cv2.connectedComponentsWithStats(mask.astype(np.uint8), 8)
+    keep = np.zeros(n, bool)
+    for i in range(1, n):
+        keep[i] = stats[i, cv2.CC_STAT_AREA] >= min_area
+    return keep[lab]
+
+
+def fill_small_holes(mask: np.ndarray, max_area: int) -> np.ndarray:
+    """Fill enclosed holes up to max_area cells; larger voids are real and stay open.
+
+    Base contacts trace the camera-facing rim of an object, so its middle is never observed.
+    Filling that reads correctly. Filling a tree-ringed courtyard would not -- hence the cap,
+    and hence skipping any component touching the border (that is outside, not a hole).
+    """
+    if max_area <= 0 or not mask.any():
+        return mask
+    inv = (~mask).astype(np.uint8)
+    n, lab, stats, _ = cv2.connectedComponentsWithStats(inv, 4)
+    h, w = mask.shape
+    out = mask.copy()
+    border = set(lab[0, :]) | set(lab[-1, :]) | set(lab[:, 0]) | set(lab[:, -1])
+    for i in range(1, n):
+        if i in border:
+            continue
+        if stats[i, cv2.CC_STAT_AREA] <= max_area:
+            out[lab == i] = True
+    return out
+
+
+def close_only(mask: np.ndarray, k: int) -> np.ndarray:
+    """Dilate-then-erode: knits a broken rim into a closed outline WITHOUT shedding small
+    blobs. `smooth` follows its close with an open, which erases anything smaller than the
+    kernel -- fatal for occupied, where a trunk or bench is one or two cells at 0.5 m."""
+    if k < 3 or not mask.any():
+        return mask
+    ker = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k | 1, k | 1))
+    return cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_CLOSE, ker).astype(bool)
+
+
+def smooth(mask: np.ndarray, k: int) -> np.ndarray:
+    """Close then open with the same kernel: knits ragged edges, then sheds the nubs."""
+    if k < 3 or not mask.any():
+        return mask
+    ker = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k | 1, k | 1))
+    m = cv2.morphologyEx(mask.astype(np.uint8), cv2.MORPH_CLOSE, ker)
+    m = cv2.morphologyEx(m, cv2.MORPH_OPEN, ker)
+    return m.astype(bool)
+
+
+def build_labels(z, args) -> tuple[np.ndarray, dict]:
+    state = z["state"]
+    surface = z["surface"] if "surface" in z else np.zeros_like(state)
+    obs = z["obs_count"] if "obs_count" in z else np.full(state.shape, 99, np.int32)
+    bearings = z["foot_bearings"] if "foot_bearings" in z else np.zeros_like(state, np.int32)
+
+    # The survey frontier is dithered at cell level (one ray lands, its neighbour misses), which
+    # renders as salt-and-pepper along every edge. Smooth the *masks* so the boundary reads as a
+    # boundary; this changes only where we admit to knowing, never what we claim to know.
+    surveyed = smooth(obs > 0, args.smooth)
+    confident = smooth(obs >= args.min_views, args.smooth)
+
+    occupied = (state == FOOTPRINT) & (bearings >= args.min_bearings)
+    hidden = (state == HIDDEN) & confident
+    free = (state == FREE) & confident
+
+    path = free & np.isin(surface, [int(Klass.PATH), int(Klass.PAVEMENT), int(Klass.STAIRS)])
+    grass = free & (surface == int(Klass.GRASS))
+    terrain = free & (surface == int(Klass.TERRAIN))
+    # FREE but unclassified surface -> walkable yet we cannot say what it is: that is
+    # low-confidence information, not terrain. Rendering it as terrain would be a guess.
+    unclassified = free & ~(path | grass | terrain)
+
+    layers = {L_OCCUPIED: occupied, L_PATH: path, L_TERRAIN: terrain,
+              L_GRASS: grass, L_HIDDEN: hidden}
+
+    stats = {}
+    for lid, m in layers.items():
+        before = int(m.sum())
+        if lid == L_OCCUPIED:
+            # Occupied is the sparsest layer by construction -- FOOTPRINT marks base contacts,
+            # a camera-facing rim, and at 0.5 m a bench or trunk is one or two cells. The blob
+            # filter tuned for area classes deletes exactly those, so occupied gets its own
+            # (small) threshold, is closed first so a broken rim becomes a ring, and only then
+            # has its interior filled.
+            m = remove_small_blobs(m, args.min_blob_occupied)
+            m = close_only(m, args.occupied_close)
+            m = fill_small_holes(m, args.max_fill)
+        else:
+            m = remove_small_blobs(m, args.min_blob)
+            m = smooth(m, args.smooth)
+        layers[lid] = m
+        stats[NAMES[lid]] = (before, int(m.sum()))
+
+    out = np.full(state.shape, L_UNSURVEYED, np.uint8)
+    out[surveyed] = L_LOWCONF                      # surveyed but not confident -> grey
+    out[unclassified] = L_LOWCONF
+    for lid in (L_HIDDEN, L_GRASS, L_TERRAIN, L_PATH, L_OCCUPIED):   # last wins
+        out[layers[lid]] = lid
+    return out, stats
+
+
+def colorize(labels: np.ndarray, scale: int, legend: bool) -> np.ndarray:
+    lut = np.zeros((len(PALETTE), 3), np.uint8)
+    for k, v in PALETTE.items():
+        lut[k] = v
+    rgb = lut[labels]
+    rgb = np.flipud(rgb)                                  # north-up, as footprint2d renders
+    if scale > 1:
+        rgb = cv2.resize(rgb, None, fx=scale, fy=scale, interpolation=cv2.INTER_NEAREST)
+    if not legend:
+        return rgb
+    pad, sw, lh = 14, 18, 26
+    bar = np.full((rgb.shape[0], 210, 3), PALETTE[L_UNSURVEYED], np.uint8)
+    for i, (lid, name) in enumerate(NAMES.items()):
+        y = pad + i * lh
+        bar[y:y + sw, pad:pad + sw] = PALETTE[lid]
+        cv2.putText(bar, name, (pad + sw + 9, y + sw - 4), cv2.FONT_HERSHEY_SIMPLEX,
+                    0.42, (235, 238, 242), 1, cv2.LINE_AA)
+    return np.hstack([rgb, bar])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--npz", required=True)
+    ap.add_argument("--out", default=None, help="output png (default: <npz dir>/bev_clean.png)")
+    ap.add_argument("--min-views", type=int, default=4,
+                    help="views a cell needs before it is drawn as a class at all; below this "
+                         "it renders grey instead of committing")
+    ap.add_argument("--min-bearings", type=int, default=2,
+                    help="distinct bearings required to draw a cell as occupied")
+    ap.add_argument("--min-blob", type=int, default=4,
+                    help="drop connected components smaller than this many cells (speckle)")
+    ap.add_argument("--min-blob-occupied", type=int, default=2,
+                    help="separate, smaller speckle threshold for occupied cells (base "
+                         "contacts are sparse; the area-class threshold would erase objects)")
+    ap.add_argument("--occupied-close", type=int, default=5,
+                    help="morphological kernel used to knit broken base-contact rims into a "
+                         "closed outline before the interior is filled")
+    ap.add_argument("--max-fill", type=int, default=40,
+                    help="fill enclosed holes in occupied regions up to this many cells; "
+                         "larger voids are real (a courtyard) and stay open")
+    ap.add_argument("--smooth", type=int, default=3, help="morphological kernel (cells), <3 off")
+    ap.add_argument("--scale", type=int, default=4, help="upscale factor")
+    ap.add_argument("--no-legend", action="store_true")
+    args = ap.parse_args()
+
+    npz = Path(args.npz).expanduser().resolve()
+    z = np.load(npz)
+    labels, stats = build_labels(z, args)
+
+    total = labels.size
+    print(f"[bev_render] {npz}")
+    for name, (before, after) in stats.items():
+        d = after - before
+        print(f"  {name:<16s} {before:>6d} -> {after:>6d} cells ({d:+d})")
+    for lid, name in NAMES.items():
+        n = int((labels == lid).sum())
+        print(f"  final {name:<16s} {100*n/total:5.1f}%")
+
+    out = Path(args.out) if args.out else npz.parent / "bev_clean.png"
+    cv2.imwrite(str(out), colorize(labels, args.scale, not args.no_legend)[:, :, ::-1])
+    print(f"  wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/footprint2d.py
+++ b/script/backbone/footprint2d.py
@@ -113,6 +113,67 @@ class SegKlass:
 
 
 # ---------------------------------------------------------------------------
+# open-vocabulary instances: Grounding DINO boxes -> SAM masks
+# ---------------------------------------------------------------------------
+class GroundedSAM:
+    """(masks, boxes, labels, scores) for one BGR image, all from cached weights."""
+
+    def __init__(self, det_model: str, sam_model: str, prompt: str,
+                 box_th: float, text_th: float, device: str | None = None):
+        import torch
+        from transformers import (AutoModelForZeroShotObjectDetection, AutoProcessor,
+                                  SamModel, SamProcessor)
+        self.torch = torch
+        self.prompt = prompt
+        self.box_th, self.text_th = box_th, text_th
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.dproc = AutoProcessor.from_pretrained(det_model)
+        self.det = AutoModelForZeroShotObjectDetection.from_pretrained(det_model).to(self.device).eval()
+        self.sproc = SamProcessor.from_pretrained(sam_model)
+        self.sam = SamModel.from_pretrained(sam_model).to(self.device).eval()
+
+    def __call__(self, bgr: np.ndarray):
+        from PIL import Image as PILImage
+        torch = self.torch
+        pil = PILImage.fromarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB))
+        inp = self.dproc(images=pil, text=self.prompt, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            out = self.det(**inp)
+        res = self.dproc.post_process_grounded_object_detection(
+            out, inp.input_ids, threshold=self.box_th, text_threshold=self.text_th,
+            target_sizes=[bgr.shape[:2]])[0]
+        boxes = res["boxes"].cpu().numpy()
+        if not len(boxes):
+            return np.zeros((0, *bgr.shape[:2]), bool), boxes, [], np.zeros(0, np.float32)
+        labels = [str(x) for x in res.get("text_labels", res["labels"])]
+        scores = res["scores"].cpu().numpy().astype(np.float32)
+        si = self.sproc(pil, input_boxes=[boxes.tolist()], return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            so = self.sam(**si, multimask_output=False)
+        masks = self.sproc.image_processor.post_process_masks(
+            so.pred_masks.cpu(), si["original_sizes"].cpu(), si["reshaped_input_sizes"].cpu())[0]
+        return masks[:, 0].numpy().astype(bool), boxes, labels, scores
+
+
+
+def snap_label(raw: str, prompt: str) -> str:
+    """Grounding DINO returns BPE-merged labels -- '##nding machine kiosk' for two adjacent
+    prompt phrases. The '##' is a WordPiece continuation marker and the merge crosses phrase
+    boundaries, so the raw string names no real class. Snap it to the prompt phrase sharing the
+    most words; cosmetic while every rescue maps to one Klass, but load-bearing the moment
+    per-label classes are wanted."""
+    toks = set(raw.replace("##", "").split())
+    best, hits = raw.strip(), 0
+    for phrase in (x.strip() for x in prompt.split(".")):
+        if not phrase:
+            continue
+        n = len(toks & set(phrase.split()))
+        if n > hits:
+            best, hits = phrase, n
+    return best
+
+
+# ---------------------------------------------------------------------------
 # metric depth (DA2-small, SfM-scaled) -- same recipe as mono_depth.py
 # ---------------------------------------------------------------------------
 class MonoDepth:
@@ -363,6 +424,11 @@ def run(args):
 
     pan = SegKlass(args.seg_model, mode=args.seg_mode)
     depth = MonoDepth(args.depth_model)
+    gsam = (GroundedSAM(args.det_model, args.sam_model, args.rescue_prompt,
+                        args.rescue_box_th, args.rescue_text_th)
+            if args.rescue_prompt.strip() else None)
+    rescue_klass = int(Klass[args.rescue_klass])
+    rescued: dict[str, int] = {}
 
     free_ct = np.zeros(ncells, np.int32)
     foot_ct = np.zeros(ncells, np.int32)
@@ -372,6 +438,8 @@ def run(args):
     print(f"  {len(frames)} frames, grid {cols}x{rows} @ {args.cell_size} m")
     if args.contact_depth_tol > 0:
         print(f"  depth contact gate: |d_mono - z_dem| <= {args.contact_depth_tol:.0%} of z_dem")
+    if gsam is not None:
+        print(f"  obstacle rescue -> {args.rescue_klass}: {args.rescue_prompt}")
     ndbg = 0
     gate_pre = gate_post = 0
     for fi, img in enumerate(frames):
@@ -400,6 +468,36 @@ def run(args):
             pts = C_local[None, :] + dmap[gy, gx][:, None] * dir_local
             cells = gf.cell_of(pts[:, :2])
             np.add.at(free_ct, cells, 1)
+
+        # ---- RESCUE: open-vocab masks for solid objects the closed-set seg calls UNKNOWN ----
+        # ADE-150 has no "vending machine", so Mask2Former labels one UNKNOWN -> Role.IGNORE and
+        # a large solid obstacle contributes NO footprint at all. Measured on maguro-park frame
+        # 8, the vending-machine region is 100% UNKNOWN/IGNORE: the machines are invisible to
+        # the occupancy map. For a navigation map that is the dangerous direction to fail in --
+        # free space asserted where something solid stands. Grounding DINO + SAM fill the hole
+        # from a text prompt, since the long tail of park objects can never be enumerated in a
+        # closed label set. Rescued pixels never overwrite a class the segmenter was confident
+        # about; they only fill IGNORE/UNKNOWN gaps.
+        if gsam is not None:
+            rmasks, _, rlabels, rscores = gsam(small)
+            # Highest score first: rescue is order-dependent (each mask only fills what earlier
+            # ones left), so without a fixed order the result depends on detector output order.
+            for i in np.argsort(-np.asarray(rscores)) if len(rscores) else []:
+                rm = rmasks[i]
+                # A single park object is not a third of the frame. Grounding DINO happily
+                # returns such boxes ('playground equipment' covering 192k px = 28% of frame 8,
+                # i.e. the vending machines and everything around them); letting one through
+                # blankets the BEV with phantom occupancy, the same over-blocking this pipeline
+                # rejected mono depth for.
+                if rm.mean() > args.rescue_max_frac:
+                    continue
+                fill = rm & (role_map != int(Role.OBSTACLE))
+                if int(fill.sum()) < args.rescue_min_px:
+                    continue
+                klass[fill] = rescue_klass
+                role_map[fill] = int(Role.OBSTACLE)
+                lab = snap_label(rlabels[i], args.rescue_prompt)
+                rescued[lab] = rescued.get(lab, 0) + 1
 
         # ---- FOOTPRINT: bottom-most obstacle pixel per column, ray-DEM ----
         obst = (role_map == int(Role.OBSTACLE))
@@ -476,6 +574,10 @@ def run(args):
           f"FOOTPRINT {np.mean(state==FOOTPRINT)*100:.1f}%  "
           f"HIDDEN {np.mean(state==HIDDEN)*100:.1f}%  "
           f"UNKNOWN {np.mean(state==UNKNOWN)*100:.1f}%  (of {n} cells)")
+    if rescued:
+        top = sorted(rescued.items(), key=lambda kv: -kv[1])
+        print(f"  obstacle rescue: {sum(rescued.values())} masks over {len(rescued)} labels -> "
+              + ", ".join(f"{k}x{v}" for k, v in top[:8]))
     if args.contact_depth_tol > 0 and gate_pre:
         print(f"  depth contact gate: {gate_pre} -> {gate_post} contacts "
               f"({100*(1-gate_post/max(gate_pre,1)):.0f}% rejected as not touching ground in 3D)")
@@ -536,6 +638,26 @@ def main():
     ap.add_argument("--z-far", type=float, default=70.0)
     ap.add_argument("--dz", type=float, default=0.2)
     ap.add_argument("--max-range", type=float, default=20.0, help="max base-contact distance (m)")
+    # --- obstacle rescue (open-vocab fill for classes the closed set lacks) ---
+    ap.add_argument("--rescue-prompt",
+                    default="vending machine. kiosk. public toilet. statue. planter. "
+                            "bollard. bike rack. playground equipment. picnic table.",
+                    help="open-vocab classes to rescue into Role.OBSTACLE when the closed-set "
+                         "segmenter leaves them UNKNOWN/IGNORE. Empty string disables (and "
+                         "skips loading the detector).")
+    ap.add_argument("--rescue-klass", default="FURNITURE",
+                    choices=[k.name for k in Klass],
+                    help="taxonomy class assigned to rescued pixels")
+    ap.add_argument("--rescue-min-px", type=int, default=600,
+                    help="ignore rescued masks smaller than this (noise)")
+    ap.add_argument("--rescue-max-frac", type=float, default=0.25,
+                    help="reject a rescued mask covering more than this fraction of the frame "
+                         "(open-vocab detectors emit whole-scene boxes that would blanket the "
+                         "BEV with phantom occupancy)")
+    ap.add_argument("--rescue-box-th", type=float, default=0.35)
+    ap.add_argument("--rescue-text-th", type=float, default=0.25)
+    ap.add_argument("--det-model", default="IDEA-Research/grounding-dino-tiny")
+    ap.add_argument("--sam-model", default="facebook/sam-vit-base")
     ap.add_argument("--contact-depth-tol", type=float, default=0.15,
                     help="reject a ground contact when measured mono depth disagrees with the "
                          "ray-DEM hit range by more than this FRACTION of the range "

--- a/script/backbone/footprint2d.py
+++ b/script/backbone/footprint2d.py
@@ -379,13 +379,13 @@ def visible_cells(C_local, RwcT, cam, gf, H, W, stride, factor, z_far, dz, max_r
     ys, xs = np.mgrid[0:H:stride, 0:W:stride]
     d_cam = pixel_dirs(xs.ravel().astype(np.float64), ys.ravel().astype(np.float64), cam, factor)
     dirs = (RwcT @ d_cam.T).T
-    hit_uv, ok, _ = ray_dem_intersect(C_local, dirs, gf, z_far=z_far, dz=dz, max_range=max_range)
+    hit_uv, ok, zt = ray_dem_intersect(C_local, dirs, gf, z_far=z_far, dz=dz, max_range=max_range)
     if not ok.any():
-        return np.zeros(0, np.int64), np.zeros((0, 2))
+        return np.zeros(0, np.int64), np.zeros((0, 2)), np.zeros(0)
     uv = hit_uv[ok]
     cells = gf.cell_of(uv)
     keep = np.unique(cells, return_index=True)[1]        # one vote per cell per frame
-    return cells[keep], uv[keep]
+    return cells[keep], uv[keep], zt[ok][keep]
 
 
 # ---------------------------------------------------------------------------
@@ -495,6 +495,7 @@ def run(args):
     foot_ct = np.zeros(ncells, np.int32)
     free_bear = np.zeros(ncells, np.uint32)
     foot_bear = np.zeros(ncells, np.uint32)
+    near_m = np.full(ncells, np.inf, np.float32)
     struct_ct = np.zeros((ncells, int(max(Klass)) + 1), np.int32)  # per-cell obstacle class votes
     # Which KIND of ground: Role.GROUND lumps PATH/PAVEMENT/GRASS/TERRAIN/STAIRS together, so
     # the walkable-surface distinction was being computed per pixel and then discarded. A
@@ -528,8 +529,12 @@ def run(args):
         # back-projects mono depth with neither restriction. So seed obs with the raycast and
         # union in whatever this frame actually voted -- a cell seen as ground was, tautologically,
         # in view.
-        ocells, _ = visible_cells(C_local, RwcT, cam, gf, H, W, args.obs_stride,
-                                  args.data_factor, args.z_far, args.dz, args.obs_max_range)
+        ocells, _, ozt = visible_cells(C_local, RwcT, cam, gf, H, W, args.obs_stride,
+                                       args.data_factor, args.z_far, args.dz, args.obs_max_range)
+        # Closest the camera ever came to each cell. A cell can be seen 60 times and still be
+        # junk if every look was from 30 m away at a grazing angle -- view COUNT cannot express
+        # that, so record nearest approach and let the renderer cut on it.
+        np.minimum.at(near_m, ocells, ozt)
         frame_obs = [ocells]
 
         # ---- FREE: ground pixels back-projected with metric depth ----
@@ -682,6 +687,7 @@ def run(args):
 
     np.savez(out / "footprint2d.npz", state=state, structure=struct, surface=surface,
              obs_count=obs_ct.reshape(rows, cols),
+             near_range=np.where(np.isfinite(near_m), near_m, -1).reshape(rows, cols),
              foot_bearings=popcount32(foot_bear).reshape(rows, cols),
              free_count=free_ct.reshape(rows, cols), foot_count=foot_ct.reshape(rows, cols),
              dem=gf.dem, coverage=gf.coverage, cell_size=args.cell_size)

--- a/script/backbone/footprint2d.py
+++ b/script/backbone/footprint2d.py
@@ -1,0 +1,453 @@
+"""2D-signals -> BEV footprint / free-space / hidden-ground pseudo-labels.
+
+An alternative to the 3D-DEM-render footprint generator: instead of rendering the
+global DEM into each camera, fuse **per-frame 2D perception** (panoptic segmentation
++ metric depth) into the BEV, using the gravity-aligned ground DEM only as a *ray
+target*. Three ground states come out, IMDF-ready:
+
+  FREE       -- walkable ground, directly observed
+  FOOTPRINT  -- ground occupied by a vertical object's *base* (not walkable)
+  HIDDEN     -- ground enclosed by free space but unobserved in every view (walk-under
+                / occluded); recovered by multi-view fusion, not any single frame
+
+Per frame (poses + PINHOLE intrinsics from COLMAP):
+  1. panoptic seg (Mask2Former, MIT) -> per-pixel taxonomy Klass + Role
+  2. metric depth (Depth-Anything-V2-Small, Apache; scale+shift fit to the frame's SfM
+     points, exactly as script/depth/mono_depth.py)
+  3. FREE   : back-project Role.GROUND pixels with metric depth -> BEV free votes
+  4. FOOTPRINT: for every image column with an obstacle, take the *bottom-most* obstacle
+     pixel (its ground-contact) and intersect that camera ray with the ground DEM
+     (NOT mono-depth -- the object base is exactly where mono's vertical-structure noise
+     is worst; ray-DEM uses only calibration + the SfM-solid DEM). Canopy over a path is
+     high up, so its column's bottom pixel is the trunk base -> footprint lands on the
+     trunk, not the whole canopy. This is the fix for "canopy marks everything occupied".
+
+Fuse across frames in BEV; HIDDEN falls out where FREE encloses unobserved cells.
+
+Run (from repo root):
+  uv run --extra segmentation --with /home/play/Code/lingbot-vision \
+    python script/backbone/footprint2d.py --session maguro-park-after-itchy --num 40
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+sys.path.insert(0, str(_SCRIPT_ROOT / "depth"))
+
+from lar_session import Session                      # noqa: E402
+from colmap_io import read_model, qvec2rotmat        # noqa: E402
+from geometry import from_reconstruction, gravity_up, align_rotation, build_dem  # noqa: E402
+from taxonomy import Klass, Role, role_of, color_lut, by_klass  # noqa: E402
+from mono_depth import sparse_samples, fit_metric    # noqa: E402
+
+# BEV ground states
+UNKNOWN, FREE, FOOTPRINT, HIDDEN = 0, 1, 2, 3
+
+
+# ---------------------------------------------------------------------------
+# panoptic segmentation -> per-pixel taxonomy Klass (COCO things+stuff, MIT)
+# ---------------------------------------------------------------------------
+class SegKlass:
+    """Mask2Former -> (klass_map, instance_map) in our taxonomy (keyword remap).
+
+    mode='semantic' (default): dense class only, instance_map all zeros. Uses the
+      large ADE model already cached by the linprobe runs -- no download. Base-contour
+      footprints only need the obstacle *class* mask, so this is enough for v1.
+    mode='panoptic': also returns 'thing' instance ids (COCO). Enables per-object
+      footprint polygons, but trees are 'stuff' in both COCO/ADE (no per-tree ids) and
+      the weights are a fresh ~850 MB download."""
+
+    def __init__(self, model_name: str, mode: str = "semantic", device: str | None = None):
+        import torch
+        from transformers import AutoImageProcessor, Mask2FormerForUniversalSegmentation
+        from taxonomy import keyword_klass
+
+        self.torch = torch
+        self.mode = mode
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.processor = AutoImageProcessor.from_pretrained(model_name)
+        self.model = Mask2FormerForUniversalSegmentation.from_pretrained(model_name).to(self.device).eval()
+        id2label = self.model.config.id2label
+        n = max(int(i) for i in id2label) + 1
+        self.lut = np.zeros(n, dtype=np.uint8)
+        for i, name in id2label.items():
+            self.lut[int(i)] = int(keyword_klass(name))
+
+    def __call__(self, image_bgr: np.ndarray):
+        torch = self.torch
+        rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
+        H, W = rgb.shape[:2]
+        inputs = self.processor(images=rgb, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            out = self.model(**inputs)
+        if self.mode == "semantic":
+            seg = self.processor.post_process_semantic_segmentation(out, target_sizes=[(H, W)])[0]
+            return self.lut[seg.cpu().numpy().astype(np.int64)].astype(np.uint8), np.zeros((H, W), np.int32)
+        res = self.processor.post_process_panoptic_segmentation(out, target_sizes=[(H, W)])[0]
+        seg = res["segmentation"].cpu().numpy().astype(np.int64)  # (H,W) segment id, -1 = void
+        klass = np.zeros((H, W), np.uint8)
+        inst = np.zeros((H, W), np.int32)
+        for s in res["segments_info"]:
+            m = seg == s["id"]
+            klass[m] = self.lut[int(s["label_id"])]
+            inst[m] = int(s["id"])
+        return klass, inst
+
+
+# ---------------------------------------------------------------------------
+# metric depth (DA2-small, SfM-scaled) -- same recipe as mono_depth.py
+# ---------------------------------------------------------------------------
+class MonoDepth:
+    def __init__(self, model_name: str, device: str | None = None):
+        import torch
+        from transformers import pipeline
+        self.pipe = pipeline("depth-estimation", model=model_name,
+                             device=0 if torch.cuda.is_available() else -1)
+
+    def metric(self, bgr, recon, img, factor):
+        """Dense per-pixel metric z-depth at 1/factor resolution, or None if unfittable."""
+        from PIL import Image as PILImage
+        H, W = bgr.shape[0] // factor, bgr.shape[1] // factor
+        rgb = cv2.cvtColor(cv2.resize(bgr, (W, H)), cv2.COLOR_BGR2RGB)
+        disp = self.pipe(PILImage.fromarray(rgb))["predicted_depth"].squeeze().float().cpu().numpy()
+        if disp.shape != (H, W):
+            disp = cv2.resize(disp, (W, H), interpolation=cv2.INTER_LINEAR)
+        scale = W / recon.cameras[img.camera_id].width
+        px, py, z = sparse_samples(recon, img, scale)
+        if not len(z):
+            return None, (H, W)
+        ix = np.clip(np.round(px).astype(int), 0, W - 1)
+        iy = np.clip(np.round(py).astype(int), 0, H - 1)
+        ab = fit_metric(disp[iy, ix], z)
+        if ab is None:
+            return None, (H, W)
+        a, b = ab
+        denom = a * disp + b
+        depth = np.where(denom > 1e-6, 1.0 / denom, 0.0).astype(np.float32)
+        depth[(depth <= 0) | ~np.isfinite(depth)] = 0.0
+        return depth, (H, W)
+
+
+# ---------------------------------------------------------------------------
+# geometry helpers (all in the gravity-aligned local frame of the GroundField)
+# ---------------------------------------------------------------------------
+def camera_local(img, gf):
+    """Return (C_local (3,), Rwc_T_local (3,3)) so that a pixel's cam-dir d_cam maps to
+    a local-frame ray direction via  dir_local = Rwc_T_local @ d_cam."""
+    Rwc = qvec2rotmat(img.qvec)              # world->cam
+    C_world = -Rwc.T @ img.tvec              # camera centre in world
+    C_local = gf.R @ C_world
+    Rwc_T_local = gf.R @ Rwc.T               # cam-dir -> local-frame dir
+    return C_local, Rwc_T_local
+
+
+def pixel_dirs(px, py, cam, factor):
+    """PINHOLE cam-space ray dirs (unnormalised, z=1) for pixel arrays at 1/factor res."""
+    fx, fy, cx, cy = cam.params[:4]
+    fx, fy, cx, cy = fx / factor, fy / factor, cx / factor, cy / factor
+    return np.stack([(px - cx) / fx, (py - cy) / fy, np.ones_like(px)], axis=1)  # (M,3)
+
+
+def ray_dem_intersect(C_local, dirs_local, gf, z_near=0.4, z_far=70.0, dz=0.2,
+                      max_range=20.0):
+    """Intersect local-frame rays with the ground DEM height field.
+
+    Marches cam-depth z; a hit is the first sign change of (ray_height - dem(ray_uv)).
+    Returns (uv (M,2), ok (M,) bool). Rejects hits outside the grid, off-coverage, or
+    beyond ``max_range`` m (far base-contacts are unreliable: ray-DEM at range + thin
+    DEM coverage scatters, so we trust only nearby contacts and let other frames cover
+    the rest)."""
+    ts = np.arange(z_near, z_far, dz)                       # (K,)
+    P = C_local[None, None, :] + ts[None, :, None] * dirs_local[:, None, :]  # (M,K,3)
+    uv = P[:, :, :2].reshape(-1, 2)
+    ground = gf.height_at(uv).reshape(P.shape[0], P.shape[1])
+    resid = P[:, :, 2] - ground                            # + above ground, - below
+    below = resid < 0
+    ok = below.any(1)
+    k = np.argmax(below, axis=1)                           # first below-ground step
+    k = np.clip(k, 1, len(ts) - 1)
+    # linear interp between k-1 (above) and k (below)
+    r0 = resid[np.arange(len(k)), k - 1]
+    r1 = resid[np.arange(len(k)), k]
+    frac = r0 / np.maximum(r0 - r1, 1e-6)
+    zt = ts[k - 1] + frac * dz
+    hit = C_local[None, :] + zt[:, None] * dirs_local      # (M,3)
+    hit_uv = hit[:, :2]
+    # keep only in-grid, covered cells, within trustworthy range
+    cells = gf.cell_of(hit_uv)
+    cov = gf.coverage.reshape(-1)[cells]
+    return hit_uv, ok & cov & (zt <= max_range)
+
+
+# ---------------------------------------------------------------------------
+def sample_frames(recon, num):
+    imgs = sorted(recon.images.values(), key=lambda im: im.name)
+    idx = np.linspace(0, len(imgs) - 1, num).round().astype(int)
+    return [imgs[i] for i in sorted(set(idx))]
+
+
+# ---------------------------------------------------------------------------
+# ground DEM: sparse COLMAP (default) or dense mono-depth fusion
+# ---------------------------------------------------------------------------
+def _pinhole(cam):
+    """(fx, fy, cx, cy) from PINHOLE / SIMPLE_PINHOLE / SIMPLE_RADIAL."""
+    p = cam.params
+    if cam.model == "PINHOLE":
+        return float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    return float(p[0]), float(p[0]), float(p[1]), float(p[2])  # SIMPLE_* : one focal
+
+
+def _backproject_mono(recon, depth_dir, stride, voxel, depth_max, log):
+    """Fused world point cloud from every frame's metric mono-depth map (voxel-deduped).
+
+    Same depth contract as footprint_labels/depth_backproject: ``<stem>.npy`` float32 (H,W)
+    metric z-depth, intrinsics scaled to depth resolution. Far/sky mono depth explodes
+    (1/(a·disp+b)) so cap it at ``depth_max`` m before fusing."""
+    depth_dir = Path(depth_dir)
+    all_pos, n, raw = [], 0, 0
+    for im in recon.images.values():
+        dp = depth_dir / f"{Path(im.name).stem}.npy"
+        if not dp.exists():
+            continue
+        depth = np.load(dp).astype(np.float32)
+        h, w = depth.shape
+        cam = recon.cameras[im.camera_id]
+        fx, fy, cx, cy = _pinhole(cam)
+        sx, sy = w / cam.width, h / cam.height
+        fx, fy, cx, cy = fx * sx, fy * sy, cx * sx, cy * sy
+        ys, xs = np.arange(0, h, stride), np.arange(0, w, stride)
+        gx, gy = (a.ravel() for a in np.meshgrid(xs, ys))
+        d = depth[gy, gx]
+        ok = (d > 0) & np.isfinite(d)
+        if depth_max > 0:
+            ok &= d < depth_max
+        if not ok.any():
+            continue
+        u, v, dd = gx[ok].astype(np.float32), gy[ok].astype(np.float32), d[ok]
+        cam_pts = np.stack([(u - cx) / fx * dd, (v - cy) / fy * dd, dd], axis=1)
+        R = qvec2rotmat(im.qvec)
+        all_pos.append((cam_pts @ R + (-R.T @ im.tvec)).astype(np.float32))
+        n += 1; raw += int(ok.sum())
+    if not all_pos:
+        raise SystemExit(f"no mono depth maps found in {depth_dir}")
+    pos = np.concatenate(all_pos)
+    vox = np.floor(pos / voxel).astype(np.int64)
+    _, inv = np.unique(vox, axis=0, return_inverse=True)
+    sums = np.zeros((int(inv.max()) + 1, 3), np.float64)
+    np.add.at(sums, inv, pos)
+    positions = (sums / np.bincount(inv)[:, None]).astype(np.float32)
+    log(f"  mono depth: {raw} pts from {n} maps -> {len(positions)} voxels @ {voxel} m")
+    return positions
+
+
+def mono_dem_field(recon, depth_dir, cell_size, stride, voxel, depth_max, log):
+    """A GroundField whose DEM surface is fused mono depth (dense) instead of sparse COLMAP.
+
+    Gravity frame still comes from the cameras, so it lines up with the COLMAP obstacle
+    geometry footprint2d votes from. Only the DEM *surface/coverage* changes."""
+    up = gravity_up(np.array([im.qvec for im in recon.images.values()]))
+    R = align_rotation(up)
+    world = _backproject_mono(recon, depth_dir, stride, voxel, depth_max, log)
+    local = (R @ world.T).T
+    return build_dem(local[:, :2], local[:, 2], R, up, cell_size=cell_size, log=log)
+
+
+def run(args):
+    s = Session(args.session)
+    model = args.model or str(s.colmap_model)   # need TRACKS for depth scale-fit -> raw model
+    images_dir = Path(args.images or str(s.images))
+    out = Path(args.out or (s.root / "output" / f"{args.session}-footprint2d"))
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"[footprint2d] model={model}\n  images={images_dir}\n  out={out}")
+    recon = read_model(model)
+    if args.dem_source == "mono":
+        depth_dir = args.depth_dir or str(s.depth_dir("mono"))
+        print(f"  DEM source: mono depth <- {depth_dir}")
+        gf = mono_dem_field(recon, depth_dir, args.cell_size, args.depth_stride,
+                            args.depth_voxel, args.depth_max, log=print)
+    else:
+        gf, *_ = from_reconstruction(recon, cell_size=args.cell_size)
+    rows, cols = gf.dem.shape
+    ncells = rows * cols
+
+    pan = SegKlass(args.seg_model, mode=args.seg_mode)
+    depth = MonoDepth(args.depth_model)
+
+    free_ct = np.zeros(ncells, np.int32)
+    foot_ct = np.zeros(ncells, np.int32)
+    struct_ct = np.zeros((ncells, int(max(Klass)) + 1), np.int32)  # per-cell obstacle class votes
+
+    frames = sample_frames(recon, args.num)
+    print(f"  {len(frames)} frames, grid {cols}x{rows} @ {args.cell_size} m")
+    ndbg = 0
+    for fi, img in enumerate(frames):
+        bgr = cv2.imread(str(images_dir / img.name), cv2.IMREAD_COLOR)
+        if bgr is None:
+            continue
+        dmap, (H, W) = depth.metric(bgr, recon, img, args.data_factor)
+        if dmap is None:
+            continue
+        small = cv2.resize(bgr, (W, H))
+        klass, inst = pan(small)
+        roles = np.vectorize(lambda k: int(role_of(int(k))))(np.arange(int(max(Klass)) + 1))
+        role_map = roles[klass]
+        cam = recon.cameras[img.camera_id]
+        C_local, RwcT = camera_local(img, gf)
+
+        # ---- FREE: ground pixels back-projected with metric depth ----
+        gmask = (role_map == int(Role.GROUND)) & (dmap > 0)
+        gy, gx = np.where(gmask)
+        if len(gx) > args.max_ground:                       # subsample for speed
+            sel = np.random.default_rng(fi).choice(len(gx), args.max_ground, replace=False)
+            gy, gx = gy[sel], gx[sel]
+        if len(gx):
+            d_cam = pixel_dirs(gx.astype(np.float64), gy.astype(np.float64), cam, args.data_factor)
+            dir_local = (RwcT @ d_cam.T).T
+            pts = C_local[None, :] + dmap[gy, gx][:, None] * dir_local
+            cells = gf.cell_of(pts[:, :2])
+            np.add.at(free_ct, cells, 1)
+
+        # ---- FOOTPRINT: bottom-most obstacle pixel per column, ray-DEM ----
+        obst = (role_map == int(Role.OBSTACLE))
+        base_klass = None
+        if obst.any():
+            has = obst.any(0)
+            base_row = (obst * np.arange(H)[:, None]).argmax(0)   # bottom-most True row/col
+            bx = np.where(has)[0]
+            by = base_row[bx]
+            base_klass = klass[by, bx]
+            d_cam = pixel_dirs(bx.astype(np.float64), by.astype(np.float64), cam, args.data_factor)
+            dir_local = (RwcT @ d_cam.T).T
+            hit_uv, ok = ray_dem_intersect(C_local, dir_local, gf,
+                                           z_far=args.z_far, dz=args.dz,
+                                           max_range=args.max_range)
+            if ok.any():
+                cells = gf.cell_of(hit_uv[ok])
+                np.add.at(foot_ct, cells, 1)
+                np.add.at(struct_ct, (cells, base_klass[ok]), 1)
+
+        # ---- per-frame debug overlay (first few) ----
+        if ndbg < args.debug_frames:
+            dbg = small.copy()
+            dbg[gmask] = (0.5 * dbg[gmask] + np.array([0, 120, 0])).astype(np.uint8)
+            if base_klass is not None:
+                for x, y in zip(bx, by):
+                    cv2.circle(dbg, (int(x), int(y)), 2, (0, 0, 255), -1)
+            cv2.imwrite(str(out / f"frame_{ndbg}_{Path(img.name).stem}.png"), dbg)
+            ndbg += 1
+        if (fi + 1) % 10 == 0:
+            print(f"  {fi + 1}/{len(frames)}  free~{int(free_ct.sum())} foot~{int(foot_ct.sum())}")
+
+    # ---- fuse -> ground-state raster ----
+    state = np.full(ncells, UNKNOWN, np.uint8)
+    free = free_ct >= args.min_free
+    foot = foot_ct >= args.min_foot
+    state[free] = FREE
+    state[foot] = FOOTPRINT                                  # footprint wins ties
+    state = state.reshape(rows, cols)
+
+    # HIDDEN: ground occluded *behind an obstacle*, not merely unobserved. A pure
+    # morphological close of FREE over UNKNOWN marks every enclosed gap -- including open
+    # fringe grass that just wasn't walked -- which over-claims (the yellow blobs). Gate the
+    # fill to cells within `hidden_occ_r` of a base-contact (a real occluder): the
+    # camera-facing side of an obstacle is observed -> FREE, so the UNKNOWN cells left next to
+    # a footprint are precisely its shadow. No footprint nearby -> just unobserved, not hidden.
+    k = max(3, int(args.hidden_close) | 1)                  # odd
+    freem = (state == FREE).astype(np.uint8)
+    closed = cv2.morphologyEx(freem, cv2.MORPH_CLOSE,
+                              cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k, k)))
+    occ_r = max(1, int(args.hidden_occ_r))
+    occ = (foot_ct.reshape(rows, cols) > 0).astype(np.uint8)   # any base-contact = an occluder
+    occ_dil = cv2.dilate(occ, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * occ_r + 1,) * 2))
+    hidden = (closed == 1) & (state == UNKNOWN) & (occ_dil > 0)
+    state[hidden] = HIDDEN
+
+    struct = struct_ct.reshape(rows, cols, -1).argmax(2).astype(np.uint8)
+    struct[state != FOOTPRINT] = int(Klass.UNKNOWN)
+
+    np.savez(out / "footprint2d.npz", state=state, structure=struct,
+             free_count=free_ct.reshape(rows, cols), foot_count=foot_ct.reshape(rows, cols),
+             dem=gf.dem, coverage=gf.coverage, cell_size=args.cell_size)
+    _render(out, state, struct, gf)
+    n = state.size
+    print(f"[footprint2d] FREE {np.mean(state==FREE)*100:.1f}%  "
+          f"FOOTPRINT {np.mean(state==FOOTPRINT)*100:.1f}%  "
+          f"HIDDEN {np.mean(state==HIDDEN)*100:.1f}%  "
+          f"UNKNOWN {np.mean(state==UNKNOWN)*100:.1f}%  (of {n} cells)")
+    print(f"  wrote {out}/footprint2d_bev.png  (+ overlay, npz, {ndbg} debug frames)")
+
+
+def _render(out, state, struct, gf):
+    """North-up: row 0 = origin_v (south), flip so up = +v (north)."""
+    rgb = np.zeros((*state.shape, 3), np.uint8)
+    rgb[state == FREE] = (60, 170, 60)
+    rgb[state == FOOTPRINT] = (40, 40, 220)
+    rgb[state == HIDDEN] = (60, 200, 230)
+    rgb[state == UNKNOWN] = (35, 35, 35)
+    up = lambda a: cv2.resize(np.flipud(a), None, fx=4, fy=4, interpolation=cv2.INTER_NEAREST)
+    cv2.imwrite(str(out / "footprint2d_bev.png"), up(rgb))
+
+    # overlay footprint/free on the DEM hillshade for context
+    dem = gf.dem
+    gy, gx = np.gradient(dem)
+    hill = np.clip(0.5 + 0.5 * (-gx - gy) / (np.hypot(gx, gy).max() + 1e-6), 0, 1)
+    base = cv2.cvtColor((hill * 255).astype(np.uint8), cv2.COLOR_GRAY2BGR)
+    base[state == FOOTPRINT] = (40, 40, 220)
+    base[state == HIDDEN] = (60, 200, 230)
+    m = state == FREE
+    base[m] = (0.5 * base[m] + np.array([30, 85, 30])).astype(np.uint8)
+    cv2.imwrite(str(out / "footprint2d_overlay.png"), up(base))
+
+    # structure footprint (dominant obstacle class per footprint cell)
+    lut = np.array(color_lut(), np.uint8)[:, ::-1]          # RGB->BGR for cv2
+    srgb = (0.25 * base).astype(np.uint8)
+    hask = struct != int(Klass.UNKNOWN)
+    srgb[hask] = lut[struct[hask]]
+    cv2.imwrite(str(out / "footprint2d_structure.png"), up(srgb))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default="maguro-park-after-itchy")
+    ap.add_argument("--model", default=None, help="COLMAP text model with TRACKS (raw, not refined)")
+    ap.add_argument("--images", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--num", type=int, default=40, help="frames to fuse")
+    ap.add_argument("--cell-size", type=float, default=0.5)
+    ap.add_argument("--data-factor", type=int, default=2)
+    ap.add_argument("--dem-source", default="colmap", choices=["colmap", "mono"],
+                    help="ground DEM from sparse COLMAP points (default) or dense fused mono depth")
+    ap.add_argument("--depth-dir", default=None, help="per-view mono depth .npy dir (default: session depth-mono)")
+    ap.add_argument("--depth-stride", type=int, default=8, help="pixel stride when back-projecting mono depth")
+    ap.add_argument("--depth-voxel", type=float, default=0.1, help="voxel size (m) for mono-depth dedup")
+    ap.add_argument("--depth-max", type=float, default=40.0, help="drop mono-depth pixels beyond this range (m)")
+    ap.add_argument("--seg-mode", default="semantic", choices=["semantic", "panoptic"])
+    ap.add_argument("--seg-model", default="facebook/mask2former-swin-large-ade-semantic",
+                    help="semantic: ADE (cached); panoptic: e.g. mask2former-swin-large-coco-panoptic")
+    ap.add_argument("--depth-model", default="depth-anything/Depth-Anything-V2-Small-hf")
+    ap.add_argument("--min-free", type=int, default=2, help="ground votes -> FREE")
+    ap.add_argument("--min-foot", type=int, default=2, help="base-contact votes -> FOOTPRINT")
+    ap.add_argument("--max-ground", type=int, default=8000, help="ground px/frame subsample")
+    ap.add_argument("--z-far", type=float, default=70.0)
+    ap.add_argument("--dz", type=float, default=0.2)
+    ap.add_argument("--max-range", type=float, default=20.0, help="max base-contact distance (m)")
+    ap.add_argument("--hidden-close", type=int, default=5, help="HIDDEN gap-fill kernel (cells)")
+    ap.add_argument("--hidden-occ-r", type=int, default=4,
+                    help="HIDDEN only within this many cells of a base-contact (occlusion shadow)")
+    ap.add_argument("--debug-frames", type=int, default=4)
+    run(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/footprint2d.py
+++ b/script/backbone/footprint2d.py
@@ -496,6 +496,10 @@ def run(args):
     free_bear = np.zeros(ncells, np.uint32)
     foot_bear = np.zeros(ncells, np.uint32)
     struct_ct = np.zeros((ncells, int(max(Klass)) + 1), np.int32)  # per-cell obstacle class votes
+    # Which KIND of ground: Role.GROUND lumps PATH/PAVEMENT/GRASS/TERRAIN/STAIRS together, so
+    # the walkable-surface distinction was being computed per pixel and then discarded. A
+    # navigation graph wants paved path separated from lawn, not one undifferentiated FREE.
+    surf_ct = np.zeros((ncells, int(max(Klass)) + 1), np.int32)
 
     frames = sample_frames(recon, args.num)
     print(f"  {len(frames)} frames, grid {cols}x{rows} @ {args.cell_size} m")
@@ -539,6 +543,7 @@ def run(args):
             dir_local = (RwcT @ d_cam.T).T
             pts = C_local[None, :] + dmap[gy, gx][:, None] * dir_local
             cells = gf.cell_of(pts[:, :2])
+            np.add.at(surf_ct, (cells, klass[gy, gx]), 1)     # class votes stay per-pixel
             uniq, ui = np.unique(cells, return_index=True)
             np.add.at(free_ct, uniq, 1)
             np.bitwise_or.at(free_bear, uniq, bearing_bits(pts[ui, :2], C_local))
@@ -665,17 +670,32 @@ def run(args):
     struct = struct_ct.reshape(rows, cols, -1).argmax(2).astype(np.uint8)
     struct[state != FOOTPRINT] = int(Klass.UNKNOWN)
 
-    np.savez(out / "footprint2d.npz", state=state, structure=struct,
+    # `state` is multi-view gated but this argmax is not, so a cell that scraped through FREE
+    # could take its class from a couple of distant pixels -- that is the speckle over open
+    # ground. Require the winner to clear a vote floor; below it the cell stays walkable but
+    # unclassified, which is the honest answer rather than a coin-flip surface.
+    surf_g = surf_ct.reshape(rows, cols, -1)
+    surface = surf_g.argmax(2).astype(np.uint8)
+    weak = np.take_along_axis(surf_g, surface[:, :, None].astype(np.intp), 2)[:, :, 0] < args.min_surf_votes
+    surface[weak] = int(Klass.UNKNOWN)
+    surface[state != FREE] = int(Klass.UNKNOWN)     # only walkable cells carry a surface
+
+    np.savez(out / "footprint2d.npz", state=state, structure=struct, surface=surface,
              obs_count=obs_ct.reshape(rows, cols),
              foot_bearings=popcount32(foot_bear).reshape(rows, cols),
              free_count=free_ct.reshape(rows, cols), foot_count=foot_ct.reshape(rows, cols),
              dem=gf.dem, coverage=gf.coverage, cell_size=args.cell_size)
-    _render(out, state, struct, gf)
+    _render(out, state, struct, surface, gf)
     n = state.size
     print(f"[footprint2d] FREE {np.mean(state==FREE)*100:.1f}%  "
           f"FOOTPRINT {np.mean(state==FOOTPRINT)*100:.1f}%  "
           f"HIDDEN {np.mean(state==HIDDEN)*100:.1f}%  "
           f"UNKNOWN {np.mean(state==UNKNOWN)*100:.1f}%  (of {n} cells)")
+    gnames = [k.name for k in sorted(Klass, key=int)]
+    sv, sc = np.unique(surface[state == FREE], return_counts=True)
+    if len(sv):
+        print("  walkable surface: " + ", ".join(
+            f"{gnames[v]} {100*c/state.size:.1f}%" for v, c in sorted(zip(sv, sc), key=lambda t: -t[1])))
     seen = obs_ct > 0
     print(f"  visibility: {100*np.mean(seen):.1f}% of cells ever in frustum, "
           f"median {int(np.median(obs_ct[seen])) if seen.any() else 0} views where seen "
@@ -691,10 +711,15 @@ def run(args):
     print(f"  wrote {out}/footprint2d_bev.png  (+ overlay, npz, {ndbg} debug frames)")
 
 
-def _render(out, state, struct, gf):
+def _render(out, state, struct, surface, gf):
     """North-up: row 0 = origin_v (south), flip so up = +v (north)."""
+    lut_bgr = np.array(color_lut(), np.uint8)[:, ::-1]      # RGB->BGR for cv2
     rgb = np.zeros((*state.shape, 3), np.uint8)
-    rgb[state == FREE] = (60, 170, 60)
+    # FREE is no longer one flat green: each walkable cell is painted with its ground class,
+    # so paved path reads distinctly from lawn at a glance.
+    freem = state == FREE
+    rgb[freem] = lut_bgr[surface[freem]]
+    rgb[freem & (surface == int(Klass.UNKNOWN))] = (60, 170, 60)   # walkable, class unvoted
     rgb[state == FOOTPRINT] = (40, 40, 220)
     rgb[state == HIDDEN] = (60, 200, 230)
     rgb[state == UNKNOWN] = (35, 35, 35)
@@ -718,6 +743,19 @@ def _render(out, state, struct, gf):
     hask = struct != int(Klass.UNKNOWN)
     srgb[hask] = lut[struct[hask]]
     cv2.imwrite(str(out / "footprint2d_structure.png"), up(srgb))
+
+    # walkable-surface map on its own, plus the isolated path mask
+    grgb = (0.25 * base).astype(np.uint8)
+    hasg = surface != int(Klass.UNKNOWN)
+    grgb[hasg] = lut_bgr[surface[hasg]]
+    cv2.imwrite(str(out / "footprint2d_surface.png"), up(grgb))
+
+    pathm = np.isin(surface, [int(Klass.PATH), int(Klass.PAVEMENT), int(Klass.STAIRS)])
+    prgb = (0.25 * base).astype(np.uint8)
+    prgb[surface == int(Klass.GRASS)] = (60, 110, 60)
+    prgb[surface == int(Klass.TERRAIN)] = (70, 90, 110)
+    prgb[pathm] = (90, 220, 255)
+    cv2.imwrite(str(out / "footprint2d_path.png"), up(prgb))
 
 
 def main():
@@ -776,6 +814,10 @@ def main():
                          "asks whether the ground was in view at all.")
     ap.add_argument("--obs-stride", type=int, default=8,
                     help="pixel stride for the per-frame visibility raycast (the denominator)")
+    ap.add_argument("--min-surf-votes", type=int, default=4,
+                    help="pixel votes the winning ground class needs before a FREE cell is "
+                         "labelled PATH/GRASS/... ; below it the cell stays walkable but "
+                         "unclassified instead of guessing")
     ap.add_argument("--min-obs", type=int, default=2,
                     help="frames that must have had a cell's ground in frustum before we call it")
     ap.add_argument("--min-free-frac", type=float, default=0.25,

--- a/script/backbone/footprint2d.py
+++ b/script/backbone/footprint2d.py
@@ -21,6 +21,14 @@ Per frame (poses + PINHOLE intrinsics from COLMAP):
      is worst; ray-DEM uses only calibration + the SfM-solid DEM). Canopy over a path is
      high up, so its column's bottom pixel is the trunk base -> footprint lands on the
      trunk, not the whole canopy. This is the fix for "canopy marks everything occupied".
+  5. DEPTH CONTACT GATE (--contact-depth-tol): step 4's "bottom-most obstacle pixel = ground
+     contact" is an assumption, and it fails whenever a mask's bottom abuts ground that is
+     really far behind it -- a bench seat or a canopy silhouetted against open lawn. Compare
+     the measured mono depth at that pixel against the range at which the ray meets the DEM:
+     equal if the object stands there, much nearer if it floats. Note this does not contradict
+     step 4 -- mono depth never *places* a contact here, it only *vetoes* one. A relative
+     comparison at a single pixel is what mono depth is reliable for; metric placement at an
+     object edge is what it is not.
 
 Fuse across frames in BEV; HIDDEN falls out where FREE encloses unobserved cells.
 
@@ -163,10 +171,16 @@ def ray_dem_intersect(C_local, dirs_local, gf, z_near=0.4, z_far=70.0, dz=0.2,
     """Intersect local-frame rays with the ground DEM height field.
 
     Marches cam-depth z; a hit is the first sign change of (ray_height - dem(ray_uv)).
-    Returns (uv (M,2), ok (M,) bool). Rejects hits outside the grid, off-coverage, or
-    beyond ``max_range`` m (far base-contacts are unreliable: ray-DEM at range + thin
-    DEM coverage scatters, so we trust only nearby contacts and let other frames cover
-    the rest)."""
+    Returns (uv (M,2), ok (M,) bool, zt (M,) float). Rejects hits outside the grid,
+    off-coverage, or beyond ``max_range`` m (far base-contacts are unreliable: ray-DEM at
+    range + thin DEM coverage scatters, so we trust only nearby contacts and let other
+    frames cover the rest).
+
+    ``zt`` is the **camera z-depth** of the hit, which is what makes ``depth_contact_gate``
+    possible: ``pixel_dirs`` returns z=1 directions and rotating into the local frame
+    preserves the camera-frame z-component, so ts (hence zt) is z-depth in exactly the same
+    convention ``MonoDepth.metric`` returns -- the two are directly comparable, no
+    conversion."""
     ts = np.arange(z_near, z_far, dz)                       # (K,)
     P = C_local[None, None, :] + ts[None, :, None] * dirs_local[:, None, :]  # (M,K,3)
     uv = P[:, :, :2].reshape(-1, 2)
@@ -186,7 +200,73 @@ def ray_dem_intersect(C_local, dirs_local, gf, z_near=0.4, z_far=70.0, dz=0.2,
     # keep only in-grid, covered cells, within trustworthy range
     cells = gf.cell_of(hit_uv)
     cov = gf.coverage.reshape(-1)[cells]
-    return hit_uv, ok & cov & (zt <= max_range)
+    return hit_uv, ok & cov & (zt <= max_range), zt
+
+
+def depth_contact_gate(dmap, rows, cols, zt, ok, tol: float, log=None, tag: str = ""):
+    """Reject 2D-adjacent-but-not-3D-touching ground contacts using measured depth.
+
+    The bottom-most-obstacle-pixel heuristic assumes an object's silhouette bottom is where
+    it meets the ground. The semantic canopy guard (``footprint_instances.contact_columns``)
+    only asks "are the pixels below me ground?", which is a **2D** test and passes exactly in
+    the failure case: a bench seat or canopy silhouetted against open lawn ten metres beyond.
+    The pixels below *are* ground -- just ground that is far behind the object -- so the
+    ray-DEM hit lands metres past it.
+
+    The geometric test: if the object really stands at the contact, its measured depth equals
+    the range at which that ray meets the ground. Floating/occluding -> the object is much
+    *nearer* than the ground its ray eventually hits, so ``d_obj << zt``.
+
+    Compared against the DEM hit rather than the neighbouring ground pixel on purpose. Mono
+    depth is smoothed across object boundaries (the discontinuity bleeds over several pixels),
+    so a boundary-crossing comparison washes out the very jump it looks for, and costs two
+    noisy samples. This is one noisy sample against the *trusted* pose+DEM.
+
+    The tolerance is **relative** (|d-zt| / zt): grazing distant rays otherwise fail
+    spuriously -- the same lesson the depression gate taught in ``base_points.py``.
+
+    It is also measured against the frame's **median depth ratio**, not against 1.0, and that
+    matters more than it sounds. ``MonoDepth.metric`` fits scale+shift per frame from that
+    frame's SfM points; when the fit is poor the whole depth map is off by a constant factor.
+    Measured on maguro-park frame 0: d_mono median 1.31 m against z_dem 3.04 m, a systematic
+    2.3x error -- an absolute test keeps 0.4% of its contacts and silently deletes the frame,
+    while a median-relative test keeps 72%. Healthy frames sit at ratio 0.91-0.93, so
+    normalising costs them nothing. This is the same trick as base_points' relative ground
+    datum: absorb the systematic per-frame bias, test only the outlier.
+
+    The assumption normalising buys into is that most bottom-most-obstacle pixels in a frame
+    are genuine contacts, so the median tracks the true scale. That holds here because ground
+    is everywhere and floating silhouettes are the minority -- and the ratio is logged so a
+    frame whose median is wildly off (a depth-fit failure worth fixing at the source) stays
+    visible rather than being quietly normalised away.
+
+    Pixels with no valid mono depth are **kept**, not dropped: absence of evidence isn't
+    evidence of floating, and punishing them would silently couple footprint recall to mono
+    coverage. Their count is reported so the blind spot stays visible.
+    """
+    if tol <= 0 or dmap is None:
+        return ok
+    d_obj = dmap[rows, cols]
+    have = d_obj > 0
+    ref = ok & have
+    # per-frame scale reference; too few samples to trust a median -> fall back to absolute
+    if int(ref.sum()) >= 20:
+        med = float(np.median(d_obj[ref] / np.maximum(zt[ref], 1e-6)))
+        if not np.isfinite(med) or med <= 1e-3:
+            med = 1.0
+    else:
+        med = 1.0
+    agree = np.abs(d_obj - med * zt) <= tol * med * np.maximum(zt, 1e-6)
+    gated = ok & (~have | agree)
+    if log is not None:
+        n0 = int(ok.sum())
+        if n0:
+            warn = "  << depth scale suspect" if not 0.7 <= med <= 1.4 else ""
+            log(f"    depth gate{tag}: {n0} -> {int(gated.sum())} contacts "
+                f"({int((ok & have & ~agree).sum())} floating, "
+                f"{int((ok & ~have).sum())} no-depth kept, "
+                f"frame d/z median {med:.3f}){warn}")
+    return gated
 
 
 # ---------------------------------------------------------------------------
@@ -290,7 +370,10 @@ def run(args):
 
     frames = sample_frames(recon, args.num)
     print(f"  {len(frames)} frames, grid {cols}x{rows} @ {args.cell_size} m")
+    if args.contact_depth_tol > 0:
+        print(f"  depth contact gate: |d_mono - z_dem| <= {args.contact_depth_tol:.0%} of z_dem")
     ndbg = 0
+    gate_pre = gate_post = 0
     for fi, img in enumerate(frames):
         bgr = cv2.imread(str(images_dir / img.name), cv2.IMREAD_COLOR)
         if bgr is None:
@@ -329,9 +412,14 @@ def run(args):
             base_klass = klass[by, bx]
             d_cam = pixel_dirs(bx.astype(np.float64), by.astype(np.float64), cam, args.data_factor)
             dir_local = (RwcT @ d_cam.T).T
-            hit_uv, ok = ray_dem_intersect(C_local, dir_local, gf,
-                                           z_far=args.z_far, dz=args.dz,
-                                           max_range=args.max_range)
+            hit_uv, ok, zt = ray_dem_intersect(C_local, dir_local, gf,
+                                               z_far=args.z_far, dz=args.dz,
+                                               max_range=args.max_range)
+            n_pre = int(ok.sum())
+            ok = depth_contact_gate(dmap, by, bx, zt, ok, args.contact_depth_tol,
+                                    log=(print if fi < args.debug_frames else None))
+            gate_pre += n_pre
+            gate_post += int(ok.sum())
             if ok.any():
                 cells = gf.cell_of(hit_uv[ok])
                 np.add.at(foot_ct, cells, 1)
@@ -342,8 +430,11 @@ def run(args):
             dbg = small.copy()
             dbg[gmask] = (0.5 * dbg[gmask] + np.array([0, 120, 0])).astype(np.uint8)
             if base_klass is not None:
-                for x, y in zip(bx, by):
-                    cv2.circle(dbg, (int(x), int(y)), 2, (0, 0, 255), -1)
+                # red = contact kept, magenta = rejected by the depth gate (2D-adjacent to
+                # ground but not touching it in 3D). Eyeballing these is how you tune the tol.
+                for x, y, keep in zip(bx, by, ok):
+                    cv2.circle(dbg, (int(x), int(y)), 2,
+                               (0, 0, 255) if keep else (255, 0, 255), -1)
             cv2.imwrite(str(out / f"frame_{ndbg}_{Path(img.name).stem}.png"), dbg)
             ndbg += 1
         if (fi + 1) % 10 == 0:
@@ -385,6 +476,9 @@ def run(args):
           f"FOOTPRINT {np.mean(state==FOOTPRINT)*100:.1f}%  "
           f"HIDDEN {np.mean(state==HIDDEN)*100:.1f}%  "
           f"UNKNOWN {np.mean(state==UNKNOWN)*100:.1f}%  (of {n} cells)")
+    if args.contact_depth_tol > 0 and gate_pre:
+        print(f"  depth contact gate: {gate_pre} -> {gate_post} contacts "
+              f"({100*(1-gate_post/max(gate_pre,1)):.0f}% rejected as not touching ground in 3D)")
     print(f"  wrote {out}/footprint2d_bev.png  (+ overlay, npz, {ndbg} debug frames)")
 
 
@@ -442,6 +536,10 @@ def main():
     ap.add_argument("--z-far", type=float, default=70.0)
     ap.add_argument("--dz", type=float, default=0.2)
     ap.add_argument("--max-range", type=float, default=20.0, help="max base-contact distance (m)")
+    ap.add_argument("--contact-depth-tol", type=float, default=0.15,
+                    help="reject a ground contact when measured mono depth disagrees with the "
+                         "ray-DEM hit range by more than this FRACTION of the range "
+                         "(catches masks that touch ground in 2D but float in 3D). 0 disables.")
     ap.add_argument("--hidden-close", type=int, default=5, help="HIDDEN gap-fill kernel (cells)")
     ap.add_argument("--hidden-occ-r", type=int, default=4,
                     help="HIDDEN only within this many cells of a base-contact (occlusion shadow)")

--- a/script/backbone/footprint2d.py
+++ b/script/backbone/footprint2d.py
@@ -7,8 +7,9 @@ target*. Three ground states come out, IMDF-ready:
 
   FREE       -- walkable ground, directly observed
   FOOTPRINT  -- ground occupied by a vertical object's *base* (not walkable)
-  HIDDEN     -- ground enclosed by free space but unobserved in every view (walk-under
-                / occluded); recovered by multi-view fusion, not any single frame
+  HIDDEN     -- ground that WAS in frustum but was never observed as walkable: something
+                stood in front of it (walk-under / occluded). Derived from the visibility
+                denominator, not from the shape of the free-space blob
 
 Per frame (poses + PINHOLE intrinsics from COLMAP):
   1. panoptic seg (Mask2Former, MIT) -> per-pixel taxonomy Klass + Role
@@ -30,7 +31,19 @@ Per frame (poses + PINHOLE intrinsics from COLMAP):
      comparison at a single pixel is what mono depth is reliable for; metric placement at an
      object edge is what it is not.
 
-Fuse across frames in BEV; HIDDEN falls out where FREE encloses unobserved cells.
+Fusion is by RATIO, not raw count. Each frame also rasterises which cells had their ground in
+frustum at all (`visible_cells`), giving the denominator the raster never had: three votes
+means something very different from 3 observations (unanimous) than from 40 (7.5% = noise).
+Cells additionally need votes from >= --min-bearings distinct camera bearings, because ten
+votes from one viewpoint are ONE correlated observation -- counting them ten times manufactures
+confidence from a single mistake, which is what drew the radial BEV streaks. HIDDEN then falls
+out geometrically: in frustum, yet never seen free.
+
+This is stricter than the old pixel-count rule, and honestly so: at 40 frames the previous
+2.3% FOOTPRINT was largely single-view claims counted once per pixel (1103 of 1196 voted cells
+had exactly one bearing). Multi-view evidence scales with sampling -- 40 -> 150 frames takes
+visibility 49.7% -> 72.0% (median 2 -> 4 views) and FOOTPRINT 0.2% -> 1.6%, now actually
+corroborated.
 
 Run (from repo root):
   uv run --extra segmentation --with /home/play/Code/lingbot-vision \
@@ -330,6 +343,51 @@ def depth_contact_gate(dmap, rows, cols, zt, ok, tol: float, log=None, tag: str 
     return gated
 
 
+
+# Multi-view evidence: 32 bearing bins packed into a uint32 per cell.
+NBEARINGS = 32
+_POP8 = np.array([bin(i).count("1") for i in range(256)], np.uint8)
+
+
+def popcount32(a: np.ndarray) -> np.ndarray:
+    """Number of distinct bearing bins set per cell. uint8-LUT so it works on any numpy."""
+    return _POP8[a.astype(np.uint32).view(np.uint8).reshape(-1, 4)].sum(1).astype(np.int32)
+
+
+def bearing_bits(cell_uv: np.ndarray, C_local: np.ndarray) -> np.ndarray:
+    """Quantised camera->cell bearing as a one-hot uint32.
+
+    Ten votes from one viewpoint are ONE piece of evidence, not ten: errors along a ray are
+    correlated, so counting them ten times manufactures confidence out of a single mistake --
+    which is exactly what draws the radial streaks in the BEV. Counting *distinct bearings*
+    instead is the trick footprint_instances already uses for its polygons.
+    """
+    ang = np.degrees(np.arctan2(cell_uv[:, 1] - C_local[1], cell_uv[:, 0] - C_local[0]))
+    b = ((ang % 360.0) * (NBEARINGS / 360.0)).astype(np.int64) % NBEARINGS
+    return (np.uint32(1) << b.astype(np.uint32))
+
+
+def visible_cells(C_local, RwcT, cam, gf, H, W, stride, factor, z_far, dz, max_range):
+    """Cells whose GROUND is geometrically in frustum this frame, occlusion ignored.
+
+    This is the denominator the raster never had. ``ray_dem_intersect`` hits the ground height
+    field only, so a ray through a tree trunk still lands on the ground behind it -- which is
+    the point: it separates "this cell's ground was never in view" (UNKNOWN) from "it was in
+    view but something stood in front of it" (HIDDEN). That distinction used to be
+    reverse-engineered with a morphological close; here it falls straight out of the geometry.
+    """
+    ys, xs = np.mgrid[0:H:stride, 0:W:stride]
+    d_cam = pixel_dirs(xs.ravel().astype(np.float64), ys.ravel().astype(np.float64), cam, factor)
+    dirs = (RwcT @ d_cam.T).T
+    hit_uv, ok, _ = ray_dem_intersect(C_local, dirs, gf, z_far=z_far, dz=dz, max_range=max_range)
+    if not ok.any():
+        return np.zeros(0, np.int64), np.zeros((0, 2))
+    uv = hit_uv[ok]
+    cells = gf.cell_of(uv)
+    keep = np.unique(cells, return_index=True)[1]        # one vote per cell per frame
+    return cells[keep], uv[keep]
+
+
 # ---------------------------------------------------------------------------
 def sample_frames(recon, num):
     imgs = sorted(recon.images.values(), key=lambda im: im.name)
@@ -430,8 +488,13 @@ def run(args):
     rescue_klass = int(Klass[args.rescue_klass])
     rescued: dict[str, int] = {}
 
+    # Frame counts, not pixel counts: a ratio against obs_ct is only meaningful if numerator
+    # and denominator are both "how many frames".
+    obs_ct = np.zeros(ncells, np.int32)
     free_ct = np.zeros(ncells, np.int32)
     foot_ct = np.zeros(ncells, np.int32)
+    free_bear = np.zeros(ncells, np.uint32)
+    foot_bear = np.zeros(ncells, np.uint32)
     struct_ct = np.zeros((ncells, int(max(Klass)) + 1), np.int32)  # per-cell obstacle class votes
 
     frames = sample_frames(recon, args.num)
@@ -455,6 +518,15 @@ def run(args):
         role_map = roles[klass]
         cam = recon.cameras[img.camera_id]
         C_local, RwcT = camera_local(img, gf)
+        # The denominator must be a SUPERSET of every numerator or ratios exceed 1 and cells
+        # get disqualified for "not being observed" in the very frame that observed them. The
+        # raycast alone is not: it is coverage-gated and capped at --obs-max-range, while FREE
+        # back-projects mono depth with neither restriction. So seed obs with the raycast and
+        # union in whatever this frame actually voted -- a cell seen as ground was, tautologically,
+        # in view.
+        ocells, _ = visible_cells(C_local, RwcT, cam, gf, H, W, args.obs_stride,
+                                  args.data_factor, args.z_far, args.dz, args.obs_max_range)
+        frame_obs = [ocells]
 
         # ---- FREE: ground pixels back-projected with metric depth ----
         gmask = (role_map == int(Role.GROUND)) & (dmap > 0)
@@ -467,7 +539,10 @@ def run(args):
             dir_local = (RwcT @ d_cam.T).T
             pts = C_local[None, :] + dmap[gy, gx][:, None] * dir_local
             cells = gf.cell_of(pts[:, :2])
-            np.add.at(free_ct, cells, 1)
+            uniq, ui = np.unique(cells, return_index=True)
+            np.add.at(free_ct, uniq, 1)
+            np.bitwise_or.at(free_bear, uniq, bearing_bits(pts[ui, :2], C_local))
+            frame_obs.append(uniq)
 
         # ---- RESCUE: open-vocab masks for solid objects the closed-set seg calls UNKNOWN ----
         # ADE-150 has no "vending machine", so Mask2Former labels one UNKNOWN -> Role.IGNORE and
@@ -520,8 +595,13 @@ def run(args):
             gate_post += int(ok.sum())
             if ok.any():
                 cells = gf.cell_of(hit_uv[ok])
-                np.add.at(foot_ct, cells, 1)
-                np.add.at(struct_ct, (cells, base_klass[ok]), 1)
+                uniq, ui = np.unique(cells, return_index=True)
+                np.add.at(foot_ct, uniq, 1)
+                np.bitwise_or.at(foot_bear, uniq, bearing_bits(hit_uv[ok][ui], C_local))
+                np.add.at(struct_ct, (cells, base_klass[ok]), 1)   # class votes stay per-pixel
+                frame_obs.append(uniq)
+
+        obs_ct[np.unique(np.concatenate(frame_obs))] += 1
 
         # ---- per-frame debug overlay (first few) ----
         if ndbg < args.debug_frames:
@@ -539,9 +619,18 @@ def run(args):
             print(f"  {fi + 1}/{len(frames)}  free~{int(free_ct.sum())} foot~{int(foot_ct.sum())}")
 
     # ---- fuse -> ground-state raster ----
+    # Evidence is now a RATIO, not a count. Three votes means something entirely different
+    # when the cell was in view 3 times (unanimous) than when it was in view 40 (7.5% -- noise).
+    # Without the denominator both looked identical, which is what the raw-count rule did.
     state = np.full(ncells, UNKNOWN, np.uint8)
-    free = free_ct >= args.min_free
-    foot = foot_ct >= args.min_foot
+    obs_ok = obs_ct >= args.min_obs
+    denom = np.maximum(obs_ct, 1)
+    p_free = free_ct / denom
+    p_foot = foot_ct / denom
+    nb_foot = popcount32(foot_bear)
+    free = obs_ok & (free_ct >= args.min_free) & (p_free >= args.min_free_frac)
+    foot = (obs_ok & (foot_ct >= args.min_foot) & (p_foot >= args.min_foot_frac)
+            & (nb_foot >= args.min_bearings))
     state[free] = FREE
     state[foot] = FOOTPRINT                                  # footprint wins ties
     state = state.reshape(rows, cols)
@@ -552,20 +641,33 @@ def run(args):
     # fill to cells within `hidden_occ_r` of a base-contact (a real occluder): the
     # camera-facing side of an obstacle is observed -> FREE, so the UNKNOWN cells left next to
     # a footprint are precisely its shadow. No footprint nearby -> just unobserved, not hidden.
-    k = max(3, int(args.hidden_close) | 1)                  # odd
-    freem = (state == FREE).astype(np.uint8)
-    closed = cv2.morphologyEx(freem, cv2.MORPH_CLOSE,
-                              cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k, k)))
-    occ_r = max(1, int(args.hidden_occ_r))
-    occ = (foot_ct.reshape(rows, cols) > 0).astype(np.uint8)   # any base-contact = an occluder
-    occ_dil = cv2.dilate(occ, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * occ_r + 1,) * 2))
-    hidden = (closed == 1) & (state == UNKNOWN) & (occ_dil > 0)
-    state[hidden] = HIDDEN
+    if args.hidden_mode == "visibility":
+        # HIDDEN is no longer inferred from the SHAPE of the free space. A cell whose ground
+        # was in frustum (obs_ct) yet never actually observed as walkable is, by definition,
+        # occluded -- something stood in front of it. The morphological close below could only
+        # guess that from geometry of the FREE blob, and needed an occluder-proximity fudge to
+        # stop it claiming every unwalked fringe.
+        hidden = (obs_ok & ~free & ~foot).reshape(rows, cols)
+        state[hidden] = HIDDEN
+    else:
+        state_f = state.reshape(-1)
+        k = max(3, int(args.hidden_close) | 1)                  # odd
+        freem = (state == FREE).astype(np.uint8)
+        closed = cv2.morphologyEx(freem, cv2.MORPH_CLOSE,
+                                  cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k, k)))
+        occ_r = max(1, int(args.hidden_occ_r))
+        occ = (foot_ct.reshape(rows, cols) > 0).astype(np.uint8)
+        occ_dil = cv2.dilate(occ, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * occ_r + 1,) * 2))
+        hidden = (closed == 1) & (state == UNKNOWN) & (occ_dil > 0)
+        state[hidden] = HIDDEN
+        del state_f
 
     struct = struct_ct.reshape(rows, cols, -1).argmax(2).astype(np.uint8)
     struct[state != FOOTPRINT] = int(Klass.UNKNOWN)
 
     np.savez(out / "footprint2d.npz", state=state, structure=struct,
+             obs_count=obs_ct.reshape(rows, cols),
+             foot_bearings=popcount32(foot_bear).reshape(rows, cols),
              free_count=free_ct.reshape(rows, cols), foot_count=foot_ct.reshape(rows, cols),
              dem=gf.dem, coverage=gf.coverage, cell_size=args.cell_size)
     _render(out, state, struct, gf)
@@ -574,6 +676,11 @@ def run(args):
           f"FOOTPRINT {np.mean(state==FOOTPRINT)*100:.1f}%  "
           f"HIDDEN {np.mean(state==HIDDEN)*100:.1f}%  "
           f"UNKNOWN {np.mean(state==UNKNOWN)*100:.1f}%  (of {n} cells)")
+    seen = obs_ct > 0
+    print(f"  visibility: {100*np.mean(seen):.1f}% of cells ever in frustum, "
+          f"median {int(np.median(obs_ct[seen])) if seen.any() else 0} views where seen "
+          f"(max {int(obs_ct.max())});  footprint cells with >=2 bearings: "
+          f"{int((nb_foot >= 2).sum())} of {int((foot_ct > 0).sum())} voted")
     if rescued:
         top = sorted(rescued.items(), key=lambda kv: -kv[1])
         print(f"  obstacle rescue: {sum(rescued.values())} masks over {len(rescued)} labels -> "
@@ -662,6 +769,26 @@ def main():
                     help="reject a ground contact when measured mono depth disagrees with the "
                          "ray-DEM hit range by more than this FRACTION of the range "
                          "(catches masks that touch ground in 2D but float in 3D). 0 disables.")
+    # --- multi-view evidence ---
+    ap.add_argument("--obs-max-range", type=float, default=40.0,
+                    help="range cap for the visibility raycast. Deliberately looser than "
+                         "--max-range: that bounds where a CONTACT is trustworthy, this only "
+                         "asks whether the ground was in view at all.")
+    ap.add_argument("--obs-stride", type=int, default=8,
+                    help="pixel stride for the per-frame visibility raycast (the denominator)")
+    ap.add_argument("--min-obs", type=int, default=2,
+                    help="frames that must have had a cell's ground in frustum before we call it")
+    ap.add_argument("--min-free-frac", type=float, default=0.25,
+                    help="fraction of observing frames that must see a cell as ground -> FREE")
+    ap.add_argument("--min-foot-frac", type=float, default=0.20,
+                    help="fraction of observing frames that must vote base-contact -> FOOTPRINT")
+    ap.add_argument("--min-bearings", type=int, default=2,
+                    help="distinct camera bearings (of 32 bins) required for FOOTPRINT; "
+                         "votes from a single viewpoint are one correlated observation, and "
+                         "counting them individually is what draws the radial BEV streaks")
+    ap.add_argument("--hidden-mode", default="visibility", choices=["visibility", "morphology"],
+                    help="visibility: in-frustum but never seen free = occluded (geometric). "
+                         "morphology: the older close+dilate heuristic, kept for comparison.")
     ap.add_argument("--hidden-close", type=int, default=5, help="HIDDEN gap-fill kernel (cells)")
     ap.add_argument("--hidden-occ-r", type=int, default=4,
                     help="HIDDEN only within this many cells of a base-contact (occlusion shadow)")

--- a/script/backbone/footprint_head.py
+++ b/script/backbone/footprint_head.py
@@ -1,0 +1,331 @@
+"""Train a footprint / free-space / ground-contact head on the frozen LingBot backbone.
+
+This is the *distillation* step: the multi-frame geometric pipeline
+(``footprint_labels.py``, DEM-render supervision) teaches a **single-image** head to
+predict, from one RGB frame, the ground state a BEV projector needs — where ground is
+walkable, where it is occupied by an object's footprint, and where it continues *behind*
+an occluder (Niantic "Footprints and Free Space", CVPR2020). The backbone stays frozen;
+only a small MLP on its patch tokens is trained, so this needs no manual labels and very
+little data.
+
+Two heads share one trunk on the frozen (optionally AnyUp-upsampled) patch grid:
+
+  class   -- 5-way ground state, one of the ``footprint_labels`` classes:
+             0 NON_GROUND  1 VISIBLE  2 HIDDEN  3 FOOTPRINT  4 OBJECT
+  contact -- binary "ground-contact contour": a FOOTPRINT patch touching walkable ground
+             (VISIBLE|HIDDEN). This is the class-agnostic precursor to per-object contact
+             *keypoints* — once SAM2 gives instances, each object's contact arc collapses
+             to one keypoint. Buildable today with zero extra deps.
+
+Supervision comes from ``footprint_labels.py`` outputs (run that first):
+  <stem>.png        uint8 5-class label at camera aspect
+  <stem>_cover.npy  float32 {0,1} DEM-observed vs extrapolated -> per-pixel loss weight
+
+Alignment: LingBot ``load_image(mode="square")`` is a plain anamorphic resize of the full
+frame to SxS, and the DEM labels are rendered full-frame at camera aspect, so a label maps
+to the patch grid by an anamorphic resize to SxS + block-majority-pool to GxG (cover is
+mean-pooled). No cropping, so the two stay pixel-aligned.
+
+Run (from repo root, same env as probe.py):
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/footprint_head.py --session maguro-park-after-itchy \
+      --upsample anyup --up-size 128 --save-head \
+      output/maguro-park-after-itchy-backbone/footprint_head.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+_HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(_HERE))
+
+from probe import feature_grid, load_anyup, load_backbone, report_vram  # noqa: E402
+from lar_session import Session  # noqa: E402
+
+# label ids -- MUST match footprint_labels.py
+NON_GROUND, VISIBLE, HIDDEN, FOOTPRINT, OBJECT = 0, 1, 2, 3, 4
+CLASS_NAMES = ["non_ground", "visible", "hidden", "footprint", "object"]
+N_CLASS = 5
+GROUND = (VISIBLE, HIDDEN)  # walkable ground states (contact touches these)
+
+# RGB palette for renders (footprint_labels uses the BGR mirror of this)
+PALETTE = np.array([
+    [0, 0, 0],        # non_ground  black
+    [80, 200, 80],    # visible     green
+    [220, 120, 40],   # hidden      orange
+    [220, 40, 40],    # footprint   red
+    [60, 200, 200],   # object      cyan
+], dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# label <-> patch-grid alignment
+# ---------------------------------------------------------------------------
+def pool_labels(label_sq: np.ndarray, cover_sq: np.ndarray, g: int):
+    """(S,S) label + cover -> (g,g) majority class, (g,g) mean cover.
+
+    S must be a multiple of g (512 & patch-16 -> 32; AnyUp 128 -> 4). Falls back to a
+    nearest/area resize if not divisible.
+    """
+    s = label_sq.shape[0]
+    if s % g != 0:
+        cls = cv2.resize(label_sq, (g, g), interpolation=cv2.INTER_NEAREST)
+        cov = cv2.resize(cover_sq, (g, g), interpolation=cv2.INTER_AREA)
+        return cls.astype(np.int64), cov.astype(np.float32)
+    b = s // g
+    blocks = label_sq.reshape(g, b, g, b).transpose(0, 2, 1, 3).reshape(g * g, b * b)
+    # majority class per block
+    onehot = (blocks[:, None, :] == np.arange(N_CLASS)[None, :, None]).sum(2)  # (g*g, C)
+    cls = onehot.argmax(1).reshape(g, g).astype(np.int64)
+    cov = cover_sq.reshape(g, b, g, b).mean((1, 3)).astype(np.float32)
+    return cls, cov
+
+
+def contact_target(cls: np.ndarray) -> np.ndarray:
+    """Binary ground-contact contour on the (g,g) class grid.
+
+    A FOOTPRINT cell 4-adjacent to walkable ground (VISIBLE|HIDDEN) — i.e. the object's
+    ground-contact edge, not its interior. Class-agnostic; the per-instance keypoint is a
+    later SAM2 step.
+    """
+    foot = cls == FOOTPRINT
+    ground = np.isin(cls, GROUND)
+    gd = cv2.dilate(ground.astype(np.uint8), np.ones((3, 3), np.uint8))
+    return (foot & (gd > 0)).astype(np.float32)
+
+
+def load_frame_target(label_dir: Path, stem: str, g: int, s: int):
+    """(cls (g,g), cover (g,g), contact (g,g)) for a frame, aligned to the patch grid."""
+    lab = cv2.imread(str(label_dir / f"{stem}.png"), cv2.IMREAD_UNCHANGED)
+    if lab is None:
+        return None
+    cov_p = label_dir / f"{stem}_cover.npy"
+    cover = np.load(cov_p).astype(np.float32) if cov_p.exists() else np.ones_like(lab, np.float32)
+    lab_sq = cv2.resize(lab, (s, s), interpolation=cv2.INTER_NEAREST)
+    cov_sq = cv2.resize(cover, (s, s), interpolation=cv2.INTER_LINEAR)
+    cls, cov = pool_labels(lab_sq, cov_sq, g)
+    return cls, cov, contact_target(cls)
+
+
+# ---------------------------------------------------------------------------
+# head
+# ---------------------------------------------------------------------------
+class FootprintHead(torch.nn.Module):
+    """Shared MLP trunk on a patch token -> (5-way class logits, contact logit)."""
+
+    def __init__(self, in_dim: int, hidden: int = 256):
+        super().__init__()
+        self.trunk = torch.nn.Sequential(
+            torch.nn.Linear(in_dim, hidden), torch.nn.GELU(),
+            torch.nn.Linear(hidden, hidden), torch.nn.GELU(),
+        )
+        self.cls = torch.nn.Linear(hidden, N_CLASS)
+        self.contact = torch.nn.Linear(hidden, 1)
+
+    def forward(self, x):
+        h = self.trunk(x)
+        return self.cls(h), self.contact(h).squeeze(-1)
+
+
+# ---------------------------------------------------------------------------
+def frame_stems(label_dir: Path) -> list[str]:
+    """Stems that have a label PNG (exclude preview/colourised aux images)."""
+    out = []
+    for p in sorted(label_dir.glob("*.png")):
+        if p.stem.endswith("_preview"):
+            continue
+        out.append(p.stem)
+    return out
+
+
+def run(args):
+    s = Session(args.session)
+    label_dir = Path(args.label_dir or (s.root / "output" / f"{args.session}-footprint"))
+    if not label_dir.exists():
+        raise SystemExit(f"no label dir {label_dir} -- run footprint_labels.py first")
+    out = Path(args.out or (s.root / "output" / f"{args.session}-backbone"))
+    out.mkdir(parents=True, exist_ok=True)
+
+    backbone, embed_dim, device, dtype = load_backbone(args.variant, args.backbone)
+    up = load_anyup(args.anyup_ckpt, args.anyup_src, device) if args.upsample == "anyup" else None
+    up_size = args.up_size if up is not None else 0
+
+    stems = frame_stems(label_dir)
+    if args.num and args.num < len(stems):
+        idx = np.linspace(0, len(stems) - 1, args.num).round().astype(int)
+        stems = [stems[i] for i in sorted(set(idx))]
+    n_val = max(1, int(round(len(stems) * args.val_frac)))
+    val_stems = set(stems[-n_val:])
+    print(f"[footprint_head] backbone={args.backbone}/{args.variant} embed_dim={embed_dim} "
+          f"frames={len(stems)} (val={n_val}) size={args.size} upsample={args.upsample}"
+          + (f" up_size={up_size}" if up else ""))
+    print(f"  labels <- {label_dir}")
+
+    Xtr, ytr, wtr, ctr = [], [], [], []
+    val = []  # (feat[G,G,C], cls(g,g), cover(g,g), contact(g,g), rgb, g)
+    n_ok = 0
+    for stem in stems:
+        img_path = s.images / f"{stem}.jpeg"
+        if not img_path.exists():
+            continue
+        feat, rgb, (g, _) = feature_grid(backbone, img_path, args.size, args.mode,
+                                         device, dtype, up, up_size, args.backbone)
+        tgt = load_frame_target(label_dir, stem, g, rgb.shape[0])
+        if tgt is None:
+            continue
+        cls, cov, ctc = tgt
+        n_ok += 1
+        if stem in val_stems:
+            val.append((feat, cls, cov, ctc, rgb, g))
+        else:
+            Xtr.append(feat.reshape(-1, embed_dim))
+            ytr.append(cls.reshape(-1))
+            wtr.append(np.clip(cov.reshape(-1), args.cover_floor, 1.0))
+            ctr.append(ctc.reshape(-1))
+    if not Xtr:
+        raise SystemExit("no training frames with both features and labels")
+    print(f"  matched {n_ok} frames to labels")
+
+    Xtr = np.concatenate(Xtr); ytr = np.concatenate(ytr)
+    wtr = np.concatenate(wtr); ctr = np.concatenate(ctr)
+    mu, sd = Xtr.mean(0), Xtr.std(0) + 1e-6
+    # keep the (potentially millions of) tokens on CPU; minibatch to GPU per step so the
+    # AnyUp-upsampled grid (128^2 tokens/frame) doesn't blow the card's VRAM.
+    Xn = torch.tensor((Xtr - mu) / sd, dtype=torch.float32)
+    yn = torch.tensor(ytr)
+    wn = torch.tensor(wtr, dtype=torch.float32)
+    cn = torch.tensor(ctr, dtype=torch.float32)
+
+    # class-balanced CE weights (footprint/hidden are rare) x per-pixel cover weight
+    freq = np.bincount(ytr, minlength=N_CLASS).astype(np.float64)
+    cls_w = torch.tensor((freq.sum() / np.maximum(freq, 1)) ** 0.5, dtype=torch.float32, device=device)
+    cls_w /= cls_w.mean()
+    # contact positives are sparse -> pos_weight balances BCE
+    pos = float(ctr.sum()); neg = float(len(ctr) - pos)
+    pos_weight = torch.tensor([neg / max(pos, 1)], device=device)
+    print(f"  class freq {dict(zip(CLASS_NAMES, freq.astype(int)))}  contact pos={int(pos)}")
+
+    head = FootprintHead(embed_dim, args.hidden).to(device)
+    opt = torch.optim.Adam(head.parameters(), lr=args.lr, weight_decay=1e-4)
+    ce = torch.nn.CrossEntropyLoss(weight=cls_w, reduction="none")
+    bce = torch.nn.BCEWithLogitsLoss(pos_weight=pos_weight)
+    head.train()
+    n = Xn.shape[0]
+    bs = min(args.batch, n)
+    gen = torch.Generator().manual_seed(0)
+    for step in range(args.steps):
+        sel = torch.randint(0, n, (bs,), generator=gen)
+        xb = Xn[sel].to(device); yb = yn[sel].to(device)
+        wb = wn[sel].to(device); cb = cn[sel].to(device)
+        opt.zero_grad()
+        logit_c, logit_ct = head(xb)
+        loss_c = (ce(logit_c, yb) * wb).sum() / wb.sum().clamp_min(1)
+        loss_ct = bce(logit_ct, cb)
+        loss = loss_c + args.contact_w * loss_ct
+        loss.backward(); opt.step()
+        if (step + 1) % max(1, args.steps // 6) == 0:
+            print(f"  step {step+1}/{args.steps}  cls={loss_c.item():.3f}  contact={loss_ct.item():.3f}")
+    head.eval()
+
+    _evaluate(head, val, embed_dim, mu, sd, device, out, args)
+    report_vram("footprint_head", device)
+
+    if args.save_head:
+        sp = Path(args.save_head)
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        torch.save({
+            "head": {k: v.cpu() for k, v in head.state_dict().items()},
+            "hidden": args.hidden, "mu": mu, "sd": sd,
+            "backbone": args.backbone, "variant": args.variant, "embed_dim": embed_dim,
+            "size": args.size, "mode": args.mode,
+            "upsample": args.upsample, "up_size": up_size,
+            "anyup_ckpt": args.anyup_ckpt, "anyup_src": args.anyup_src,
+            "classes": CLASS_NAMES,
+        }, sp)
+        print(f"[footprint_head] saved head -> {sp}")
+
+
+def _evaluate(head, val, embed_dim, mu, sd, device, out, args):
+    inter = np.zeros(N_CLASS); union = np.zeros(N_CLASS)
+    correct = total = 0.0
+    ct_tp = ct_fp = ct_fn = 0
+    tiles = []
+    for feat, cls, cov, ctc, rgb, g in val:
+        Xv = torch.tensor((feat.reshape(-1, embed_dim) - mu) / sd, dtype=torch.float32, device=device)
+        with torch.no_grad():
+            lc, lct = head(Xv)
+            pred = lc.argmax(1).cpu().numpy()
+            pct = (torch.sigmoid(lct) > 0.5).cpu().numpy()
+        y = cls.reshape(-1); w = cov.reshape(-1) > 0.0
+        correct += float((pred[w] == y[w]).sum()); total += float(w.sum())
+        for c in range(N_CLASS):
+            pc, yc = (pred == c) & w, (y == c) & w
+            inter[c] += float((pc & yc).sum()); union[c] += float((pc | yc).sum())
+        gt = ctc.reshape(-1) > 0.5
+        ct_tp += int((pct & gt).sum()); ct_fp += int((pct & ~gt).sum()); ct_fn += int((~pct & gt).sum())
+        tiles.append(_tile(rgb, cls, pred.reshape(g, g), ctc, pct.reshape(g, g)))
+
+    iou = inter / np.maximum(union, 1)
+    present = union > 0
+    prec = ct_tp / max(ct_tp + ct_fp, 1); rec = ct_tp / max(ct_tp + ct_fn, 1)
+    f1 = 2 * prec * rec / max(prec + rec, 1e-6)
+    print(f"\n[footprint_head] val acc={correct/max(total,1):.3f}  mIoU(present)={iou[present].mean():.3f}")
+    for c in np.where(present)[0]:
+        print(f"    {CLASS_NAMES[c]:11s} IoU {iou[c]:.3f}")
+    print(f"  contact  P={prec:.3f} R={rec:.3f} F1={f1:.3f}")
+
+    tag = "" if args.upsample == "none" else f"_{args.upsample}{args.up_size}"
+    dst = out / f"footprint_head_{args.variant}{tag}.png"
+    cv2.imwrite(str(dst), cv2.cvtColor(np.concatenate(tiles, 0), cv2.COLOR_RGB2BGR))
+    print(f"[footprint_head] wrote {dst}  (RGB | target | pred | contact)")
+
+
+def _tile(rgb, cls_g, pred_g, ctc_g, pct_g):
+    """RGB | target-class | pred-class | pred-contact-over-RGB, all upsampled to rgb size."""
+    S = rgb.shape[0]
+    up = lambda a: cv2.resize(a, (S, S), interpolation=cv2.INTER_NEAREST)
+    tgt = up(PALETTE[cls_g])
+    prd = up(PALETTE[pred_g])
+    ov = rgb.copy()
+    ct = up((pct_g * 255).astype(np.uint8))
+    ov[ct > 0] = (0.35 * ov[ct > 0] + np.array([255, 255, 0]) * 0.65).astype(np.uint8)
+    # ground-truth contact as a thin outline for reference (magenta)
+    gt = up((ctc_g * 255).astype(np.uint8))
+    ov[(gt > 0) & (ct == 0)] = (0.5 * ov[(gt > 0) & (ct == 0)] + np.array([255, 0, 255]) * 0.5).astype(np.uint8)
+    return np.concatenate([rgb, tgt, prd, ov], axis=1)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default="maguro-park-after-itchy")
+    ap.add_argument("--label-dir", default=None, help="footprint_labels.py output (default output/<session>-footprint)")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--backbone", default="lingbot", choices=["lingbot", "dinov2"])
+    ap.add_argument("--variant", default="small")
+    ap.add_argument("--size", type=int, default=512)
+    ap.add_argument("--mode", default="square", choices=["square", "shortest"])
+    ap.add_argument("--num", type=int, default=0, help="subsample labelled frames (0=all)")
+    ap.add_argument("--val-frac", type=float, default=0.25)
+    ap.add_argument("--steps", type=int, default=400)
+    ap.add_argument("--batch", type=int, default=262144, help="tokens/step (minibatch to GPU)")
+    ap.add_argument("--lr", type=float, default=5e-3)
+    ap.add_argument("--hidden", type=int, default=256)
+    ap.add_argument("--contact-w", type=float, default=0.5, help="contact-head loss weight")
+    ap.add_argument("--cover-floor", type=float, default=0.2, help="min per-patch loss weight")
+    ap.add_argument("--upsample", default="none", choices=["none", "anyup"])
+    ap.add_argument("--up-size", type=int, default=128)
+    ap.add_argument("--anyup-ckpt", default="multi", choices=["multi", "paper"])
+    ap.add_argument("--anyup-src", default="/home/play/Code/anyup")
+    ap.add_argument("--save-head", default=None)
+    run(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/footprint_instances.py
+++ b/script/backbone/footprint_instances.py
@@ -1,0 +1,445 @@
+"""Per-object footprint polygons + ground-contact keypoints (Grounded-SAM -> BEV).
+
+``footprint2d.py`` fuses a *class-level* BEV: cells are FREE / FOOTPRINT / HIDDEN, but every
+tree in a row of trees melts into one anonymous red arc. Semantic segmentation cannot fix
+this -- trees are "stuff" in both COCO and ADE, so there are no per-tree ids to fuse. This
+script adds the missing level: **instances**, each with its own footprint polygon and a single
+ground-contact keypoint, which is what IMDF (``amenity.landmark`` / ``unit.structure``) and any
+downstream navigation graph actually want.
+
+Per frame:
+  1. **Grounding DINO** (Apache-2.0, open-vocab) -> one box per object from a text prompt.
+  2. **SAM** (Apache-2.0) -> a real mask per box (a box is not a footprint; a leaning tree's
+     box covers metres of path it doesn't occupy).
+  3. **Ground-contact columns.** For every image column the mask spans, take its bottom-most
+     masked pixel and keep it only if the pixels just below are Role.GROUND in the semantic
+     seg. This is the canopy guard: a canopy's mask bottom is mid-air with more foliage under
+     it, so it is rejected, while the trunk base -- which sits on path/grass -- is kept. Without
+     the guard a floating canopy's ray-DEM hit lands metres behind the tree.
+  4. **Ray-DEM** those contact pixels (calibration + the gravity DEM, never mono depth at the
+     object edge where it is worst) -> BEV cells = this object's ground extent in this frame.
+     Too few valid contacts -> keep the object as a point-only landmark (box bottom-centre).
+
+Across frames: union-find clusters observations by label + contact proximity, so the same tree
+seen from 12 views collapses to one instance and a one-frame false positive stays a singleton
+and is dropped. Per cluster the polygon is the cells voted by >= --min-cell-views observations
+(largest connected component, contoured); the keypoint is the median contact.
+
+Run (from repo root; offline avoids the HF HEAD-hang, all weights are cached):
+  HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 uv run --extra segmentation \
+    python script/backbone/footprint_instances.py --session maguro-park-after-itchy \
+    --num 40 --dem-source mono
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_HERE))
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+sys.path.insert(0, str(_SCRIPT_ROOT / "depth"))
+
+from lar_session import Session                      # noqa: E402
+from colmap_io import read_model                     # noqa: E402
+from geometry import from_reconstruction             # noqa: E402
+from taxonomy import Klass, Role, role_of            # noqa: E402
+from footprint2d import (                            # noqa: E402
+    SegKlass, camera_local, pixel_dirs, ray_dem_intersect, mono_dem_field, sample_frames,
+)
+
+DEFAULT_PROMPT = "tree. bench. pole. sign. trash can. street lamp. rock. bush. fence."
+
+# stable BGR per canonical label (matches base_points.py so the two outputs read alike)
+CLASS_COLORS = {
+    "tree": (60, 170, 60), "bench": (200, 150, 40), "pole": (40, 140, 220),
+    "sign": (40, 40, 220), "trash can": (180, 60, 200), "street lamp": (60, 200, 200),
+    "rock": (120, 120, 120), "bush": (80, 200, 140), "fence": (150, 150, 60),
+}
+_FALLBACK = [(200, 100, 60), (60, 100, 200), (100, 200, 60), (200, 60, 160)]
+
+# per-label merge radius (m): how far two contacts of the same label can be and still be
+# the same object. A tree trunk localises tightly; a bench or fence spans metres.
+MERGE_RADIUS = {"tree": 1.2, "bush": 1.5, "bench": 1.5, "fence": 2.0}
+DEFAULT_RADIUS = 1.0
+
+
+def color_for(label: str) -> tuple[int, int, int]:
+    if label in CLASS_COLORS:
+        return CLASS_COLORS[label]
+    return _FALLBACK[hash(label) % len(_FALLBACK)]
+
+
+# ---------------------------------------------------------------------------
+# open-vocabulary instances: Grounding DINO boxes -> SAM masks
+# ---------------------------------------------------------------------------
+class GroundedSAM:
+    """(masks, boxes, labels, scores) for one BGR image, all from cached weights."""
+
+    def __init__(self, det_model: str, sam_model: str, prompt: str,
+                 box_th: float, text_th: float, device: str | None = None):
+        import torch
+        from transformers import (AutoModelForZeroShotObjectDetection, AutoProcessor,
+                                  SamModel, SamProcessor)
+        self.torch = torch
+        self.prompt = prompt
+        self.box_th, self.text_th = box_th, text_th
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.dproc = AutoProcessor.from_pretrained(det_model)
+        self.det = AutoModelForZeroShotObjectDetection.from_pretrained(det_model).to(self.device).eval()
+        self.sproc = SamProcessor.from_pretrained(sam_model)
+        self.sam = SamModel.from_pretrained(sam_model).to(self.device).eval()
+
+    def __call__(self, bgr: np.ndarray):
+        from PIL import Image as PILImage
+        torch = self.torch
+        pil = PILImage.fromarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB))
+        inp = self.dproc(images=pil, text=self.prompt, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            out = self.det(**inp)
+        res = self.dproc.post_process_grounded_object_detection(
+            out, inp.input_ids, threshold=self.box_th, text_threshold=self.text_th,
+            target_sizes=[bgr.shape[:2]])[0]
+        boxes = res["boxes"].cpu().numpy()
+        if not len(boxes):
+            return np.zeros((0, *bgr.shape[:2]), bool), boxes, [], np.zeros(0, np.float32)
+        labels = [str(x) for x in res.get("text_labels", res["labels"])]
+        scores = res["scores"].cpu().numpy().astype(np.float32)
+        si = self.sproc(pil, input_boxes=[boxes.tolist()], return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            so = self.sam(**si, multimask_output=False)
+        masks = self.sproc.image_processor.post_process_masks(
+            so.pred_masks.cpu(), si["original_sizes"].cpu(), si["reshaped_input_sizes"].cpu())[0]
+        return masks[:, 0].numpy().astype(bool), boxes, labels, scores
+
+
+# ---------------------------------------------------------------------------
+# ground contacts of one instance mask
+# ---------------------------------------------------------------------------
+def contact_columns(mask: np.ndarray, ground: np.ndarray, stride: int, probe: int):
+    """Columns where ``mask``'s bottom-most pixel is a genuine ground contact.
+
+    The canopy guard: a column's lowest masked pixel is only a *base* if what lies immediately
+    below it is walkable ground. Under a canopy the pixels below are more tree/background, so
+    the column is rejected and the object contributes no phantom footprint metres behind it.
+    Columns bottoming out at the image edge are rejected too -- the object continues out of
+    frame, so its true base is unseen."""
+    H, W = mask.shape
+    cols = np.where(mask.any(0))[0][::stride]
+    if not len(cols):
+        return np.zeros(0, np.int64), np.zeros(0, np.int64)
+    rows = H - 1 - mask[::-1][:, cols].argmax(0)          # bottom-most masked row per column
+    keep = rows < H - 2
+    cols, rows = cols[keep], rows[keep]
+    if not len(cols):
+        return cols, rows
+    below = np.clip(rows[None, :] + np.arange(1, probe + 1)[:, None], 0, H - 1)
+    is_ground = ground[below, cols[None, :]].mean(0) > 0.5
+    return cols[is_ground], rows[is_ground]
+
+
+# ---------------------------------------------------------------------------
+# multi-view fusion: union-find over (label, contact proximity)
+# ---------------------------------------------------------------------------
+def cluster_observations(obs, radius_of):
+    """Group per-frame observations of the same physical object. Returns list of index lists."""
+    from scipy.spatial import cKDTree
+    n = len(obs)
+    parent = list(range(n))
+
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    xy = np.array([o["contact"][:2] for o in obs], np.float64)
+    labels = [o["label"] for o in obs]
+    tree = cKDTree(xy)
+    rmax = max(radius_of(l) for l in set(labels)) if labels else 0.0
+    for i, j in tree.query_pairs(rmax):
+        if labels[i] != labels[j]:
+            continue
+        r = radius_of(labels[i])
+        if np.linalg.norm(xy[i] - xy[j]) <= r:
+            union(i, j)
+    groups: dict[int, list[int]] = {}
+    for i in range(n):
+        groups.setdefault(find(i), []).append(i)
+    return list(groups.values())
+
+
+def polygon_of(cell_bearings, rows, cols, spec, min_bearings, close_k, contact, max_extent):
+    """Cell votes -> (contour in local metres, area m^2, mask). None if nothing survives.
+
+    ``cell_bearings`` maps cell -> set of quantised camera bearings that voted it. Counting
+    *distinct bearings* rather than observations is what kills the ray-streak artefact: depth
+    along a ray is the weak axis of ray-DEM, so a mis-estimated contact smears cells backwards
+    away from the camera -- but only along that one line of sight. Consecutive frames share a
+    vantage and happily re-vote the same wrong streak, so an observation count cannot tell the
+    difference. Cells on the object's real ground extent are hit from every side you walk past
+    it; cells on a streak are hit from one. Requiring >= 2 bearings is a small-scale visual
+    hull: keep only what multiple viewpoints agree on."""
+    grid = np.zeros(rows * cols, np.int32)
+    for c, bearings in cell_bearings.items():
+        grid[c] = len(bearings)
+    m = (grid.reshape(rows, cols) >= min_bearings).astype(np.uint8)
+    if max_extent > 0 and m.any():                       # safety net: no runaway tails
+        yy, xx = np.mgrid[0:rows, 0:cols]
+        du = spec.origin_u + (xx + 0.5) * spec.cell_size - contact[0]
+        dv = spec.origin_v + (yy + 0.5) * spec.cell_size - contact[1]
+        m &= (np.hypot(du, dv) <= max_extent).astype(np.uint8)
+    if not m.any():
+        return None
+    k = max(3, int(close_k) | 1)
+    m = cv2.morphologyEx(m, cv2.MORPH_CLOSE, cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (k, k)))
+    nlab, lab, stats, _ = cv2.connectedComponentsWithStats(m, 8)
+    if nlab <= 1:
+        return None
+    big = 1 + int(np.argmax(stats[1:, cv2.CC_STAT_AREA]))
+    m = (lab == big).astype(np.uint8)
+    cnts, _ = cv2.findContours(m, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not cnts:
+        return None
+    cnt = max(cnts, key=cv2.contourArea)
+    cnt = cv2.approxPolyDP(cnt, 1.0, True).reshape(-1, 2)   # simplify to ~1 cell
+    poly = np.stack([spec.origin_u + (cnt[:, 0] + 0.5) * spec.cell_size,
+                     spec.origin_v + (cnt[:, 1] + 0.5) * spec.cell_size], axis=1)
+    return poly, float(m.sum()) * spec.cell_size ** 2, m
+
+
+# ---------------------------------------------------------------------------
+def run(args):
+    s = Session(args.session)
+    model = args.model or str(s.colmap_model)
+    images_dir = Path(args.images or str(s.images))
+    out = Path(args.out or (s.root / "output" / f"{args.session}-instances"))
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"[instances] model={model}\n  images={images_dir}\n  out={out}")
+    recon = read_model(model)
+    if args.dem_source == "mono":
+        depth_dir = args.depth_dir or str(s.depth_dir("mono"))
+        print(f"  DEM source: mono depth <- {depth_dir}")
+        gf = mono_dem_field(recon, depth_dir, args.cell_size, args.depth_stride,
+                            args.depth_voxel, args.depth_max, log=print)
+    else:
+        gf, *_ = from_reconstruction(recon, cell_size=args.cell_size)
+    rows, cols = gf.dem.shape
+
+    seg = SegKlass(args.seg_model, mode="semantic")
+    gsam = GroundedSAM(args.det_model, args.sam_model, args.prompt, args.box_th, args.text_th)
+    roles = np.array([int(role_of(int(k))) for k in range(int(max(Klass)) + 1)], np.uint8)
+
+    frames = sample_frames(recon, args.num)
+    print(f"  {len(frames)} frames, grid {cols}x{rows} @ {args.cell_size} m, prompt: {args.prompt}")
+
+    obs, ndbg = [], 0
+    for fi, img in enumerate(frames):
+        bgr = cv2.imread(str(images_dir / img.name), cv2.IMREAD_COLOR)
+        if bgr is None:
+            continue
+        H, W = bgr.shape[0] // args.data_factor, bgr.shape[1] // args.data_factor
+        small = cv2.resize(bgr, (W, H))
+        klass, _ = seg(small)
+        ground = roles[klass] == int(Role.GROUND)
+        masks, boxes, labels, scores = gsam(small)
+        cam = recon.cameras[img.camera_id]
+        C_local, RwcT = camera_local(img, gf)
+        dbg = small.copy() if ndbg < args.debug_frames else None
+
+        for mi in range(len(masks)):
+            mask = masks[mi]
+            if mask.sum() < args.min_mask_px:
+                continue
+            cx, cy = contact_columns(mask, ground, args.col_stride, args.ground_probe)
+            point_only = len(cx) < args.min_contacts
+            if point_only:                                # fall back to box bottom-centre
+                x0, y0, x1, y1 = boxes[mi]
+                cx = np.array([(x0 + x1) / 2], np.int64)
+                cy = np.array([min(y1, H - 3)], np.int64)
+            d_cam = pixel_dirs(cx.astype(np.float64), cy.astype(np.float64), cam, args.data_factor)
+            dir_local = (RwcT @ d_cam.T).T
+            hit_uv, ok = ray_dem_intersect(C_local, dir_local, gf, z_far=args.z_far,
+                                           dz=args.dz, max_range=args.max_range)
+            if not ok.any():
+                continue
+            hits = hit_uv[ok]
+            contact = np.array([np.median(hits[:, 0]), np.median(hits[:, 1])])
+            # bearing camera->contact, quantised: the viewpoint identity used to gate polygons
+            bear = np.degrees(np.arctan2(contact[1] - C_local[1], contact[0] - C_local[0]))
+            obs.append({
+                "frame": Path(img.name).stem, "label": labels[mi], "score": float(scores[mi]),
+                "contact": np.array([contact[0], contact[1],
+                                     float(gf.height_at(contact[None, :])[0])]),
+                "cells": np.unique(gf.cell_of(hits)) if not point_only else np.zeros(0, np.int64),
+                "bearing": int(bear // args.bearing_bin),
+                "point_only": bool(point_only),
+            })
+            if dbg is not None:
+                c = color_for(labels[mi])
+                dbg[mask] = (0.6 * dbg[mask] + 0.4 * np.array(c)).astype(np.uint8)
+                for x, y in zip(cx, cy):
+                    cv2.circle(dbg, (int(x), int(y)), 2, (0, 0, 255) if not point_only else (0, 200, 255), -1)
+                cv2.putText(dbg, labels[mi], (int(boxes[mi][0]), max(12, int(boxes[mi][1]) - 4)),
+                            cv2.FONT_HERSHEY_SIMPLEX, 0.5, c, 1)
+        if dbg is not None:
+            cv2.imwrite(str(out / f"frame_{ndbg}_{Path(img.name).stem}.png"), dbg)
+            ndbg += 1
+        if (fi + 1) % 10 == 0:
+            print(f"  {fi + 1}/{len(frames)}  observations={len(obs)}")
+
+    if not obs:
+        raise SystemExit("no instance observations -- lower --box-th or check the prompt")
+
+    # ---- fuse observations into instances ----
+    groups = cluster_observations(obs, lambda l: MERGE_RADIUS.get(l, args.merge_radius))
+    print(f"  {len(obs)} observations -> {len(groups)} raw clusters")
+
+    instances = []
+    for g in sorted(groups, key=len, reverse=True):
+        members = [obs[i] for i in g]
+        nviews = len({m["frame"] for m in members})
+        if nviews < args.min_views:                       # a one-frame blip is a false positive
+            continue
+        contacts = np.array([m["contact"] for m in members])
+        contact = np.median(contacts, axis=0)
+        votes: dict[int, set] = {}
+        for m in members:
+            for c in m["cells"]:
+                votes.setdefault(int(c), set()).add(m["bearing"])
+        nbear = len({m["bearing"] for m in members})
+        poly = polygon_of(votes, rows, cols, gf.spec,
+                          min(args.min_bearings, max(1, nbear)), args.close_k,
+                          contact, args.max_extent)
+        label = max(set(m["label"] for m in members), key=[m["label"] for m in members].count)
+        world = gf.R.T @ contact
+        instances.append({
+            "id": len(instances), "label": label,
+            "score": float(np.mean([m["score"] for m in members])),
+            "n_views": nviews, "n_obs": len(members),
+            "contact_local": [float(x) for x in contact],
+            "contact_world": [float(x) for x in world],
+            "area_m2": None if poly is None else round(poly[1], 2),
+            "polygon_local": None if poly is None else [[float(a), float(b)] for a, b in poly[0]],
+            "_mask": None if poly is None else poly[2],
+        })
+
+    print(f"  {len(instances)} instances (>= {args.min_views} views)")
+    by_label: dict[str, int] = {}
+    for it in instances:
+        by_label[it["label"]] = by_label.get(it["label"], 0) + 1
+    for k, v in sorted(by_label.items(), key=lambda kv: -kv[1]):
+        print(f"    {k:14s} {v}")
+    npoly = sum(1 for it in instances if it["polygon_local"])
+    print(f"  {npoly}/{len(instances)} have a footprint polygon "
+          f"(rest are point-only landmarks)")
+
+    _render(out, instances, gf)
+    ids = np.zeros((rows, cols), np.int32)
+    for it in instances:
+        if it["_mask"] is not None:
+            ids[it["_mask"] > 0] = it["id"] + 1
+    np.savez(out / "instances.npz", instance_ids=ids, dem=gf.dem, coverage=gf.coverage,
+             cell_size=args.cell_size, origin=[gf.spec.origin_u, gf.spec.origin_v])
+    for it in instances:
+        it.pop("_mask")
+    (out / "instances.json").write_text(json.dumps(
+        {"session": args.session, "cell_size": args.cell_size, "frames": len(frames),
+         "prompt": args.prompt, "instances": instances}, indent=1))
+    print(f"  wrote {out}/instances.json, instances.npz, instances_bev.png")
+
+
+def _render(out, instances, gf):
+    dem = gf.dem
+    gy, gx = np.gradient(dem)
+    hill = np.clip(0.5 + 0.5 * (-gx - gy) / (np.hypot(gx, gy).max() + 1e-6), 0, 1)
+    base = cv2.cvtColor((hill * 255).astype(np.uint8), cv2.COLOR_GRAY2BGR)
+    base = (0.55 * base + 60).astype(np.uint8)
+    S = 4
+    big = cv2.resize(np.flipud(base), None, fx=S, fy=S, interpolation=cv2.INTER_NEAREST)
+    rows = base.shape[0]
+
+    def to_px(u, v):
+        """local metres -> flipped, upscaled image pixel"""
+        cxp = (u - gf.spec.origin_u) / gf.spec.cell_size
+        cyp = (v - gf.spec.origin_v) / gf.spec.cell_size
+        return int(cxp * S), int((rows - 1 - cyp) * S)
+
+    for it in instances:
+        c = color_for(it["label"])
+        if it["polygon_local"]:
+            pts = np.array([to_px(u, v) for u, v in it["polygon_local"]], np.int32)
+            cv2.fillPoly(big, [pts], tuple(int(0.45 * x) for x in c))
+            cv2.polylines(big, [pts], True, c, 2)
+    for it in instances:
+        c = color_for(it["label"])
+        x, y = to_px(it["contact_local"][0], it["contact_local"][1])
+        cv2.circle(big, (x, y), 5, (255, 255, 255), -1)
+        cv2.circle(big, (x, y), 4, c, -1)
+        cv2.putText(big, f"{it['label'][:6]}{it['id']}", (x + 6, y - 4),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.35, (255, 255, 255), 1, cv2.LINE_AA)
+    cv2.imwrite(str(out / "instances_bev.png"), big)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default="maguro-park-after-itchy")
+    ap.add_argument("--model", default=None, help="COLMAP text model with TRACKS (raw)")
+    ap.add_argument("--images", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--num", type=int, default=40, help="frames to fuse")
+    ap.add_argument("--cell-size", type=float, default=0.5)
+    ap.add_argument("--data-factor", type=int, default=2)
+    # ground DEM (same contract as footprint2d)
+    ap.add_argument("--dem-source", default="mono", choices=["colmap", "mono"])
+    ap.add_argument("--depth-dir", default=None)
+    ap.add_argument("--depth-stride", type=int, default=8)
+    ap.add_argument("--depth-voxel", type=float, default=0.1)
+    ap.add_argument("--depth-max", type=float, default=40.0)
+    # detection / segmentation
+    ap.add_argument("--prompt", default=DEFAULT_PROMPT, help="open-vocab classes, '. '-separated")
+    ap.add_argument("--det-model", default="IDEA-Research/grounding-dino-tiny")
+    ap.add_argument("--sam-model", default="facebook/sam-vit-base")
+    ap.add_argument("--seg-model", default="facebook/mask2former-swin-large-ade-semantic")
+    ap.add_argument("--box-th", type=float, default=0.3)
+    ap.add_argument("--text-th", type=float, default=0.25)
+    ap.add_argument("--min-mask-px", type=int, default=400)
+    # ground contacts
+    ap.add_argument("--col-stride", type=int, default=4, help="column subsample within a mask")
+    ap.add_argument("--ground-probe", type=int, default=4,
+                    help="pixels below the mask that must be GROUND for a valid contact")
+    ap.add_argument("--min-contacts", type=int, default=4,
+                    help="valid contact columns needed for a polygon; below this -> point-only")
+    ap.add_argument("--z-far", type=float, default=70.0)
+    ap.add_argument("--dz", type=float, default=0.2)
+    ap.add_argument("--max-range", type=float, default=20.0)
+    # fusion
+    ap.add_argument("--merge-radius", type=float, default=DEFAULT_RADIUS,
+                    help="default same-object contact radius (m); per-class overrides in MERGE_RADIUS")
+    ap.add_argument("--min-views", type=int, default=3, help="views needed to keep an instance")
+    ap.add_argument("--min-bearings", type=int, default=2,
+                    help="distinct camera bearings that must vote a cell into the polygon")
+    ap.add_argument("--bearing-bin", type=float, default=20.0, help="bearing quantisation (deg)")
+    ap.add_argument("--max-extent", type=float, default=6.0,
+                    help="drop polygon cells beyond this radius from the contact (m); 0 = off")
+    ap.add_argument("--close-k", type=int, default=3, help="polygon morphological close (cells)")
+    ap.add_argument("--debug-frames", type=int, default=6)
+    run(ap.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/footprint_instances.py
+++ b/script/backbone/footprint_instances.py
@@ -19,6 +19,15 @@ Per frame:
   4. **Ray-DEM** those contact pixels (calibration + the gravity DEM, never mono depth at the
      object edge where it is worst) -> BEV cells = this object's ground extent in this frame.
      Too few valid contacts -> keep the object as a point-only landmark (box bottom-centre).
+  5. **Depth contact gate** (``--contact-depth-tol``). Step 3 is a *2D* test and cannot catch a
+     mask whose bottom abuts ground that is really far behind it -- a bench seat or canopy
+     silhouetted against open lawn passes the canopy guard, because the pixels below genuinely
+     are ground. So compare the measured mono depth at the contact against the range at which
+     that ray meets the DEM: if the object stands there they agree; if it floats, it is much
+     nearer than the ground its ray hits. Note this does not contradict step 4 -- mono depth is
+     never used to *place* the contact (it stays ray-DEM), only to *veto* one. A relative
+     comparison at a single pixel is what mono depth is reliable for; metric placement at an
+     object edge is what it is not.
 
 Across frames: union-find clusters observations by label + contact proximity, so the same tree
 seen from 12 views collapses to one instance and a one-frame false positive stays a singleton
@@ -53,7 +62,8 @@ from colmap_io import read_model                     # noqa: E402
 from geometry import from_reconstruction             # noqa: E402
 from taxonomy import Klass, Role, role_of            # noqa: E402
 from footprint2d import (                            # noqa: E402
-    SegKlass, camera_local, pixel_dirs, ray_dem_intersect, mono_dem_field, sample_frames,
+    MonoDepth, SegKlass, camera_local, depth_contact_gate, pixel_dirs, ray_dem_intersect,
+    mono_dem_field, sample_frames,
 )
 
 DEFAULT_PROMPT = "tree. bench. pole. sign. trash can. street lamp. rock. bush. fence."
@@ -242,12 +252,16 @@ def run(args):
 
     seg = SegKlass(args.seg_model, mode="semantic")
     gsam = GroundedSAM(args.det_model, args.sam_model, args.prompt, args.box_th, args.text_th)
+    # The semantic canopy guard in contact_columns is a 2D test and cannot tell a base from a
+    # silhouette against distant ground; depth_contact_gate settles it geometrically.
+    mono = MonoDepth(args.depth_model) if args.contact_depth_tol > 0 else None
     roles = np.array([int(role_of(int(k))) for k in range(int(max(Klass)) + 1)], np.uint8)
 
     frames = sample_frames(recon, args.num)
     print(f"  {len(frames)} frames, grid {cols}x{rows} @ {args.cell_size} m, prompt: {args.prompt}")
 
     obs, ndbg = [], 0
+    gate_pre = gate_post = 0
     for fi, img in enumerate(frames):
         bgr = cv2.imread(str(images_dir / img.name), cv2.IMREAD_COLOR)
         if bgr is None:
@@ -256,6 +270,7 @@ def run(args):
         small = cv2.resize(bgr, (W, H))
         klass, _ = seg(small)
         ground = roles[klass] == int(Role.GROUND)
+        dmap = mono.metric(bgr, recon, img, args.data_factor)[0] if mono is not None else None
         masks, boxes, labels, scores = gsam(small)
         cam = recon.cameras[img.camera_id]
         C_local, RwcT = camera_local(img, gf)
@@ -273,8 +288,11 @@ def run(args):
                 cy = np.array([min(y1, H - 3)], np.int64)
             d_cam = pixel_dirs(cx.astype(np.float64), cy.astype(np.float64), cam, args.data_factor)
             dir_local = (RwcT @ d_cam.T).T
-            hit_uv, ok = ray_dem_intersect(C_local, dir_local, gf, z_far=args.z_far,
-                                           dz=args.dz, max_range=args.max_range)
+            hit_uv, ok, zt = ray_dem_intersect(C_local, dir_local, gf, z_far=args.z_far,
+                                               dz=args.dz, max_range=args.max_range)
+            gate_pre += int(ok.sum())
+            ok = depth_contact_gate(dmap, cy, cx, zt, ok, args.contact_depth_tol)
+            gate_post += int(ok.sum())
             if not ok.any():
                 continue
             hits = hit_uv[ok]
@@ -360,6 +378,9 @@ def run(args):
     (out / "instances.json").write_text(json.dumps(
         {"session": args.session, "cell_size": args.cell_size, "frames": len(frames),
          "prompt": args.prompt, "instances": instances}, indent=1))
+    if args.contact_depth_tol > 0 and gate_pre:
+        print(f"  depth contact gate: {gate_pre} -> {gate_post} contacts "
+              f"({100*(1-gate_post/max(gate_pre,1)):.0f}% rejected as not touching ground in 3D)")
     print(f"  wrote {out}/instances.json, instances.npz, instances_bev.png")
 
 
@@ -420,6 +441,13 @@ def main():
     ap.add_argument("--min-mask-px", type=int, default=400)
     # ground contacts
     ap.add_argument("--col-stride", type=int, default=4, help="column subsample within a mask")
+    ap.add_argument("--contact-depth-tol", type=float, default=0.15,
+                    help="reject a contact when measured mono depth disagrees with the "
+                         "ray-DEM hit range by more than this FRACTION of the range. The "
+                         "3D counterpart to the 2D canopy guard. 0 disables (and skips "
+                         "loading the depth model).")
+    ap.add_argument("--depth-model", default="depth-anything/Depth-Anything-V2-Small-hf",
+                    help="mono depth model backing --contact-depth-tol")
     ap.add_argument("--ground-probe", type=int, default=4,
                     help="pixels below the mask that must be GROUND for a valid contact")
     ap.add_argument("--min-contacts", type=int, default=4,

--- a/script/backbone/footprint_instances.py
+++ b/script/backbone/footprint_instances.py
@@ -62,8 +62,8 @@ from colmap_io import read_model                     # noqa: E402
 from geometry import from_reconstruction             # noqa: E402
 from taxonomy import Klass, Role, role_of            # noqa: E402
 from footprint2d import (                            # noqa: E402
-    MonoDepth, SegKlass, camera_local, depth_contact_gate, pixel_dirs, ray_dem_intersect,
-    mono_dem_field, sample_frames,
+    GroundedSAM, MonoDepth, SegKlass, camera_local, depth_contact_gate, pixel_dirs,
+    ray_dem_intersect, mono_dem_field, sample_frames,
 )
 
 DEFAULT_PROMPT = "tree. bench. pole. sign. trash can. street lamp. rock. bush. fence."
@@ -86,49 +86,6 @@ def color_for(label: str) -> tuple[int, int, int]:
     if label in CLASS_COLORS:
         return CLASS_COLORS[label]
     return _FALLBACK[hash(label) % len(_FALLBACK)]
-
-
-# ---------------------------------------------------------------------------
-# open-vocabulary instances: Grounding DINO boxes -> SAM masks
-# ---------------------------------------------------------------------------
-class GroundedSAM:
-    """(masks, boxes, labels, scores) for one BGR image, all from cached weights."""
-
-    def __init__(self, det_model: str, sam_model: str, prompt: str,
-                 box_th: float, text_th: float, device: str | None = None):
-        import torch
-        from transformers import (AutoModelForZeroShotObjectDetection, AutoProcessor,
-                                  SamModel, SamProcessor)
-        self.torch = torch
-        self.prompt = prompt
-        self.box_th, self.text_th = box_th, text_th
-        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
-        self.dproc = AutoProcessor.from_pretrained(det_model)
-        self.det = AutoModelForZeroShotObjectDetection.from_pretrained(det_model).to(self.device).eval()
-        self.sproc = SamProcessor.from_pretrained(sam_model)
-        self.sam = SamModel.from_pretrained(sam_model).to(self.device).eval()
-
-    def __call__(self, bgr: np.ndarray):
-        from PIL import Image as PILImage
-        torch = self.torch
-        pil = PILImage.fromarray(cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB))
-        inp = self.dproc(images=pil, text=self.prompt, return_tensors="pt").to(self.device)
-        with torch.no_grad():
-            out = self.det(**inp)
-        res = self.dproc.post_process_grounded_object_detection(
-            out, inp.input_ids, threshold=self.box_th, text_threshold=self.text_th,
-            target_sizes=[bgr.shape[:2]])[0]
-        boxes = res["boxes"].cpu().numpy()
-        if not len(boxes):
-            return np.zeros((0, *bgr.shape[:2]), bool), boxes, [], np.zeros(0, np.float32)
-        labels = [str(x) for x in res.get("text_labels", res["labels"])]
-        scores = res["scores"].cpu().numpy().astype(np.float32)
-        si = self.sproc(pil, input_boxes=[boxes.tolist()], return_tensors="pt").to(self.device)
-        with torch.no_grad():
-            so = self.sam(**si, multimask_output=False)
-        masks = self.sproc.image_processor.post_process_masks(
-            so.pred_masks.cpu(), si["original_sizes"].cpu(), si["reshaped_input_sizes"].cpu())[0]
-        return masks[:, 0].numpy().astype(bool), boxes, labels, scores
 
 
 # ---------------------------------------------------------------------------

--- a/script/backbone/footprint_labels.py
+++ b/script/backbone/footprint_labels.py
@@ -134,7 +134,7 @@ class GroundMesh:
 
 
 def backproject_positions(recon, depth_dir: Path, image_ids, stride: int, voxel: float,
-                          log=print) -> np.ndarray:
+                          depth_max: float = 0.0, log=print) -> np.ndarray:
     """Fused world point cloud from per-view metric depth (positions only, voxel-deduped).
 
     Positions-only twin of ``depth_backproject.backproject_labeled_points`` — no MaskStore,
@@ -158,6 +158,8 @@ def backproject_positions(recon, depth_dir: Path, image_ids, stride: int, voxel:
         gx, gy = (a.ravel() for a in np.meshgrid(xs, ys))
         d = depth[gy, gx]
         ok = (d > 0) & np.isfinite(d)
+        if depth_max > 0:
+            ok &= d < depth_max          # far/sky mono depth explodes (1/(a·disp+b)); cull it
         if not ok.any():
             continue
         u, v, dd = gx[ok].astype(np.float32), gy[ok].astype(np.float32), d[ok]
@@ -378,6 +380,8 @@ def main() -> None:
     ap.add_argument("--depth-dir", help="per-view depth .npy dir (default: session.depth_dir('mono'))")
     ap.add_argument("--depth-stride", type=int, default=8, help="pixel stride when back-projecting depth")
     ap.add_argument("--depth-voxel", type=float, default=0.1, help="voxel size (m) for depth dedup")
+    ap.add_argument("--depth-max", type=float, default=40.0,
+                    help="drop mono-depth pixels beyond this range (m); far/sky depth explodes")
     ap.add_argument("--cell-size", type=float, default=0.5, help="DEM cell size (m)")
     ap.add_argument("--clearance-lo", type=float, default=0.4,
                     help="body-height band lower bound above ground (m)")
@@ -425,7 +429,7 @@ def main() -> None:
     if args.dem_source == "mono":
         print(f"DEM source: mono depth <- {depth_dir}")
         dem_world = backproject_positions(recon, depth_dir, list(recon.images),
-                                          args.depth_stride, args.depth_voxel)
+                                          args.depth_stride, args.depth_voxel, args.depth_max)
 
     mesh, occ_world = build_ground_mesh(
         recon, args.cell_size, (args.clearance_lo, args.clearance_hi),

--- a/script/backbone/footprint_labels.py
+++ b/script/backbone/footprint_labels.py
@@ -132,37 +132,91 @@ class GroundMesh:
         self.face_coverage = np.tile(f_cov, 2)                              # (F,)
 
 
-def build_ground_mesh(recon, cell_size: float, clearance: tuple[float, float],
-                      min_count: int, solid_gap: float, log=print
-                      ) -> tuple[GroundMesh, np.ndarray]:
-    """DEM mesh + body-height occluder cloud in one pass.
+def backproject_positions(recon, depth_dir: Path, image_ids, stride: int, voxel: float,
+                          log=print) -> np.ndarray:
+    """Fused world point cloud from per-view metric depth (positions only, voxel-deduped).
 
-    A cell is a **footprint** (occupied) only when it passes the same *solid-to-ground* test
-    the validated occupancy layer uses (`ground_model.build_level`): ≥ ``min_count`` obstacle
-    points AND their low (0.1) height-above-ground quantile ≤ ``solid_gap`` — i.e. the column
-    reaches down to the ground (trunk / wall / bush / building). Canopy overhanging an open
-    path floats above the gap, so the path stays walkable ground, not footprint. Without this
-    test every cell with a few stray body-height points reads as occupied and open paths turn
-    into solid footprint (the failure this fixes).
-
-    Occluders for the visible/hidden split are the body-height **band** points (they block the
-    camera's view of the ground whether or not they reach it — canopy included).
+    Positions-only twin of ``depth_backproject.backproject_labeled_points`` — no MaskStore,
+    since the DEM only needs geometry. Same depth-map contract: ``<stem>.npy`` float32 (H,W)
+    metric z-depth, intrinsics scaled to depth resolution.
     """
-    gf, local, hag, label = geometry.from_reconstruction(recon, cell_size=cell_size, log=log)
+    depth_dir = Path(depth_dir)
+    all_pos, n, raw = [], 0, 0
+    for img_id in image_ids:
+        im = recon.images[img_id]
+        dp = depth_dir / f"{Path(im.name).stem}.npy"
+        if not dp.exists():
+            continue
+        depth = np.load(dp).astype(np.float32)
+        h, w = depth.shape
+        cam = recon.cameras[im.camera_id]
+        fx, fy, cx, cy = pinhole_params(cam)
+        sx, sy = w / cam.width, h / cam.height           # scale intrinsics to depth res
+        fx, fy, cx, cy = fx * sx, fy * sy, cx * sx, cy * sy
+        ys, xs = np.arange(0, h, stride), np.arange(0, w, stride)
+        gx, gy = (a.ravel() for a in np.meshgrid(xs, ys))
+        d = depth[gy, gx]
+        ok = (d > 0) & np.isfinite(d)
+        if not ok.any():
+            continue
+        u, v, dd = gx[ok].astype(np.float32), gy[ok].astype(np.float32), d[ok]
+        cam_pts = np.stack([(u - cx) / fx * dd, (v - cy) / fy * dd, dd], axis=1)
+        R = qvec2rotmat(im.qvec)
+        world = cam_pts @ R + (-R.T @ im.tvec)           # world = R^T @ cam + C
+        all_pos.append(world.astype(np.float32))
+        n += 1
+        raw += len(world)
+    if not all_pos:
+        raise SystemExit(f"no depth maps found in {depth_dir}")
+    pos = np.concatenate(all_pos)
+    vox = np.floor(pos / voxel).astype(np.int64)
+    uniq, inv = np.unique(vox, axis=0, return_inverse=True)
+    sums = np.zeros((len(uniq), 3), np.float64)
+    np.add.at(sums, inv, pos)
+    positions = (sums / np.bincount(inv)[:, None]).astype(np.float32)
+    log(f"  mono depth: {raw} pts from {n} maps -> {len(positions)} voxels @ {voxel} m")
+    return positions
+
+
+def build_ground_mesh(recon, cell_size: float, clearance: tuple[float, float],
+                      min_count: int, solid_gap: float, *, dem_world: np.ndarray | None = None,
+                      log=print) -> tuple[GroundMesh, np.ndarray]:
+    """DEM mesh (from ``dem_world`` or COLMAP points) + COLMAP footprint/occluders.
+
+    The ground **surface** (DEM) can come from a denser source via ``dem_world`` (e.g. fused
+    mono depth) while the **footprint/occupancy stays on the sparse-but-accurate COLMAP
+    obstacle cloud** — the depth-bench hybrid verdict (mono's ~20% vertical noise scatters
+    canopy into the band and over-blocks; SfM is geometrically exact). Both share one gravity
+    frame derived from the cameras, so the mono DEM and the COLMAP footprint cells line up.
+
+    A cell is a **footprint** (occupied) only if it passes the *solid-to-ground* test the
+    validated occupancy layer uses (`ground_model.build_level`): ≥ ``min_count`` obstacle
+    points whose low (0.1) height-above-ground quantile ≤ ``solid_gap`` — the column reaches
+    the ground (trunk/wall/bush/building). Canopy over a path floats above the gap → the path
+    stays walkable ground. Occluders for the visible/hidden split are the body-height **band**
+    points (canopy over a path still occludes the ground below).
+    """
+    qvecs = np.array([im.qvec for im in recon.images.values()])
+    up = geometry.gravity_up(qvecs)
+    R = geometry.align_rotation(up)
+    log(f"gravity up = [{up[0]:+.4f} {up[1]:+.4f} {up[2]:+.4f}] (axis {int(np.argmax(np.abs(up)))})")
+
+    colmap_xyz = np.array([p.xyz for p in recon.points3d.values()])
+    dem_local = (colmap_xyz if dem_world is None else dem_world) @ R.T
+    gf = geometry.build_dem(dem_local[:, :2], dem_local[:, 2], R, up, cell_size=cell_size, log=log)
+
+    # footprint + occluders: COLMAP obstacle points classified against this DEM
+    colmap_local = colmap_xyz @ R.T
+    hag, label = geometry.classify_points(colmap_local[:, :2], colmap_local[:, 2], gf)
     ncells = gf.spec.rows * gf.spec.cols
-
-    # footprint: solid-to-ground obstacle cells
     obstacle = label == geometry.VERTICAL
-    o_cid = gf.cell_of(local[obstacle, :2])
-    base_hag, _ = geometry._cell_quantile(o_cid, hag[obstacle], ncells, 0.1, min_count)
+    base_hag, _ = geometry._cell_quantile(gf.cell_of(colmap_local[obstacle, :2]),
+                                          hag[obstacle], ncells, 0.1, min_count)
     footprint_cell = np.isfinite(base_hag) & (base_hag <= solid_gap)
-
-    # occluders: body-height band points (canopy over a path still occludes the ground)
     lo, hi = clearance
     band = (hag > lo) & (hag < hi)
-    occ_world = local[band] @ gf.R  # local_row @ R -> world
-
-    log(f"  obstacles {obstacle.sum()}, band {band.sum()} ({band.mean() * 100:.0f}% of cloud), "
+    occ_world = colmap_xyz[band]  # already world coords
+    log(f"  obstacles {int(obstacle.sum())}, band {int(band.sum())}, "
         f"footprint cells {int(footprint_cell.sum())} / {ncells}")
     return GroundMesh(gf, footprint_cell), occ_world
 
@@ -318,6 +372,11 @@ def main() -> None:
     ap.add_argument("--model", help="COLMAP text model dir (default: session.best_model())")
     ap.add_argument("--images", help="image dir (default: session.images)")
     ap.add_argument("--out", help="output dir (default: output/<session>-footprint)")
+    ap.add_argument("--dem-source", choices=["colmap", "mono"], default="colmap",
+                    help="ground DEM from COLMAP points (default) or fused mono depth (denser)")
+    ap.add_argument("--depth-dir", help="per-view depth .npy dir (default: session.depth_dir('mono'))")
+    ap.add_argument("--depth-stride", type=int, default=8, help="pixel stride when back-projecting depth")
+    ap.add_argument("--depth-voxel", type=float, default=0.1, help="voxel size (m) for depth dedup")
     ap.add_argument("--cell-size", type=float, default=0.5, help="DEM cell size (m)")
     ap.add_argument("--clearance-lo", type=float, default=0.4,
                     help="body-height band lower bound above ground (m)")
@@ -338,8 +397,8 @@ def main() -> None:
     ap.add_argument("--no-preview", action="store_true", help="skip RGB preview blends")
     args = ap.parse_args()
 
-    if args.session:
-        s = Session(args.session)
+    s = Session(args.session) if args.session else None
+    if s:
         model = Path(args.model) if args.model else s.best_model()
         images = Path(args.images) if args.images else s.images
         out = Path(args.out) if args.out else s.root / "output" / f"{s.name}-footprint"
@@ -347,6 +406,12 @@ def main() -> None:
         if not (args.model and args.images and args.out):
             ap.error("without --session, pass --model, --images and --out")
         model, images, out = Path(args.model), Path(args.images), Path(args.out)
+
+    depth_dir = None
+    if args.dem_source == "mono":
+        depth_dir = Path(args.depth_dir) if args.depth_dir else (s.depth_dir("mono") if s else None)
+        if depth_dir is None:
+            ap.error("--dem-source mono needs --depth-dir (or --session)")
     out.mkdir(parents=True, exist_ok=True)
 
     print(f"model  : {model}")
@@ -355,9 +420,15 @@ def main() -> None:
     recon = read_model(str(model))
     print(f"loaded {len(recon.images)} images, {recon.num_points} points")
 
+    dem_world = None
+    if args.dem_source == "mono":
+        print(f"DEM source: mono depth <- {depth_dir}")
+        dem_world = backproject_positions(recon, depth_dir, list(recon.images),
+                                          args.depth_stride, args.depth_voxel)
+
     mesh, occ_world = build_ground_mesh(
         recon, args.cell_size, (args.clearance_lo, args.clearance_hi),
-        args.min_count, args.solid_gap)
+        args.min_count, args.solid_gap, dem_world=dem_world)
     print(f"mesh: {len(mesh.verts_world)} verts, {len(mesh.faces)} faces, "
           f"{len(occ_world)} occluder points")
 
@@ -397,7 +468,7 @@ def main() -> None:
 
     meta = {
         "classes": {i: n for i, n in enumerate(CLASS_NAMES)},
-        "cell_size": args.cell_size, "render_size": args.size,
+        "dem_source": args.dem_source, "cell_size": args.cell_size, "render_size": args.size,
         "clearance_band": [args.clearance_lo, args.clearance_hi], "min_count": args.min_count,
         "solid_gap": args.solid_gap,
         "max_range": args.max_range, "occ_margin": args.occ_margin,

--- a/script/backbone/footprint_labels.py
+++ b/script/backbone/footprint_labels.py
@@ -100,6 +100,7 @@ class GroundMesh:
     """
 
     def __init__(self, gf: geometry.GroundField, footprint_cell: np.ndarray):
+        self.gf = gf  # kept so downstream (base_points.py) can reuse the DEM/grid + gravity R
         spec, dem = gf.spec, gf.dem
         rows, cols, cs = spec.rows, spec.cols, spec.cell_size
         # vertex grid at cell centres, local (gravity-aligned) frame

--- a/script/backbone/footprint_labels.py
+++ b/script/backbone/footprint_labels.py
@@ -1,0 +1,413 @@
+"""Footprint / free-space supervision generator for a per-frame ground head.
+
+Produces the training targets a *footprint / free-space* head (à la Niantic's
+"Footprints and Free Space from a Single Color Image", CVPR 2020) needs on top of the
+frozen LingBot backbone — the one signal plain semantic segmentation can't give you:
+**where the ground continues *behind* objects**, and **which ground cells an object's
+footprint occupies**. That's exactly what tells the BEV projector which pixels map onto
+the ground plane (incl. hidden ground) and which map onto occupied area.
+
+Why this is cheaper/cleaner than Niantic's method:
+Niantic had no global model, so they *manufactured* hidden-ground labels by projecting the
+ground observed in neighbouring frames into the target view. We already reconstruct a
+gravity-aligned **global ground DEM** (`geometry.from_reconstruction`) that aggregates every
+frame's ground. Rendering that DEM into a target camera yields the full ground extent —
+visible *and* occluded — in one shot, with far less noise than pairwise reprojection. The
+neighbour-frame trick is subsumed by "render the global DEM".
+
+Per target frame we emit, at a downscaled render resolution:
+  - `<stem>.png`        uint8 class map, one of:
+        0 NON_GROUND      (sky / above / unobserved)
+        1 VISIBLE_GROUND  (ground directly visible — project it)
+        2 HIDDEN_GROUND   (traversable ground occluded by an object — project it too)
+        3 FOOTPRINT       (ground cell occupied by a vertical object — its contact/occupied area)
+        4 OBJECT          (the occluder body standing above the ground)
+  - `<stem>_depth.npy`  float32 metric depth from the camera to the DEM ground surface,
+                        valid wherever the ground extent is (visible|hidden|footprint) —
+                        the Niantic "depth to (hidden) ground" regression target.
+  - `<stem>_cover.npy`  float32 in {0,1}: was the ground cell DEM-*observed* (trust) vs
+                        extrapolated — use as a per-pixel loss weight.
+  - `<stem>_preview.png` RGB blended with the colourised class map (eyeball check).
+
+Geometry-only for now (footprint is class-agnostic): the *what-class* layer (tree / building
+/ wall / furniture per footprint cell, "occupied areas WITH semantic labels") drops in next by
+voting each VERTICAL point's class from the cached Mask2Former masks — see FOOTPRINT-SEMANTICS
+hook below.
+
+Run (from repo root):
+  uv run python script/backbone/footprint_labels.py --session maguro-park-after-itchy --limit 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# --- make sibling script packages importable (geometry, colmap_io, lar_session) ---
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+
+import geometry  # noqa: E402
+from colmap_io import qvec2rotmat, read_model  # noqa: E402
+from lar_session import Session  # noqa: E402
+
+# class ids (keep in sync with the module docstring / meta.json legend)
+NON_GROUND, VISIBLE_GROUND, HIDDEN_GROUND, FOOTPRINT, OBJECT = 0, 1, 2, 3, 4
+CLASS_NAMES = ["non_ground", "visible_ground", "hidden_ground", "footprint", "object"]
+# BGR palette for previews
+PALETTE = np.array([
+    [0, 0, 0],        # non_ground   black
+    [80, 200, 80],    # visible      green
+    [40, 120, 220],   # hidden       orange
+    [40, 40, 220],    # footprint    red
+    [200, 200, 60],   # object       cyan-ish
+], dtype=np.uint8)
+
+
+# --------------------------------------------------------------------------- #
+# intrinsics
+# --------------------------------------------------------------------------- #
+def pinhole_params(cam) -> tuple[float, float, float, float]:
+    """(fx, fy, cx, cy) from a PINHOLE / SIMPLE_PINHOLE / SIMPLE_RADIAL camera.
+
+    Distortion (SIMPLE_RADIAL's k) is ignored — the DEM render only needs the pinhole
+    part, and these ARKit-derived cameras are near-pinhole after undistortion.
+    """
+    p = cam.params
+    if cam.model == "PINHOLE":
+        return float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    if cam.model in ("SIMPLE_PINHOLE", "SIMPLE_RADIAL", "RADIAL"):
+        return float(p[0]), float(p[0]), float(p[1]), float(p[2])
+    raise ValueError(f"camera model {cam.model!r} not supported")
+
+
+# --------------------------------------------------------------------------- #
+# ground mesh (built once from the DEM, reused for every frame)
+# --------------------------------------------------------------------------- #
+class GroundMesh:
+    """The DEM as a triangle mesh of world-space vertices + per-face attributes.
+
+    Vertices sit at cell centres of the gravity-aligned DEM; two triangles per cell quad.
+    ``footprint`` / ``coverage`` are per-face booleans so a rasterised pixel resolves
+    straight to "is this ground under an object?" / "was this ground observed?".
+    """
+
+    def __init__(self, gf: geometry.GroundField, footprint_cell: np.ndarray):
+        spec, dem = gf.spec, gf.dem
+        rows, cols, cs = spec.rows, spec.cols, spec.cell_size
+        # vertex grid at cell centres, local (gravity-aligned) frame
+        cc, rr = np.meshgrid(np.arange(cols), np.arange(rows))
+        u = spec.origin_u + (cc + 0.5) * cs
+        v = spec.origin_v + (rr + 0.5) * cs
+        vert_local = np.stack([u.ravel(), v.ravel(), dem.ravel()], axis=1)  # (V,3)
+        # local -> world: world_row = local_row @ R  (R maps world->local, orthonormal)
+        self.verts_world = vert_local @ gf.R                                 # (V,3)
+
+        cov = gf.coverage.ravel()
+        foot = footprint_cell.reshape(rows, cols)
+        # two triangles per quad (r,c)-(r+1,c+1); vertex index = r*cols + c
+        r0, c0 = np.meshgrid(np.arange(rows - 1), np.arange(cols - 1), indexing="ij")
+        r0, c0 = r0.ravel(), c0.ravel()
+        i00 = r0 * cols + c0
+        i01 = r0 * cols + (c0 + 1)
+        i10 = (r0 + 1) * cols + c0
+        i11 = (r0 + 1) * cols + (c0 + 1)
+        faces = np.concatenate([
+            np.stack([i00, i01, i11], axis=1),
+            np.stack([i00, i11, i10], axis=1),
+        ], axis=0)
+        self.faces = faces                                                  # (F,3)
+        # per-face attrs, indexed by the quad's min corner cell (r0,c0)
+        quad_cell = r0 * cols + c0
+        f_foot = foot.ravel()[quad_cell]
+        f_cov = cov[quad_cell]
+        self.face_footprint = np.tile(f_foot, 2)                            # (F,)
+        self.face_coverage = np.tile(f_cov, 2)                              # (F,)
+
+
+def build_ground_mesh(recon, cell_size: float, clearance: tuple[float, float],
+                      min_count: int, solid_gap: float, log=print
+                      ) -> tuple[GroundMesh, np.ndarray]:
+    """DEM mesh + body-height occluder cloud in one pass.
+
+    A cell is a **footprint** (occupied) only when it passes the same *solid-to-ground* test
+    the validated occupancy layer uses (`ground_model.build_level`): ≥ ``min_count`` obstacle
+    points AND their low (0.1) height-above-ground quantile ≤ ``solid_gap`` — i.e. the column
+    reaches down to the ground (trunk / wall / bush / building). Canopy overhanging an open
+    path floats above the gap, so the path stays walkable ground, not footprint. Without this
+    test every cell with a few stray body-height points reads as occupied and open paths turn
+    into solid footprint (the failure this fixes).
+
+    Occluders for the visible/hidden split are the body-height **band** points (they block the
+    camera's view of the ground whether or not they reach it — canopy included).
+    """
+    gf, local, hag, label = geometry.from_reconstruction(recon, cell_size=cell_size, log=log)
+    ncells = gf.spec.rows * gf.spec.cols
+
+    # footprint: solid-to-ground obstacle cells
+    obstacle = label == geometry.VERTICAL
+    o_cid = gf.cell_of(local[obstacle, :2])
+    base_hag, _ = geometry._cell_quantile(o_cid, hag[obstacle], ncells, 0.1, min_count)
+    footprint_cell = np.isfinite(base_hag) & (base_hag <= solid_gap)
+
+    # occluders: body-height band points (canopy over a path still occludes the ground)
+    lo, hi = clearance
+    band = (hag > lo) & (hag < hi)
+    occ_world = local[band] @ gf.R  # local_row @ R -> world
+
+    log(f"  obstacles {obstacle.sum()}, band {band.sum()} ({band.mean() * 100:.0f}% of cloud), "
+        f"footprint cells {int(footprint_cell.sum())} / {ncells}")
+    return GroundMesh(gf, footprint_cell), occ_world
+
+
+# --------------------------------------------------------------------------- #
+# projection + rasterisation
+# --------------------------------------------------------------------------- #
+def project(world: np.ndarray, R_wc: np.ndarray, tvec: np.ndarray,
+            fx, fy, cx, cy) -> tuple[np.ndarray, np.ndarray]:
+    """world (N,3) -> pixel (N,2) + camera-space depth z (N,). Mirrors dense_projection."""
+    cam = world @ R_wc.T + tvec
+    z = cam[:, 2]
+    px = np.full(len(z), -1.0)
+    py = np.full(len(z), -1.0)
+    front = z > 1e-6
+    px[front] = fx * cam[front, 0] / z[front] + cx
+    py[front] = fy * cam[front, 1] / z[front] + cy
+    return np.stack([px, py], axis=1), z
+
+
+def rasterize(verts_px: np.ndarray, verts_z: np.ndarray, faces: np.ndarray,
+              h: int, w: int) -> tuple[np.ndarray, np.ndarray]:
+    """Z-buffer a triangle mesh -> (depth[h,w] float32, face_id[h,w] int32, -1 empty).
+
+    Plain per-face barycentric fill over the face's pixel bounding box. Face count is
+    already culled to the frustum+range slice, so the python loop stays small.
+    """
+    zbuf = np.full((h, w), np.inf, np.float32)
+    fbuf = np.full((h, w), -1, np.int32)
+    for fi in range(len(faces)):
+        a, b, c = faces[fi]
+        pa, pb, pc = verts_px[a], verts_px[b], verts_px[c]
+        za, zb, zc = verts_z[a], verts_z[b], verts_z[c]
+        minx = max(int(np.floor(min(pa[0], pb[0], pc[0]))), 0)
+        maxx = min(int(np.ceil(max(pa[0], pb[0], pc[0]))), w - 1)
+        miny = max(int(np.floor(min(pa[1], pb[1], pc[1]))), 0)
+        maxy = min(int(np.ceil(max(pa[1], pb[1], pc[1]))), h - 1)
+        if maxx < minx or maxy < miny:
+            continue
+        denom = (pb[1] - pc[1]) * (pa[0] - pc[0]) + (pc[0] - pb[0]) * (pa[1] - pc[1])
+        if abs(denom) < 1e-9:
+            continue
+        gx, gy = np.meshgrid(np.arange(minx, maxx + 1), np.arange(miny, maxy + 1))
+        w0 = ((pb[1] - pc[1]) * (gx - pc[0]) + (pc[0] - pb[0]) * (gy - pc[1])) / denom
+        w1 = ((pc[1] - pa[1]) * (gx - pc[0]) + (pa[0] - pc[0]) * (gy - pc[1])) / denom
+        w2 = 1.0 - w0 - w1
+        inside = (w0 >= 0) & (w1 >= 0) & (w2 >= 0)
+        if not inside.any():
+            continue
+        z = w0 * za + w1 * zb + w2 * zc
+        sub_z = zbuf[miny:maxy + 1, minx:maxx + 1]
+        sub_f = fbuf[miny:maxy + 1, minx:maxx + 1]
+        m = inside & (z < sub_z)
+        sub_z[m] = z[m]
+        sub_f[m] = fi
+    return zbuf, fbuf
+
+
+def splat_occluders(px: np.ndarray, py: np.ndarray, z: np.ndarray,
+                    h: int, w: int, radius: int) -> np.ndarray:
+    """Nearest-depth buffer of the (sparse) vertical points, dilated by ``radius`` px.
+
+    A min-filter (cv2.erode on depth) grows each point into a small disk so the sparse
+    SfM occluders form connected blobs to test ground pixels against.
+    """
+    BIG = np.float32(1e9)
+    buf = np.full(h * w, BIG, np.float32)
+    ix = np.round(px).astype(np.int64)
+    iy = np.round(py).astype(np.int64)
+    ok = (ix >= 0) & (ix < w) & (iy >= 0) & (iy < h) & (z > 1e-6)
+    np.minimum.at(buf, iy[ok] * w + ix[ok], z[ok].astype(np.float32))
+    buf = buf.reshape(h, w)
+    if radius > 0:
+        k = 2 * radius + 1
+        buf = cv2.erode(buf, np.ones((k, k), np.uint8))  # grayscale erode = local min
+    return buf
+
+
+# --------------------------------------------------------------------------- #
+# per-frame label assembly
+# --------------------------------------------------------------------------- #
+def make_frame_labels(mesh: GroundMesh, occ_world: np.ndarray, im, cam,
+                      render_size: int, max_range: float, occ_margin: float,
+                      splat_radius: int) -> dict | None:
+    """Render the DEM (+ occluders) into one frame -> class map, ground depth, coverage."""
+    scale = render_size / max(cam.width, cam.height)
+    w = int(round(cam.width * scale))
+    h = int(round(cam.height * scale))
+    fx, fy, cx, cy = (v * scale for v in pinhole_params(cam))
+    R_wc = qvec2rotmat(im.qvec)
+    tvec = im.tvec
+
+    verts_px, verts_z = project(mesh.verts_world, R_wc, tvec, fx, fy, cx, cy)
+
+    # cull faces: all 3 verts in front, and the face's nearest vertex within range
+    fz = verts_z[mesh.faces]                      # (F,3)
+    keep = (fz > 1e-6).all(axis=1) & (fz.min(axis=1) < max_range)
+    if not keep.any():
+        return None
+    kept = np.flatnonzero(keep)
+    ground_depth, fbuf = rasterize(verts_px, verts_z, mesh.faces[kept], h, w)
+
+    # occluder depth from the band points, culled to render range (far points can't
+    # meaningfully occlude the ground we actually render)
+    opx, oz = project(occ_world, R_wc, tvec, fx, fy, cx, cy)
+    near = oz < max_range
+    obj_depth = splat_occluders(opx[near, 0], opx[near, 1], oz[near], h, w, splat_radius)
+
+    ground = np.isfinite(ground_depth)
+    face_at = fbuf.copy()
+    face_at[~ground] = -1
+    is_foot = np.zeros((h, w), bool)
+    cover = np.zeros((h, w), np.float32)
+    valid = face_at >= 0
+    if valid.any():
+        # map rasterised local-face-index -> global face index -> attrs
+        gfi = kept[face_at[valid]]
+        is_foot[valid] = mesh.face_footprint[gfi]
+        cover[valid] = mesh.face_coverage[gfi].astype(np.float32)
+
+    has_occ = obj_depth < 1e8
+    occluded = ground & has_occ & (obj_depth < ground_depth - occ_margin)
+
+    # A pixel that visually shows an occluder but has DEM ground behind it is labelled by that
+    # ground (HIDDEN, or FOOTPRINT if the cell is occupied) — the Niantic "predict the ground
+    # behind the object" target. OBJECT is reserved for occluders standing over sky (above the
+    # horizon), i.e. structure that is genuinely not ground.
+    label = np.full((h, w), NON_GROUND, np.uint8)
+    label[ground] = VISIBLE_GROUND
+    label[occluded] = HIDDEN_GROUND
+    label[ground & is_foot] = FOOTPRINT           # ground-under-object = the contact/occupied area
+    label[has_occ & ~ground] = OBJECT             # occluder over sky = above-horizon structure
+
+    depth_out = np.where(ground, ground_depth, np.nan).astype(np.float32)
+    return {"label": label, "depth": depth_out, "cover": cover, "size": (w, h)}
+
+
+def colourise(label: np.ndarray, rgb: np.ndarray | None) -> np.ndarray:
+    vis = PALETTE[label]
+    if rgb is not None:
+        rgb = cv2.resize(rgb, (label.shape[1], label.shape[0]))
+        vis = cv2.addWeighted(rgb, 0.5, vis, 0.5, 0)
+    return vis
+
+
+# --------------------------------------------------------------------------- #
+# driver
+# --------------------------------------------------------------------------- #
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session")
+    ap.add_argument("--model", help="COLMAP text model dir (default: session.best_model())")
+    ap.add_argument("--images", help="image dir (default: session.images)")
+    ap.add_argument("--out", help="output dir (default: output/<session>-footprint)")
+    ap.add_argument("--cell-size", type=float, default=0.5, help="DEM cell size (m)")
+    ap.add_argument("--clearance-lo", type=float, default=0.4,
+                    help="body-height band lower bound above ground (m)")
+    ap.add_argument("--clearance-hi", type=float, default=2.0,
+                    help="body-height band upper bound above ground (m); canopy above is ignored")
+    ap.add_argument("--min-count", type=int, default=3,
+                    help="min obstacle points in a cell to call it a footprint")
+    ap.add_argument("--solid-gap", type=float, default=0.8,
+                    help="max low-quantile height-above-ground for a footprint (solid-to-ground test)")
+    ap.add_argument("--size", type=int, default=512, help="render long-side resolution")
+    ap.add_argument("--max-range", type=float, default=30.0, help="cull ground beyond this (m)")
+    ap.add_argument("--occ-margin", type=float, default=0.5,
+                    help="depth margin (m) for an occluder to count as in-front of ground")
+    ap.add_argument("--splat-radius", type=int, default=2, help="occluder splat radius (px)")
+    ap.add_argument("--limit", type=int, default=0, help="process only the first N frames (0=all)")
+    ap.add_argument("--sample", type=int, default=0,
+                    help="process N frames spaced evenly across the capture (overrides --limit)")
+    ap.add_argument("--no-preview", action="store_true", help="skip RGB preview blends")
+    args = ap.parse_args()
+
+    if args.session:
+        s = Session(args.session)
+        model = Path(args.model) if args.model else s.best_model()
+        images = Path(args.images) if args.images else s.images
+        out = Path(args.out) if args.out else s.root / "output" / f"{s.name}-footprint"
+    else:
+        if not (args.model and args.images and args.out):
+            ap.error("without --session, pass --model, --images and --out")
+        model, images, out = Path(args.model), Path(args.images), Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"model  : {model}")
+    print(f"images : {images}")
+    print(f"out    : {out}")
+    recon = read_model(str(model))
+    print(f"loaded {len(recon.images)} images, {recon.num_points} points")
+
+    mesh, occ_world = build_ground_mesh(
+        recon, args.cell_size, (args.clearance_lo, args.clearance_hi),
+        args.min_count, args.solid_gap)
+    print(f"mesh: {len(mesh.verts_world)} verts, {len(mesh.faces)} faces, "
+          f"{len(occ_world)} occluder points")
+
+    ims = sorted(recon.images.values(), key=lambda im: im.name)
+    if args.sample and args.sample < len(ims):
+        idx = np.linspace(0, len(ims) - 1, args.sample).round().astype(int)
+        ims = [ims[i] for i in idx]
+    elif args.limit:
+        ims = ims[: args.limit]
+
+    counts = np.zeros(len(CLASS_NAMES), np.int64)
+    done = skipped = 0
+    for im in ims:
+        cam = recon.cameras[im.camera_id]
+        res = make_frame_labels(mesh, occ_world, im, cam, args.size,
+                                args.max_range, args.occ_margin, args.splat_radius)
+        if res is None:
+            skipped += 1
+            continue
+        stem = Path(im.name).stem
+        cv2.imwrite(str(out / f"{stem}.png"), res["label"])
+        np.save(out / f"{stem}_depth.npy", res["depth"])
+        np.save(out / f"{stem}_cover.npy", res["cover"])
+        if not args.no_preview:
+            rgb = cv2.imread(str(images / im.name))
+            cv2.imwrite(str(out / f"{stem}_preview.png"), colourise(res["label"], rgb))
+        counts += np.bincount(res["label"].ravel(), minlength=len(CLASS_NAMES))
+        done += 1
+        if done % 25 == 0:
+            print(f"  {done}/{len(ims)}")
+
+    total = counts.sum()
+    print(f"\nwrote {done} frames ({skipped} skipped, no ground in view) -> {out}")
+    if total:
+        for name, c in zip(CLASS_NAMES, counts):
+            print(f"  {name:14s} {c / total * 100:5.1f}%")
+
+    meta = {
+        "classes": {i: n for i, n in enumerate(CLASS_NAMES)},
+        "cell_size": args.cell_size, "render_size": args.size,
+        "clearance_band": [args.clearance_lo, args.clearance_hi], "min_count": args.min_count,
+        "solid_gap": args.solid_gap,
+        "max_range": args.max_range, "occ_margin": args.occ_margin,
+        "splat_radius": args.splat_radius, "frames": done,
+        "note": "FOOTPRINT-SEMANTICS hook: vote each VERTICAL point's Mask2Former class "
+                "(MaskStore) to give footprint cells a class id.",
+    }
+    (out / "meta.json").write_text(json.dumps(meta, indent=2))
+    print(f"wrote {out / 'meta.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/ground_head.py
+++ b/script/backbone/ground_head.py
@@ -1,0 +1,281 @@
+"""Train a walkable-SURFACE head on the frozen LingBot backbone.
+
+Complements `footprint_head.py`, which learns ground *geometry* (free / hidden / footprint)
+from DEM renders. This learns what the ground *is* — path, grass, dirt, stairs, water — the
+distinction the BEV surface map needs and the one the current stack is measurably worst at.
+
+**Why it exists.** Mask2Former labels this park's lawn `earth`, not `grass` (26.5% vs 11.5% of
+pixels), and its GRASS IoU against ADE ground truth is **9.2** — near useless. A frozen-LingBot
+linear probe scored **7.8** on the same class, so neither model is usable for the ground split
+today. Two independent reasons to own this head rather than distil the teacher:
+
+  * measured: LingBot + a linear head already *beats* Mask2Former on FURNITURE (24.6 vs 9.0),
+    so distillation would import the teacher's blind spots (see `ade20k_eval.py`);
+  * licensing: Mask2Former's **weights are CC-BY-NC** (its repo LICENSE is MIT, which covers
+    code only — MODEL_ZOO.md states the NC term for every checkpoint). It cannot ship.
+
+The backbone stays frozen and Apache-licensed; only this small MLP trains.
+
+**Why the earlier probe scored 7.8, and what is different here.** That was a *linear* head over
+all 14 classes with 120 training images and no class balancing — and GRASS is rare, so a
+frequency-weighted loss simply ignores it. This narrows the problem to the ground split, uses
+an MLP, trains on far more data, and weights classes by inverse-sqrt frequency so the rare
+surface classes survive the loss.
+
+**Licensing of the supervision matters more than usual here.** ADE20K *images* are not clear
+for training a shipped model — they are fine to evaluate against. So `--data ade20k` exists to
+validate the approach and to produce comparable numbers, and any checkpoint it yields is
+research-only. A shippable head wants GOOSE (CC-BY-SA, and its `low_grass`/`high_grass`/
+`gravel`/`soil`/`asphalt` classes are a far better fit for a park than ADE's coarse
+`earth`/`grass` split) plus hand labels from `relabel.py` on our own frames. The loaders are
+kept behind `--data` so swapping the corpus does not touch the model code.
+
+Run (from repo root):
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/ground_head.py --data ade20k --train-num 800 --val-num 200
+  # then look at what it does on real park frames, which is the actual target domain:
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/ground_head.py --predict-session maguro-park-after-itchy \
+      --head output/ground-head/ground_head.pt --predict-num 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_HERE))
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+
+from taxonomy import Klass  # noqa: E402
+from ade20k_eval import (  # noqa: E402
+    _ADE_KLASS, ade_root, feature_grid, list_split, load_backbone, load_class_names,
+    patch_labels, resize_label,
+)
+
+# Ground split. Deliberately NOT the full 14-class taxonomy: the question is what a walkable
+# cell is made of, and collapsing everything else into one NOT_GROUND class stops the head
+# spending capacity on distinctions the BEV surface map never reads.
+NOT_GROUND, G_PATH, G_GRASS, G_TERRAIN, G_STAIRS, G_WATER = range(6)
+GNAMES = ["not-ground", "path/paved", "grass", "terrain/dirt", "stairs", "water"]
+GCOLORS = np.array([(40, 40, 44), (238, 220, 170), (104, 176, 92),
+                    (168, 142, 108), (206, 150, 210), (86, 140, 200)], np.uint8)
+
+# our Klass -> ground class
+KLASS_TO_GROUND = {
+    int(Klass.PATH): G_PATH, int(Klass.PAVEMENT): G_PATH,
+    int(Klass.GRASS): G_GRASS, int(Klass.TERRAIN): G_TERRAIN,
+    int(Klass.STAIRS): G_STAIRS, int(Klass.WATER): G_WATER,
+}
+
+
+def ade_ground_lut(names: list[str]) -> np.ndarray:
+    """ADE id -> ground class, via the hand-written ADE table (never keyword matching)."""
+    lut = np.zeros(151, np.uint8)
+    for i, k in _ADE_KLASS.items():
+        lut[i] = KLASS_TO_GROUND.get(int(k), NOT_GROUND)
+    return lut
+
+
+class GroundHead(torch.nn.Module):
+    """Small MLP on frozen patch tokens. Kept tiny on purpose — if this cannot separate grass
+    from dirt, the fault is in the features or the labels, not in head capacity."""
+
+    def __init__(self, dim: int, hidden: int, n_cls: int = 6):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(dim, hidden), torch.nn.GELU(),
+            torch.nn.Dropout(0.1),
+            torch.nn.Linear(hidden, hidden // 2), torch.nn.GELU(),
+            torch.nn.Linear(hidden // 2, n_cls),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+def iou_table(inter, union, tag):
+    valid = union > 0
+    ious = inter / np.maximum(union, 1e-9)
+    miou = float(ious[valid].mean()) if valid.any() else 0.0
+    print(f"\n[{tag}]  mIoU {miou * 100:.1f}")
+    for i in np.argsort(-union):
+        if union[i] <= 0:
+            continue
+        print(f"    {GNAMES[i]:<14s} IoU {ious[i] * 100:5.1f}   support {int(union[i]):>10d}")
+    return miou, {GNAMES[i]: float(ious[i]) for i in range(len(GNAMES)) if union[i] > 0}
+
+
+def accumulate(pred, gt, inter, union):
+    for k in range(len(GNAMES)):
+        p, g = pred == k, gt == k
+        inter[k] += np.logical_and(p, g).sum()
+        union[k] += np.logical_or(p, g).sum()
+
+
+def train(args):
+    base = ade_root(Path(args.root).expanduser())
+    lut = ade_ground_lut(load_class_names(base))
+    backbone, dim, device, dtype = load_backbone(args.variant)
+    tr = list_split(base, "training", args.train_num, seed=0)
+    va = list_split(base, "validation", args.val_num, seed=1)
+    print(f"[ground_head] {len(tr)} train / {len(va)} val  dim={dim} device={device}")
+
+    X, Y = [], []
+    for i, (ip, ap) in enumerate(tr):
+        f, rgb, (h, w) = feature_grid(backbone, ip, args.size, args.mode, device, dtype)
+        gt = lut[resize_label(cv2.imread(str(ap), cv2.IMREAD_GRAYSCALE), rgb.shape)]
+        X.append(f.reshape(-1, dim)); Y.append(patch_labels(gt, h, w, len(GNAMES)))
+        if (i + 1) % 100 == 0:
+            print(f"  features {i + 1}/{len(tr)}")
+    X = np.concatenate(X); Y = np.concatenate(Y)
+    cnt = np.bincount(Y, minlength=len(GNAMES))
+    print("  patches: " + ", ".join(f"{n}:{c}" for n, c in zip(GNAMES, cnt)))
+
+    mu, sd = X.mean(0), X.std(0) + 1e-6
+    Xt = torch.tensor((X - mu) / sd, dtype=torch.float32)
+    Yt = torch.tensor(Y)
+
+    # Inverse-sqrt frequency. Plain inverse frequency swings too hard on classes with a few
+    # hundred patches and the head starts hallucinating them everywhere; unweighted, the rare
+    # surface classes are simply ignored -- which is how the earlier probe scored 7.8 on grass.
+    wt = torch.tensor((cnt.sum() / np.maximum(cnt, 1)) ** 0.5, dtype=torch.float32)
+    wt = (wt / wt.mean()).to(device)
+    print("  class weights: " + ", ".join(f"{n}:{w:.2f}" for n, w in zip(GNAMES, wt.tolist())))
+
+    head = GroundHead(dim, args.hidden).to(device)
+    opt = torch.optim.AdamW(head.parameters(), lr=args.lr, weight_decay=1e-4)
+    sched = torch.optim.lr_scheduler.CosineAnnealingLR(opt, args.steps)
+    lossf = torch.nn.CrossEntropyLoss(weight=wt)
+    n = len(Xt)
+    head.train()
+    for step in range(args.steps):
+        idx = torch.randint(0, n, (min(args.batch, n),))
+        xb, yb = Xt[idx].to(device), Yt[idx].to(device)
+        opt.zero_grad()
+        loss = lossf(head(xb), yb)
+        loss.backward(); opt.step(); sched.step()
+        if (step + 1) % max(1, args.steps // 6) == 0:
+            print(f"  step {step + 1}/{args.steps} loss={loss.item():.4f}")
+    head.eval()
+
+    hi, hu = np.zeros(len(GNAMES)), np.zeros(len(GNAMES))
+    ti, tu = np.zeros(len(GNAMES)), np.zeros(len(GNAMES))
+    seg = None
+    if not args.no_teacher:
+        from segmentation import make_segmenter
+        seg = make_segmenter(args.teacher)
+    for i, (ip, ap) in enumerate(va):
+        f, rgb, (h, w) = feature_grid(backbone, ip, args.size, args.mode, device, dtype)
+        gt = lut[resize_label(cv2.imread(str(ap), cv2.IMREAD_GRAYSCALE), rgb.shape)]
+        with torch.no_grad():
+            xv = torch.tensor((f.reshape(-1, dim) - mu) / sd, dtype=torch.float32, device=device)
+            pp = head(xv).argmax(1).cpu().numpy().reshape(h, w).astype(np.uint8)
+        pred = cv2.resize(pp, (rgb.shape[1], rgb.shape[0]), interpolation=cv2.INTER_NEAREST)
+        accumulate(pred.ravel(), gt.ravel(), hi, hu)
+        if seg is not None:
+            tk = seg.segment(cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR))
+            tg = np.vectorize(lambda k: KLASS_TO_GROUND.get(int(k), NOT_GROUND))(tk).astype(np.uint8)
+            accumulate(tg.ravel(), gt.ravel(), ti, tu)
+        if (i + 1) % 50 == 0:
+            print(f"  val {i + 1}/{len(va)}")
+
+    hm, hres = iou_table(hi, hu, f"LingBot-{args.variant} + ground MLP  vs GT")
+    res = {"head": hres}
+    if seg is not None:
+        tm, tres = iou_table(ti, tu, f"{args.teacher} (CC-BY-NC, cannot ship)  vs GT")
+        res["teacher"] = tres
+        g_h, g_t = hres.get("grass", 0) * 100, tres.get("grass", 0) * 100
+        print(f"\n  GRASS IoU: head {g_h:.1f} vs teacher {g_t:.1f}  ({g_h - g_t:+.1f})")
+        print(f"  mIoU     : head {hm * 100:.1f} vs teacher {tm * 100:.1f}")
+
+    out = Path(args.out or (_SCRIPT_ROOT.parent / "output" / "ground-head"))
+    out.mkdir(parents=True, exist_ok=True)
+    torch.save({"state": head.state_dict(), "mu": mu, "sd": sd, "dim": dim,
+                "hidden": args.hidden, "variant": args.variant, "size": args.size,
+                "mode": args.mode, "names": GNAMES,
+                "provenance": "trained on ADE20K images — research/validation only, not shippable"},
+               out / "ground_head.pt")
+    (out / "ground_head.json").write_text(json.dumps({"config": vars(args), "results": res},
+                                                     indent=2, default=str))
+    print(f"\n  wrote {out}/ground_head.pt (+ .json)")
+
+
+def predict(args):
+    """Run a trained head on real park frames — the target domain, where the teacher fails."""
+    from lar_session import Session
+    from colmap_io import read_model
+    from footprint2d import sample_frames
+
+    ck = torch.load(args.head, map_location="cpu", weights_only=False)
+    backbone, dim, device, dtype = load_backbone(ck["variant"])
+    head = GroundHead(dim, ck["hidden"]).to(device)
+    head.load_state_dict(ck["state"]); head.eval()
+    mu, sd = ck["mu"], ck["sd"]
+
+    s = Session(args.predict_session)
+    frames = sample_frames(read_model(str(s.colmap_model)), args.predict_num)
+    out = Path(args.out or (_SCRIPT_ROOT.parent / "output" / "ground-head")) / "park"
+    out.mkdir(parents=True, exist_ok=True)
+    tally = np.zeros(len(GNAMES), np.int64)
+    for img in frames:
+        p = s.images / img.name
+        f, rgb, (h, w) = feature_grid(backbone, p, ck["size"], ck["mode"], device, dtype)
+        with torch.no_grad():
+            xv = torch.tensor((f.reshape(-1, dim) - mu) / sd, dtype=torch.float32, device=device)
+            pp = head(xv).argmax(1).cpu().numpy().reshape(h, w).astype(np.uint8)
+        pred = cv2.resize(pp, (rgb.shape[1], rgb.shape[0]), interpolation=cv2.INTER_NEAREST)
+        tally += np.bincount(pred.ravel(), minlength=len(GNAMES))
+        col = GCOLORS[pred]
+        blend = (0.45 * rgb + 0.55 * col).astype(np.uint8)
+        cv2.imwrite(str(out / f"{Path(img.name).stem}_ground.png"),
+                    np.hstack([rgb, blend])[:, :, ::-1])
+    tot = max(tally.sum(), 1)
+    print(f"[ground_head] {len(frames)} park frames ->  " +
+          ", ".join(f"{n} {100 * c / tot:.1f}%" for n, c in zip(GNAMES, tally) if c))
+    print(f"  wrote {out}/*_ground.png")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--data", default="ade20k", choices=["ade20k"],
+                    help="supervision corpus. ADE20K validates the approach but its images are "
+                         "not clear for a shipped model; GOOSE + relabel.py labels come next.")
+    ap.add_argument("--root", default="/home/play/Code/datasets/ade20k")
+    ap.add_argument("--variant", default="small")
+    ap.add_argument("--size", type=int, default=512)
+    ap.add_argument("--mode", default="square", choices=["square", "shortest"])
+    ap.add_argument("--train-num", type=int, default=800)
+    ap.add_argument("--val-num", type=int, default=200)
+    ap.add_argument("--steps", type=int, default=3000)
+    ap.add_argument("--batch", type=int, default=32768)
+    ap.add_argument("--lr", type=float, default=2e-3)
+    ap.add_argument("--hidden", type=int, default=512)
+    ap.add_argument("--teacher", default="mask2former-large",
+                    help="segmenter kind for the baseline column (make_segmenter names, not "
+                         "HF paths). CC-BY-NC weights: comparison only, never shipped.")
+    ap.add_argument("--no-teacher", action="store_true")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--head", default=None, help="checkpoint for --predict-session")
+    ap.add_argument("--predict-session", default=None)
+    ap.add_argument("--predict-num", type=int, default=8)
+    args = ap.parse_args()
+    if args.predict_session:
+        if not args.head:
+            raise SystemExit("--predict-session needs --head")
+        predict(args)
+    else:
+        train(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/probe.py
+++ b/script/backbone/probe.py
@@ -1,0 +1,419 @@
+"""Probe the LingBot-Vision ViT backbone on park frames.
+
+Two questions, two tasks:
+
+  pca      — are the frozen patch features spatially meaningful? PCA the tokens to
+             3 channels (shared basis across frames) and render RGB | feature-PCA.
+             The fast "are these worth building on" eyeball test.
+
+  linprobe — do the frozen features *linearly* separate OUR park taxonomy? Train a
+             single linear layer (patch feature -> Klass) on Mask2Former pseudo-labels
+             (no manual labels), evaluate held-out mIoU, and render pred vs pseudo.
+             If a linear head already works, a real custom head is cheap.
+
+Backbone: robbyant/lingbot-vision (Apache-2.0 code + weights). Frozen, eval-only.
+
+Optionally feature-upsample the frozen tokens with AnyUp (wimmerth/anyup,
+CC-BY-4.0) before probing — a feature-agnostic, post-hoc upsampler that sharpens
+the coarse patch-16 grid to object boundaries without touching the backbone.
+Add ``--upsample anyup [--variant large] [--up-size 128]``.
+
+Run (from repo root):
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/probe.py pca      --session maguro-park-after-itchy --num 6
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/probe.py linprobe --session maguro-park-after-itchy --num 24
+  # AnyUp-upsampled large backbone:
+  uv run --extra segmentation --with omegaconf --with /home/play/Code/lingbot-vision \
+    python script/backbone/probe.py linprobe --variant large --upsample anyup --up-size 128
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+# --- make sibling script packages importable (taxonomy, segmentation, lar_session) ---
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+
+from lar_session import Session  # noqa: E402
+from lingbot_vision import extract_patch_tokens, load_image, load_pretrained_backbone  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# shared: load backbone + sample frames + extract a feature grid per frame
+# ---------------------------------------------------------------------------
+def sample_frames(session: Session, num: int) -> list[Path]:
+    paths = sorted(session.images.glob("*_image.jpeg"))
+    if not paths:
+        raise SystemExit(f"no *_image.jpeg under {session.images}")
+    idx = np.linspace(0, len(paths) - 1, num).round().astype(int)
+    return [paths[i] for i in idx]
+
+
+# DINOv2 (facebookresearch/dinov2, Apache-2.0). Same ImageNet normalization and
+# the same "x_norm_patchtokens" key as LingBot, so it drops into feature_grid
+# behind the ``kind`` dispatch below. patch_size=14 (vs LingBot's 16).
+_DINOV2_HUB = {
+    "small": "dinov2_vits14", "base": "dinov2_vitb14",
+    "large": "dinov2_vitl14", "giant": "dinov2_vitg14",
+}
+
+
+def load_backbone(variant: str, kind: str = "lingbot"):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16 if device == "cuda" else torch.float32
+    if kind == "lingbot":
+        backbone, embed_dim = load_pretrained_backbone(variant=variant, device=device, dtype=dtype)
+    elif kind == "dinov2":
+        backbone = torch.hub.load("facebookresearch/dinov2", _DINOV2_HUB[variant], verbose=False)
+        backbone = backbone.to(device).to(dtype).eval()
+        for p in backbone.parameters():
+            p.requires_grad_(False)
+        embed_dim = backbone.embed_dim
+    else:
+        raise ValueError(f"unknown backbone kind: {kind!r}")
+    if device == "cuda":
+        torch.cuda.reset_peak_memory_stats()
+    return backbone, embed_dim, device, dtype
+
+
+@torch.no_grad()
+def extract_tokens(backbone, img_norm, device: str, dtype, kind: str):
+    """Backbone-agnostic patch tokens: (tokens [B,N,C], (h,w)).
+
+    LingBot exposes them via ``extract_patch_tokens``; DINOv2 via
+    ``forward_features(...)['x_norm_patchtokens']``. Both consume the same
+    ImageNet-normalized batch and return the same grid convention.
+    """
+    if kind == "lingbot":
+        return extract_patch_tokens(backbone, img_norm, device, dtype)
+    x = img_norm.to(device).to(dtype)
+    ps = backbone.patch_size
+    _, _, H, W = x.shape
+    h, w = H // ps, W // ps
+    use_ac = device.startswith("cuda") and dtype != torch.float32
+    with torch.autocast(device_type="cuda", dtype=dtype, enabled=use_ac):
+        out = backbone.forward_features(x)
+    return out["x_norm_patchtokens"], (h, w)
+
+
+# --- AnyUp feature upsampler (wimmerth/anyup, CC-BY-4.0) -------------------
+# Feature-agnostic: consumes any encoder's low-res token grid + the guidance
+# image and produces edge-aligned high-res features WITHOUT touching the frozen
+# backbone. Applied post-hoc, so it composes with the linprobe head unchanged.
+_ANYUP_CACHE = {}
+
+
+def load_anyup(ckpt: str, src: str, device: str):
+    """Lazily build the AnyUp upsampler (frozen, eval). Cached per checkpoint.
+
+    ckpt='multi' -> anyup_multi_backbone, trained on several backbones; best
+    generalization to an unseen encoder like LingBot-Vision. ckpt='paper' was
+    trained on DINOv2-S only. Weights auto-download to the torch hub cache.
+    """
+    key = (ckpt, src, device)
+    if key in _ANYUP_CACHE:
+        return _ANYUP_CACHE[key]
+    if src and src not in sys.path:
+        sys.path.insert(0, src)
+    from anyup.model import AnyUp  # noqa: E402
+    urls = {
+        "multi": "https://github.com/wimmerth/anyup/releases/download/checkpoint_v2/anyup_multi_backbone.pth",
+        "paper": "https://github.com/wimmerth/anyup/releases/download/checkpoint/anyup_paper.pth",
+    }
+    model = AnyUp().to(device).eval()
+    sd = torch.hub.load_state_dict_from_url(urls[ckpt], map_location=device, progress=True)
+    model.load_state_dict(sd)
+    _ANYUP_CACHE[key] = model
+    return model
+
+
+def report_vram(tag: str, device: str):
+    if device == "cuda":
+        peak = torch.cuda.max_memory_allocated() / 1e9
+        print(f"[{tag}] peak VRAM = {peak:.2f} GB")
+
+
+@torch.no_grad()
+def feature_grid(backbone, path: Path, size: int, mode: str, device: str, dtype,
+                 upsampler=None, up_size: int = 0, kind: str = "lingbot"):
+    """Return (feat [G,G,C] float32, rgb [H,W,3] uint8, (G,G)).
+
+    Native grid is (h,w) = size/patch_size. With an AnyUp ``upsampler`` the
+    frozen tokens are feature-upsampled to (up_size, up_size), guided by the
+    same ImageNet-normalized image the backbone saw.
+    """
+    img_norm, rgb, _ = load_image(str(path), size=size, patch_size=backbone.patch_size, mode=mode)
+    tokens, (h, w) = extract_tokens(backbone, img_norm, device, dtype, kind)
+    if upsampler is None:
+        feat = tokens[0].float().cpu().numpy().reshape(h, w, -1)
+        return feat, rgb, (h, w)
+    lr = tokens[0].float().reshape(1, h, w, -1).permute(0, 3, 1, 2).contiguous()  # [1,C,h,w]
+    guide = img_norm.to(device).float()
+    hr = upsampler(guide, lr, output_size=(up_size, up_size), q_chunk_size=256)  # [1,C,up,up]
+    feat = hr[0].permute(1, 2, 0).float().cpu().numpy()  # [up,up,C]
+    return feat, rgb, (up_size, up_size)
+
+
+def _upsample(grid: np.ndarray, size: int, interp=cv2.INTER_NEAREST) -> np.ndarray:
+    return cv2.resize(grid, (size, size), interpolation=interp)
+
+
+def _tag(args) -> str:
+    """Output-filename suffix so baseline and AnyUp runs don't overwrite."""
+    return "" if args.upsample == "none" else f"_{args.upsample}{args.up_size}"
+
+
+def _bb(args) -> str:
+    """Backbone prefix for output names; empty for the default (lingbot)."""
+    return "" if args.backbone == "lingbot" else f"{args.backbone}_"
+
+
+# ---------------------------------------------------------------------------
+# task: pca
+# ---------------------------------------------------------------------------
+def robust_norm(x: np.ndarray, lo=2.0, hi=98.0) -> np.ndarray:
+    a, b = np.percentile(x, lo), np.percentile(x, hi)
+    return np.clip((x - a) / (b - a + 1e-8), 0, 1)
+
+
+def run_pca(args):
+    backbone, embed_dim, device, dtype = load_backbone(args.variant, args.backbone)
+    up = load_anyup(args.anyup_ckpt, args.anyup_src, device) if args.upsample == "anyup" else None
+    up_size = args.up_size if up is not None else 0
+    frames = sample_frames(Session(args.session), args.num)
+    print(f"[pca] backbone={args.backbone} variant={args.variant} embed_dim={embed_dim} "
+          f"frames={len(frames)} size={args.size} upsample={args.upsample}"
+          + (f" up_size={up_size}" if up else ""))
+
+    feats, rgbs, grids = [], [], []
+    for p in frames:
+        f, rgb, hw = feature_grid(backbone, p, args.size, args.mode, device, dtype, up, up_size, args.backbone)
+        feats.append(f); rgbs.append(rgb); grids.append(hw)
+
+    # shared PCA basis across every patch of every frame -> consistent colours
+    stack = np.concatenate([f.reshape(-1, embed_dim) for f in feats], axis=0)
+    mean = stack.mean(0, keepdims=True)
+    _, _, vt = np.linalg.svd(stack - mean, full_matrices=False)
+    basis = vt[:3]  # (3, C)
+
+    proj_all = (stack - mean) @ basis.T
+    lo = np.percentile(proj_all, 2, axis=0)
+    hi = np.percentile(proj_all, 98, axis=0)
+
+    tiles = []
+    for f, rgb, (h, w) in zip(feats, rgbs, grids):
+        proj = (f.reshape(-1, embed_dim) - mean) @ basis.T
+        proj = np.clip((proj - lo) / (hi - lo + 1e-8), 0, 1).reshape(h, w, 3)
+        pca_img = _upsample((proj * 255).astype(np.uint8), rgb.shape[0], cv2.INTER_NEAREST)
+        row = np.concatenate([rgb, pca_img], axis=1)  # RGB | PCA
+        tiles.append(row)
+
+    sheet = np.concatenate(tiles, axis=0)
+    out = Path(args.out or (Session(args.session).root / "output" / f"{args.session}-backbone"))
+    out.mkdir(parents=True, exist_ok=True)
+    dst = out / f"pca_{_bb(args)}{args.variant}{_tag(args)}.png"
+    cv2.imwrite(str(dst), cv2.cvtColor(sheet, cv2.COLOR_RGB2BGR))
+    print(f"[pca] wrote {dst}  (left=RGB, right=feature-PCA; shared basis)")
+
+
+# ---------------------------------------------------------------------------
+# task: linprobe  (frozen features -> linear layer -> our Klass, vs Mask2Former)
+# ---------------------------------------------------------------------------
+def patch_labels(mask_hw: np.ndarray, h: int, w: int) -> np.ndarray:
+    """Majority Klass per patch block -> (h*w,) int."""
+    H, W = mask_hw.shape
+    ph, pw = H // h, W // w
+    out = np.empty(h * w, dtype=np.int64)
+    k = 0
+    for i in range(h):
+        for j in range(w):
+            block = mask_hw[i * ph:(i + 1) * ph, j * pw:(j + 1) * pw].ravel()
+            out[k] = np.bincount(block).argmax()
+            k += 1
+    return out
+
+
+def run_linprobe(args):
+    from taxonomy import Klass, color_lut
+    from segmentation import make_segmenter
+
+    backbone, embed_dim, device, dtype = load_backbone(args.variant, args.backbone)
+    up = load_anyup(args.anyup_ckpt, args.anyup_src, device) if args.upsample == "anyup" else None
+    up_size = args.up_size if up is not None else 0
+    seg = make_segmenter("mask2former-large")
+    frames = sample_frames(Session(args.session), args.num)
+    n_val = max(1, int(round(len(frames) * args.val_frac)))
+    val_set = set(frames[-n_val:])
+    print(f"[linprobe] backbone={args.backbone} variant={args.variant} embed_dim={embed_dim} "
+          f"frames={len(frames)} (val={n_val}) size={args.size} upsample={args.upsample}"
+          + (f" up_size={up_size}" if up else ""))
+
+    Xtr, ytr, val = [], [], []  # val: list of (feat[G,G,C], pseudo(G*G), rgb, (G,G))
+    for p in frames:
+        f, rgb, (h, w) = feature_grid(backbone, p, args.size, args.mode, device, dtype, up, up_size, args.backbone)
+        # Segment the exact image the backbone saw (snapped size) so M2F pseudo-labels
+        # and features align — patch-14 backbones snap 512->504, patch-16 stay at 512.
+        bgr = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+        y = patch_labels(seg.segment(bgr), h, w)
+        if p in val_set:
+            val.append((f, y, rgb, (h, w)))
+        else:
+            Xtr.append(f.reshape(-1, embed_dim)); ytr.append(y)
+
+    Xtr = np.concatenate(Xtr); ytr = np.concatenate(ytr)
+    keep = ytr != int(Klass.UNKNOWN)              # don't train on "nothing"
+    Xtr, ytr = Xtr[keep], ytr[keep]
+    n_klass = int(max(Klass)) + 1
+
+    # standardise on train stats
+    mu, sd = Xtr.mean(0), Xtr.std(0) + 1e-6
+    Xn = torch.tensor((Xtr - mu) / sd, dtype=torch.float32, device=device)
+    yn = torch.tensor(ytr, device=device)
+
+    head = torch.nn.Linear(embed_dim, n_klass).to(device)
+    opt = torch.optim.Adam(head.parameters(), lr=1e-2, weight_decay=1e-4)
+    lossf = torch.nn.CrossEntropyLoss()
+    head.train()
+    for step in range(args.steps):
+        opt.zero_grad()
+        loss = lossf(head(Xn), yn)
+        loss.backward(); opt.step()
+        if (step + 1) % max(1, args.steps // 5) == 0:
+            print(f"  step {step+1}/{args.steps}  loss={loss.item():.3f}")
+    head.eval()
+
+    # evaluate held-out mIoU + render
+    lut = np.array(color_lut(), dtype=np.uint8)
+    inter = np.zeros(n_klass); union = np.zeros(n_klass); correct = total = 0
+    tiles = []
+    for f, y, rgb, (h, w) in val:
+        Xv = torch.tensor((f.reshape(-1, embed_dim) - mu) / sd, dtype=torch.float32, device=device)
+        with torch.no_grad():
+            pred = head(Xv).argmax(1).cpu().numpy()
+        m = y != int(Klass.UNKNOWN)
+        correct += int((pred[m] == y[m]).sum()); total += int(m.sum())
+        for c in range(n_klass):
+            pc, yc = pred == c, y == c
+            inter[c] += int((pc & yc).sum()); union[c] += int((pc | yc).sum())
+        pred_img = _upsample(lut[pred.reshape(h, w)], rgb.shape[0], cv2.INTER_NEAREST)
+        pseudo_img = _upsample(lut[y.reshape(h, w)], rgb.shape[0], cv2.INTER_NEAREST)
+        tiles.append(np.concatenate([rgb, pseudo_img, pred_img], axis=1))  # RGB | M2F | linear
+
+    iou = inter / np.maximum(union, 1)
+    present = union > 0
+    print(f"\n[linprobe] val patch-acc = {correct/max(total,1):.3f}   "
+          f"mIoU(present) = {iou[present].mean():.3f}")
+    print("  per-class IoU (present classes):")
+    for c in np.where(present)[0]:
+        print(f"    {Klass(c).name:10s} {iou[c]:.3f}")
+
+    out = Path(args.out or (Session(args.session).root / "output" / f"{args.session}-backbone"))
+    out.mkdir(parents=True, exist_ok=True)
+    dst = out / f"linprobe_{_bb(args)}{args.variant}{_tag(args)}.png"
+    cv2.imwrite(str(dst), cv2.cvtColor(np.concatenate(tiles, 0), cv2.COLOR_RGB2BGR))
+    print(f"[linprobe] wrote {dst}  (left=RGB, mid=Mask2Former pseudo-label, right=linear head)")
+    report_vram("linprobe", device)
+
+    if args.save_head:
+        sp = Path(args.save_head)
+        sp.parent.mkdir(parents=True, exist_ok=True)
+        # Everything LingBotSegmenter needs to reproduce this head at inference.
+        torch.save({
+            "head": {k: v.cpu() for k, v in head.state_dict().items()},
+            "mu": mu, "sd": sd,
+            "backbone": args.backbone,
+            "variant": args.variant, "embed_dim": embed_dim, "n_klass": n_klass,
+            "size": args.size, "mode": args.mode,
+            "upsample": args.upsample, "up_size": up_size,
+            "anyup_ckpt": args.anyup_ckpt, "anyup_src": args.anyup_src,
+        }, sp)
+        print(f"[linprobe] saved head -> {sp}")
+
+
+# ---------------------------------------------------------------------------
+# task: segment  (drive make_segmenter("lingbot") end-to-end from a saved head)
+# ---------------------------------------------------------------------------
+def run_segment(args):
+    from taxonomy import color_lut
+    from segmentation import make_segmenter
+
+    seg = make_segmenter("lingbot", ckpt=args.head)
+    ref = make_segmenter("mask2former-large") if args.ref else None
+    frames = sample_frames(Session(args.session), args.num)
+    lut = np.array(color_lut(), dtype=np.uint8)
+    print(f"[segment] head={args.head} frames={len(frames)} size={args.size} ref={bool(ref)}")
+
+    tiles = []
+    for p in frames:
+        bgr = cv2.resize(cv2.imread(str(p)), (args.size, args.size))
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+        row = [rgb]
+        if ref is not None:
+            row.append(lut[ref.segment(bgr)])
+        row.append(lut[seg.segment(bgr)])
+        tiles.append(np.concatenate(row, axis=1))  # RGB | [M2F] | lingbot
+
+    out = Path(args.out or (Session(args.session).root / "output" / f"{args.session}-backbone"))
+    out.mkdir(parents=True, exist_ok=True)
+    dst = out / "segment_lingbot.png"
+    cv2.imwrite(str(dst), cv2.cvtColor(np.concatenate(tiles, 0), cv2.COLOR_RGB2BGR))
+    cols = "RGB | Mask2Former | lingbot" if ref is not None else "RGB | lingbot"
+    print(f"[segment] wrote {dst}  ({cols})")
+
+
+# ---------------------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="task", required=True)
+
+    def common(p):
+        p.add_argument("--session", default="maguro-park-after-itchy")
+        p.add_argument("--backbone", default="lingbot", choices=["lingbot", "dinov2"],
+                       help="frozen feature source: lingbot (patch-16) or dinov2 (patch-14)")
+        p.add_argument("--variant", default="small", help="small/base/large/giant")
+        p.add_argument("--size", type=int, default=512)
+        p.add_argument("--mode", default="square", choices=["square", "shortest"])
+        p.add_argument("--out", default=None)
+        p.add_argument("--upsample", default="none", choices=["none", "anyup"],
+                       help="feature upsampler applied to frozen tokens before probing")
+        p.add_argument("--up-size", type=int, default=128,
+                       help="AnyUp target grid (square); larger = crisper but more VRAM/RAM")
+        p.add_argument("--anyup-ckpt", default="multi", choices=["multi", "paper"],
+                       help="multi = anyup_multi_backbone (best for unseen backbones)")
+        p.add_argument("--anyup-src", default="/home/play/Code/anyup",
+                       help="path to cloned wimmerth/anyup repo (added to sys.path)")
+
+    p_pca = sub.add_parser("pca"); common(p_pca)
+    p_pca.add_argument("--num", type=int, default=6)
+
+    p_lin = sub.add_parser("linprobe"); common(p_lin)
+    p_lin.add_argument("--num", type=int, default=24)
+    p_lin.add_argument("--val-frac", type=float, default=0.3)
+    p_lin.add_argument("--steps", type=int, default=300)
+    p_lin.add_argument("--save-head", default=None,
+                       help="save trained head + config to this path for make_segmenter('lingbot')")
+
+    p_seg = sub.add_parser("segment")
+    p_seg.add_argument("--session", default="maguro-park-after-itchy")
+    p_seg.add_argument("--head", required=True, help="checkpoint from linprobe --save-head")
+    p_seg.add_argument("--size", type=int, default=512)
+    p_seg.add_argument("--num", type=int, default=6)
+    p_seg.add_argument("--ref", action="store_true", help="also render a Mask2Former column")
+    p_seg.add_argument("--out", default=None)
+
+    args = ap.parse_args()
+    {"pca": run_pca, "linprobe": run_linprobe, "segment": run_segment}[args.task](args)
+
+
+if __name__ == "__main__":
+    main()

--- a/script/backbone/relabel.py
+++ b/script/backbone/relabel.py
@@ -1,0 +1,514 @@
+"""BEV relabeler — hand-correct footprint2d output + place semantic ground-contact keypoints.
+
+`footprint2d.py` fuses per-frame seg+depth into a BEV raster of ground states
+(FREE / FOOTPRINT / HIDDEN / UNKNOWN) plus a per-cell obstacle class. It gets the broad
+structure right and the *edges* wrong: footprint boundaries bleed where the bottom-most
+obstacle pixel is a shadow or a leaf, HIDDEN over/under-claims, and thin structures
+(fences, hedges) come out speckled.
+
+Fixing that in image space would mean painting 970 frames. Fixing it **in BEV means
+painting once** — the park is one 201x230 grid — and every frame that sees a cell inherits
+the correction when the raster is rendered back into that camera (the same DEM->camera
+rasterisation `footprint_labels.py` already does). That asymmetry is the whole point of
+editing here rather than per-frame.
+
+Two annotation products come out:
+
+  1. **corrected rasters** — `state` (ground state) and `structure` (per-cell class),
+     same grid, same dtype as the input npz. Dense supervision for a ground/footprint head.
+  2. **semantic ground-contact keypoints** — sparse (class, u, v) points marking where a
+     discrete object actually meets the ground. This is the signal `base_points.py`
+     triangulates for; hand-placed points are the ground truth to *score* it against, and
+     the target for a contact-point head on frozen LingBot features.
+
+Run (from repo root):
+  uv run --extra segmentation python script/backbone/relabel.py \
+      --npz output/maguro-park-after-itchy-footprint2d-mono2/footprint2d.npz
+
+then open the printed URL. Edits save next to the npz as `relabel.npz` + `keypoints.json`;
+the original is never overwritten. Re-running picks up where you left off.
+
+GRID REGISTRATION CAVEAT: footprint2d's npz stores `cell_size` but not the DEM origin, so
+the edits are registered to *that grid*, not to world coordinates. Consumers must rebuild
+the GroundField with the same session/cell-size/dem-source (deterministic) and apply the
+edits cell-wise. Adding `origin_u`/`origin_v` to footprint2d's `np.savez` would make this
+self-describing; keypoints then carry true world (u, v).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import io
+import json
+import sys
+import webbrowser
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import numpy as np
+
+_HERE = Path(__file__).resolve().parent
+_SCRIPT_ROOT = _HERE.parent
+sys.path.insert(0, str(_SCRIPT_ROOT))
+sys.path.insert(0, str(_SCRIPT_ROOT / "semantic_bev"))
+
+from taxonomy import Klass, color_lut  # noqa: E402
+
+UNKNOWN, FREE, FOOTPRINT, HIDDEN = 0, 1, 2, 3
+STATE_NAMES = ["UNKNOWN", "FREE", "FOOTPRINT", "HIDDEN"]
+STATE_COLORS = [(35, 35, 35), (60, 170, 60), (220, 40, 40), (230, 200, 60)]  # RGB
+
+
+def hillshade(dem: np.ndarray, coverage: np.ndarray) -> np.ndarray:
+    """Grey relief of the DEM so the editor has real terrain context under the labels.
+
+    Uncovered cells (no DEM support) render near-black, which is itself information: it
+    shows where the raster is extrapolated guesswork rather than observed ground.
+    """
+    d = np.where(np.isfinite(dem), dem, np.nan)
+    gy, gx = np.gradient(np.nan_to_num(d, nan=float(np.nanmedian(d)) if np.isfinite(d).any() else 0.0))
+    shade = np.clip(0.5 + 1.6 * (gx + gy), 0.0, 1.0)
+    lo, hi = (np.nanpercentile(d, [2, 98]) if np.isfinite(d).any() else (0.0, 1.0))
+    height = np.clip((np.nan_to_num(d, nan=lo) - lo) / max(hi - lo, 1e-6), 0.0, 1.0)
+    v = (0.35 + 0.45 * height) * (0.55 + 0.45 * shade)
+    v = np.where(coverage, v, v * 0.25)
+    g = (np.clip(v, 0, 1) * 255).astype(np.uint8)
+    return np.dstack([g, g, g])
+
+
+def png_b64(rgb: np.ndarray) -> str:
+    """Encode HxWx3 uint8 to a data URI. Prefers cv2, falls back to a raw-zlib PNG writer."""
+    try:
+        import cv2
+
+        ok, buf = cv2.imencode(".png", rgb[:, :, ::-1])
+        if ok:
+            return "data:image/png;base64," + base64.b64encode(buf.tobytes()).decode()
+    except Exception:
+        pass
+    import struct
+    import zlib
+
+    h, w, _ = rgb.shape
+    raw = b"".join(b"\x00" + rgb[y].tobytes() for y in range(h))
+
+    def chunk(tag, data):
+        c = struct.pack(">I", len(data)) + tag + data
+        return c + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    png = (b"\x89PNG\r\n\x1a\n"
+           + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+           + chunk(b"IDAT", zlib.compress(raw, 6))
+           + chunk(b"IEND", b""))
+    return "data:image/png;base64," + base64.b64encode(png).decode()
+
+
+class Store:
+    """Holds the grids and owns persistence. Original npz is read-only."""
+
+    def __init__(self, npz_path: Path, out_dir: Path | None):
+        self.npz_path = npz_path
+        z = np.load(npz_path)
+        self.state0 = z["state"].astype(np.uint8)
+        self.struct0 = z["structure"].astype(np.uint8)
+        self.dem = z["dem"].astype(np.float32)
+        self.coverage = z["coverage"].astype(bool)
+        self.cell_size = float(z["cell_size"])
+        self.free_count = z["free_count"] if "free_count" in z else np.zeros_like(self.state0, np.int32)
+        self.foot_count = z["foot_count"] if "foot_count" in z else np.zeros_like(self.state0, np.int32)
+        self.rows, self.cols = self.state0.shape
+
+        self.out_dir = out_dir or npz_path.parent
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self.relabel_npz = self.out_dir / "relabel.npz"
+        self.keypoints_json = self.out_dir / "keypoints.json"
+
+        # resume a previous session if present
+        self.state = self.state0.copy()
+        self.structure = self.struct0.copy()
+        self.keypoints: list[dict] = []
+        if self.relabel_npz.exists():
+            r = np.load(self.relabel_npz)
+            if r["state"].shape == self.state0.shape:
+                self.state = r["state"].astype(np.uint8)
+                self.structure = r["structure"].astype(np.uint8)
+                print(f"[relabel] resumed rasters from {self.relabel_npz}")
+        if self.keypoints_json.exists():
+            self.keypoints = json.loads(self.keypoints_json.read_text()).get("keypoints", [])
+            print(f"[relabel] resumed {len(self.keypoints)} keypoints from {self.keypoints_json}")
+
+    def save(self, state, structure, keypoints):
+        self.state = np.asarray(state, np.uint8).reshape(self.rows, self.cols)
+        self.structure = np.asarray(structure, np.uint8).reshape(self.rows, self.cols)
+        self.keypoints = keypoints
+        edited = int((self.state != self.state0).sum() + (self.structure != self.struct0).sum())
+        np.savez(self.relabel_npz,
+                 state=self.state, structure=self.structure,
+                 state_orig=self.state0, structure_orig=self.struct0,
+                 dem=self.dem, coverage=self.coverage, cell_size=self.cell_size,
+                 edited_cells=edited)
+        self.keypoints_json.write_text(json.dumps({
+            "source_npz": str(self.npz_path),
+            "cell_size": self.cell_size,
+            "grid": {"rows": self.rows, "cols": self.cols},
+            "coords": "cell indices (col, row) in the source grid; +row = +v (north)",
+            "classes": {int(k): k.name for k in Klass},
+            "keypoints": keypoints,
+        }, indent=2))
+        return {"edited_cells": edited, "keypoints": len(keypoints),
+                "npz": str(self.relabel_npz), "json": str(self.keypoints_json)}
+
+
+PAGE = r"""<!doctype html><html><head><meta charset=utf-8><title>BEV relabeler</title>
+<style>
+ :root{--bg:#12141a;--panel:#1b1e26;--ink:#e6e8ee;--mut:#8b93a7;--line:#2b2f3a;--acc:#4da3ff}
+ *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);
+   font:13px/1.45 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;display:flex;height:100vh;overflow:hidden}
+ #side{width:260px;flex:none;background:var(--panel);border-right:1px solid var(--line);
+   padding:14px;overflow-y:auto}
+ #stage{flex:1;position:relative;overflow:hidden;background:#0b0d11}
+ canvas{position:absolute;top:0;left:0;image-rendering:pixelated;cursor:crosshair}
+ h1{font-size:14px;margin:0 0 4px} .sub{color:var(--mut);font-size:11px;margin-bottom:14px}
+ h2{font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--mut);
+   margin:16px 0 7px;padding-bottom:5px;border-bottom:1px solid var(--line)}
+ .row{display:flex;gap:5px;flex-wrap:wrap}
+ button{background:#252a35;color:var(--ink);border:1px solid var(--line);border-radius:6px;
+   padding:6px 9px;font:inherit;font-size:12px;cursor:pointer}
+ button:hover{border-color:var(--acc)} button.on{background:var(--acc);border-color:var(--acc);color:#08121e;font-weight:600}
+ .sw{display:flex;align-items:center;gap:7px;width:100%;padding:5px 7px;border-radius:6px;
+   border:1px solid transparent;cursor:pointer}
+ .sw:hover{background:#232833} .sw.on{border-color:var(--acc);background:#232833}
+ .chip{width:13px;height:13px;border-radius:3px;flex:none;border:1px solid #0006}
+ label{display:flex;align-items:center;gap:7px;margin:5px 0;color:var(--mut);cursor:pointer}
+ input[type=range]{width:100%} kbd{background:#252a35;border:1px solid var(--line);
+   border-radius:3px;padding:0 4px;font-size:11px}
+ #status{position:absolute;left:10px;bottom:10px;background:#0d0f14dd;border:1px solid var(--line);
+   border-radius:6px;padding:6px 10px;font-size:11px;color:var(--mut);pointer-events:none}
+ #save{width:100%;background:#1f6f43;border-color:#2b8c57;font-weight:600;padding:9px}
+ #save:hover{background:#268051}
+</style></head><body>
+<div id=side>
+  <h1>BEV relabeler</h1><div class=sub id=meta></div>
+
+  <h2>Tool</h2>
+  <div class=row>
+    <button class=tool data-t=state>Ground</button>
+    <button class=tool data-t=struct>Class</button>
+    <button class=tool data-t=kp>Keypoint</button>
+  </div>
+
+  <h2 id=palhdr>Ground state</h2>
+  <div id=pal></div>
+
+  <h2>Brush</h2>
+  <input type=range id=brush min=0 max=12 value=1>
+  <div class=sub id=brushlbl style=margin:0></div>
+
+  <h2>Layers</h2>
+  <label><input type=checkbox id=lbg checked> Terrain relief</label>
+  <label><input type=checkbox id=lstate checked> Ground state</label>
+  <label><input type=checkbox id=lstruct> Class overlay</label>
+  <label><input type=checkbox id=lkp checked> Keypoints</label>
+  <label><input type=checkbox id=ldiff> Highlight my edits</label>
+  <label>Opacity <input type=range id=alpha min=10 max=100 value=70></label>
+
+  <h2>Session</h2>
+  <div class=row>
+    <button id=undo>Undo <kbd>Z</kbd></button>
+    <button id=reset>Revert all</button>
+  </div>
+  <div style=height:9px></div>
+  <button id=save>Save annotations</button>
+  <div class=sub id=saved style=margin:8px_0_0></div>
+
+  <h2>Keys</h2>
+  <div class=sub>
+    <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd> tool &nbsp; <kbd>Z</kbd> undo<br>
+    <kbd>[</kbd><kbd>]</kbd> brush &nbsp; drag=paint<br>
+    wheel=zoom &nbsp; <kbd>space</kbd>+drag or middle=pan<br>
+    keypoint: click=add, <kbd>shift</kbd>+click=delete
+  </div>
+</div>
+<div id=stage><canvas id=cv></canvas><div id=status></div></div>
+<script>
+const D = __DATA__;
+const R = D.rows, C = D.cols;
+const b64 = s => Uint8Array.from(atob(s), c => c.charCodeAt(0));
+let state = b64(D.state), struct = b64(D.struct);
+const state0 = b64(D.state), struct0 = b64(D.struct0);
+let kps = D.keypoints.slice();
+
+const cv = document.getElementById('cv'), ctx = cv.getContext('2d');
+const stage = document.getElementById('stage');
+const bg = new Image(); bg.src = D.bg;
+// offscreen at grid resolution; scaled up with smoothing off => crisp cells
+const off = document.createElement('canvas'); off.width = C; off.height = R;
+const octx = off.getContext('2d'), oimg = octx.createImageData(C, R);
+
+let tool = 'state', paint = 1, brush = 1, undoStack = [], stroke = null;
+let view = {x:0, y:0, s:4}, panning = false, spaceDown = false, last = null;
+
+// row 0 of the array is min-v (south); display flipped so north is up, matching
+// footprint2d's own BEV render. All click math inverts through the same flip.
+const cellAt = (px, py) => {
+  const gx = Math.floor((px - view.x) / view.s), gy = Math.floor((py - view.y) / view.s);
+  return (gx < 0 || gy < 0 || gx >= C || gy >= R) ? null : {c: gx, r: R - 1 - gy};
+};
+
+function draw() {
+  const a = +document.getElementById('alpha').value / 100;
+  const showState = document.getElementById('lstate').checked;
+  const showStruct = document.getElementById('lstruct').checked;
+  const showDiff = document.getElementById('ldiff').checked;
+  const p = oimg.data;
+  for (let r = 0; r < R; r++) {
+    const dy = R - 1 - r;                       // flip for north-up display
+    for (let c = 0; c < C; c++) {
+      const i = r * C + c, o = (dy * C + c) * 4;
+      let col = null;
+      if (showStruct && struct[i]) col = D.klassColors[struct[i]];
+      if (!col && showState && state[i] !== 0) col = D.stateColors[state[i]];
+      if (showDiff && (state[i] !== state0[i] || struct[i] !== struct0[i])) col = [255, 0, 255];
+      if (col) { p[o] = col[0]; p[o+1] = col[1]; p[o+2] = col[2]; p[o+3] = Math.round(255*a); }
+      else p[o+3] = 0;
+    }
+  }
+  octx.putImageData(oimg, 0, 0);
+
+  cv.width = stage.clientWidth; cv.height = stage.clientHeight;
+  ctx.imageSmoothingEnabled = false;
+  ctx.clearRect(0, 0, cv.width, cv.height);
+  if (document.getElementById('lbg').checked && bg.complete)
+    ctx.drawImage(bg, view.x, view.y, C*view.s, R*view.s);
+  ctx.drawImage(off, view.x, view.y, C*view.s, R*view.s);
+
+  if (document.getElementById('lkp').checked) {
+    for (const k of kps) {
+      const x = view.x + (k.col + 0.5)*view.s, y = view.y + (R - 1 - k.row + 0.5)*view.s;
+      const col = D.klassColors[k.klass] || [255,255,255];
+      ctx.beginPath(); ctx.arc(x, y, 5, 0, 7);
+      ctx.fillStyle = `rgb(${col})`; ctx.fill();
+      ctx.lineWidth = 1.5; ctx.strokeStyle = '#000'; ctx.stroke();
+    }
+  }
+  document.getElementById('status').textContent =
+    `${tool} · ${C}x${R} @ ${D.cell}m · ${kps.length} keypoints · zoom ${view.s.toFixed(1)}x`;
+}
+
+function apply(cell) {
+  if (!cell) return;
+  const rad = brush;
+  for (let dr = -rad; dr <= rad; dr++) for (let dc = -rad; dc <= rad; dc++) {
+    if (dr*dr + dc*dc > rad*rad + rad) continue;
+    const r = cell.r + dr, c = cell.c + dc;
+    if (r < 0 || c < 0 || r >= R || c >= C) continue;
+    const i = r*C + c;
+    const arr = tool === 'struct' ? struct : state;
+    if (arr[i] === paint) continue;
+    stroke.push([tool === 'struct' ? 1 : 0, i, arr[i]]);   // record prior value for undo
+    arr[i] = paint;
+  }
+}
+
+cv.addEventListener('mousedown', e => {
+  if (e.button === 1 || spaceDown) { panning = true; last = [e.clientX, e.clientY]; return; }
+  const cell = cellAt(e.offsetX, e.offsetY); if (!cell) return;
+  if (tool === 'kp') {
+    if (e.shiftKey) {
+      let bi = -1, bd = 1e9;
+      kps.forEach((k, i) => { const d = (k.col-cell.c)**2 + (k.row-cell.r)**2; if (d < bd) { bd = d; bi = i; } });
+      if (bi >= 0 && bd < 64) { undoStack.push({kp: kps.slice()}); kps.splice(bi, 1); }
+    } else {
+      undoStack.push({kp: kps.slice()});
+      kps.push({klass: paint, name: D.klassNames[paint], col: cell.c, row: cell.r,
+                u: +( (cell.c + 0.5) * D.cell).toFixed(3), v: +((cell.r + 0.5) * D.cell).toFixed(3)});
+    }
+    draw(); return;
+  }
+  stroke = []; apply(cell); draw();
+});
+cv.addEventListener('mousemove', e => {
+  if (panning) { view.x += e.clientX - last[0]; view.y += e.clientY - last[1];
+                 last = [e.clientX, e.clientY]; draw(); return; }
+  if (stroke) { apply(cellAt(e.offsetX, e.offsetY)); draw(); }
+});
+window.addEventListener('mouseup', () => {
+  panning = false;
+  if (stroke && stroke.length) undoStack.push({cells: stroke});
+  stroke = null;
+});
+cv.addEventListener('contextmenu', e => e.preventDefault());
+cv.addEventListener('wheel', e => {
+  e.preventDefault();
+  const f = e.deltaY < 0 ? 1.15 : 1/1.15, ns = Math.max(1, Math.min(40, view.s*f));
+  view.x = e.offsetX - (e.offsetX - view.x) * (ns/view.s);
+  view.y = e.offsetY - (e.offsetY - view.y) * (ns/view.s);
+  view.s = ns; draw();
+}, {passive:false});
+
+function undo() {
+  const u = undoStack.pop(); if (!u) return;
+  if (u.kp) kps = u.kp;
+  else for (let i = u.cells.length - 1; i >= 0; i--) {
+    const [which, idx, prev] = u.cells[i];
+    (which ? struct : state)[idx] = prev;
+  }
+  draw();
+}
+
+// ---- palettes -------------------------------------------------------------
+function buildPalette() {
+  const pal = document.getElementById('pal');
+  const hdr = document.getElementById('palhdr');
+  pal.innerHTML = '';
+  const items = tool === 'state'
+    ? D.stateNames.map((n, i) => [i, n, D.stateColors[i]])
+    : D.klassNames.map((n, i) => [i, n, D.klassColors[i]]);
+  hdr.textContent = tool === 'state' ? 'Ground state' : (tool === 'kp' ? 'Keypoint class' : 'Object class');
+  if (!items.some(it => it[0] === paint)) paint = items[0][0];
+  for (const [v, n, col] of items) {
+    const d = document.createElement('div');
+    d.className = 'sw' + (v === paint ? ' on' : '');
+    d.innerHTML = `<span class=chip style="background:rgb(${col})"></span>${n}`;
+    d.onclick = () => { paint = v; buildPalette(); draw(); };
+    pal.appendChild(d);
+  }
+}
+function setTool(t) {
+  tool = t;
+  document.querySelectorAll('.tool').forEach(b => b.classList.toggle('on', b.dataset.t === t));
+  buildPalette(); draw();
+}
+document.querySelectorAll('.tool').forEach(b => b.onclick = () => setTool(b.dataset.t));
+
+document.getElementById('brush').oninput = e => {
+  brush = +e.target.value;
+  document.getElementById('brushlbl').textContent =
+    `radius ${brush} cell${brush===1?'':'s'} ≈ ${((2*brush+1)*D.cell).toFixed(1)} m across`;
+  draw();
+};
+['lbg','lstate','lstruct','lkp','ldiff','alpha'].forEach(id =>
+  document.getElementById(id).oninput = draw);
+document.getElementById('undo').onclick = undo;
+document.getElementById('reset').onclick = () => {
+  if (!confirm('Discard all edits and keypoints, back to the footprint2d output?')) return;
+  state = state0.slice(); struct = struct0.slice(); kps = []; undoStack = []; draw();
+};
+document.getElementById('save').onclick = async () => {
+  const btn = document.getElementById('save'); btn.textContent = 'Saving…'; btn.disabled = true;
+  const b = a => btoa(String.fromCharCode(...a));
+  const res = await fetch('/save', {method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({state: b(state), structure: b(struct), keypoints: kps})});
+  const j = await res.json();
+  document.getElementById('saved').textContent =
+    `saved ${j.edited_cells} edited cells, ${j.keypoints} keypoints`;
+  btn.textContent = 'Save annotations'; btn.disabled = false;
+};
+window.addEventListener('keydown', e => {
+  if (e.code === 'Space') { spaceDown = true; e.preventDefault(); }
+  if (e.key === 'z') undo();
+  if (e.key === '1') setTool('state');
+  if (e.key === '2') setTool('struct');
+  if (e.key === '3') setTool('kp');
+  if (e.key === '[') { brush = Math.max(0, brush-1); document.getElementById('brush').value = brush; draw(); }
+  if (e.key === ']') { brush = Math.min(12, brush+1); document.getElementById('brush').value = brush; draw(); }
+});
+window.addEventListener('keyup', e => { if (e.code === 'Space') spaceDown = false; });
+window.addEventListener('resize', draw);
+
+document.getElementById('meta').textContent = D.meta;
+document.getElementById('brush').dispatchEvent(new Event('input'));
+// fit the grid to the viewport on open
+view.s = Math.max(1, Math.min(stage.clientWidth/C, stage.clientHeight/R) * 0.92);
+view.x = (stage.clientWidth - C*view.s)/2; view.y = (stage.clientHeight - R*view.s)/2;
+setTool('state');
+bg.onload = draw;
+</script></body></html>
+"""
+
+
+def build_page(store: Store) -> str:
+    lut = color_lut()
+    klass_names = [k.name for k in sorted(Klass, key=int)]
+    klass_colors = [list(lut[int(k)]) if int(k) < len(lut) else [200, 200, 200]
+                    for k in sorted(Klass, key=int)]
+    data = {
+        "rows": store.rows, "cols": store.cols, "cell": store.cell_size,
+        "state": base64.b64encode(store.state.tobytes()).decode(),
+        "struct": base64.b64encode(store.structure.tobytes()).decode(),
+        "struct0": base64.b64encode(store.struct0.tobytes()).decode(),
+        "bg": png_b64(hillshade(store.dem, store.coverage)),
+        "stateNames": STATE_NAMES, "stateColors": [list(c) for c in STATE_COLORS],
+        "klassNames": klass_names, "klassColors": klass_colors,
+        "keypoints": store.keypoints,
+        "meta": (f"{store.npz_path.parent.name} · {store.cols}×{store.rows} cells @ "
+                 f"{store.cell_size} m · {store.coverage.mean()*100:.0f}% DEM coverage"),
+    }
+    return PAGE.replace("__DATA__", json.dumps(data))
+
+
+def serve(store: Store, port: int, open_browser: bool):
+    page = build_page(store).encode()
+
+    class H(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def _send(self, body, ctype="application/json"):
+            self.send_response(200)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path in ("/", "/index.html"):
+                self._send(page, "text/html; charset=utf-8")
+            else:
+                self.send_error(404)
+
+        def do_POST(self):
+            if self.path != "/save":
+                return self.send_error(404)
+            n = int(self.headers.get("Content-Length", 0))
+            req = json.loads(self.rfile.read(n))
+            info = store.save(np.frombuffer(base64.b64decode(req["state"]), np.uint8),
+                              np.frombuffer(base64.b64decode(req["structure"]), np.uint8),
+                              req["keypoints"])
+            print(f"[relabel] saved: {info['edited_cells']} edited cells, "
+                  f"{info['keypoints']} keypoints -> {info['npz']}")
+            self._send(json.dumps(info).encode())
+
+    url = f"http://127.0.0.1:{port}/"
+    print(f"[relabel] {store.npz_path}\n[relabel] grid {store.cols}x{store.rows} @ "
+          f"{store.cell_size} m\n[relabel] serving {url}  (ctrl-c to stop)")
+    if open_browser:
+        try:
+            webbrowser.open(url)
+        except Exception:
+            pass
+    HTTPServer(("127.0.0.1", port), H).serve_forever()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--npz", required=True, help="footprint2d.npz to correct")
+    ap.add_argument("--out", default=None, help="where to write relabel.npz/keypoints.json "
+                                                "(default: alongside --npz)")
+    ap.add_argument("--port", type=int, default=8765)
+    ap.add_argument("--no-browser", action="store_true")
+    args = ap.parse_args()
+
+    npz = Path(args.npz).expanduser().resolve()
+    if not npz.exists():
+        raise SystemExit(f"no such npz: {npz}")
+    store = Store(npz, Path(args.out).expanduser().resolve() if args.out else None)
+    try:
+        serve(store, args.port, not args.no_browser)
+    except KeyboardInterrupt:
+        print("\n[relabel] stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/colmap/export_mvs_depth.py
+++ b/script/colmap/export_mvs_depth.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""COLMAP dense MVS -> per-view metric depth for the semantic-BEV depth bake-off.
+
+Runs the standard COLMAP dense pipeline on a (refined) sparse model —
+``image_undistorter`` -> ``patch_match_stereo`` (geometric consistency) — and converts the
+resulting geometric depth maps into the bake-off contract: ``<out>/<image_stem>.npy``
+(float32 metric z-depth, 0 = invalid). Also writes the undistorted model as text to
+``<out>/model/`` so the back-projection harness uses matching intrinsics/poses.
+
+Launch inside the COLMAP env so both `colmap` and `uv` resolve, e.g.:
+  ~/bin/micromamba run -n colmap uv run python script/colmap/export_mvs_depth.py \
+      --session maguro-park-after-itchy --data-factor 2
+
+Notes: MVS is globally-consistent metric geometry, strong on textured/solid surfaces
+(vending machines, tables, plazas), weak on thin structures (poles, chair legs) and
+low-texture grass. On 8 GB keep --max-image-size modest and cache_size small.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def read_colmap_array(path: Path) -> np.ndarray:
+    """Read a COLMAP dense depth/normal map (.bin): '<W>&<H>&<C>&' header then float32."""
+    with open(path, "rb") as f:
+        w, h, c = np.genfromtxt(f, delimiter="&", max_rows=1, usecols=(0, 1, 2), dtype=int)
+        f.seek(0)
+        n = 0
+        while n < 3:
+            if f.read(1) == b"&":
+                n += 1
+        arr = np.fromfile(f, np.float32)
+    arr = arr.reshape((int(w), int(h), int(c)), order="F")
+    return np.transpose(arr, (1, 0, 2)).squeeze()
+
+
+def run(cmd, log):
+    log("$ " + " ".join(str(c) for c in cmd))
+    subprocess.run([str(c) for c in cmd], check=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None, help="fills --model/--images/--out from the layout")
+    ap.add_argument("--model", default=None, help="COLMAP sparse model dir (text or bin)")
+    ap.add_argument("--images", default=None, help="source images dir")
+    ap.add_argument("--out", default=None, help="depth output dir")
+    ap.add_argument("--data-factor", type=int, default=2, help="max_image_size = 1920 // this")
+    ap.add_argument("--max-image-size", type=int, default=None, help="override MVS image size")
+    ap.add_argument("--cache-size", type=int, default=8, help="patch-match GB cache (8 GB card)")
+    ap.add_argument("--colmap", default="colmap", help="colmap binary (on PATH inside the env)")
+    args = ap.parse_args()
+
+    if args.session:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.depth_dir("mvs"))
+    if not (args.model and args.images and args.out):
+        ap.error("need --session or explicit --model/--images/--out")
+
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    ws = out / "_mvs_workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    max_size = args.max_image_size or (1920 // args.data_factor)
+
+    run([args.colmap, "image_undistorter", "--image_path", args.images,
+         "--input_path", args.model, "--output_path", ws,
+         "--output_type", "COLMAP", "--max_image_size", max_size], print)
+    run([args.colmap, "patch_match_stereo", "--workspace_path", ws,
+         "--workspace_format", "COLMAP",
+         "--PatchMatchStereo.geom_consistency", "true",
+         "--PatchMatchStereo.cache_size", args.cache_size,
+         "--PatchMatchStereo.max_image_size", max_size], print)
+    # Undistorted model as text so the harness reads matching intrinsics/poses.
+    (out / "model").mkdir(exist_ok=True)
+    run([args.colmap, "model_converter", "--input_path", ws / "sparse",
+         "--output_path", out / "model", "--output_type", "TXT"], print)
+
+    depth_maps = sorted((ws / "stereo" / "depth_maps").glob("*.geometric.bin"))
+    if not depth_maps:
+        raise SystemExit("no geometric depth maps produced (patch_match_stereo failed?)")
+    print(f"converting {len(depth_maps)} depth maps -> {out}")
+    for i, dm in enumerate(depth_maps):
+        stem = dm.name[:-len("_image.jpeg.geometric.bin")] + "_image" \
+            if dm.name.endswith("_image.jpeg.geometric.bin") else dm.name.split(".")[0]
+        depth = read_colmap_array(dm).astype(np.float32)
+        depth[~np.isfinite(depth)] = 0.0
+        np.save(out / f"{stem}.npy", depth)
+        if (i + 1) % 100 == 0 or i + 1 == len(depth_maps):
+            print(f"  {i + 1}/{len(depth_maps)}")
+    print(f"done -> {out}   (pass --model {out}/model to the BEV harness, or --session handles it)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/depth/README.md
+++ b/script/depth/README.md
@@ -1,0 +1,75 @@
+# script/depth — monocular metric depth (commercial-friendly)
+
+Per-view metric depth for the semantic-BEV depth bake-off. Every backend writes the same
+contract consumed by `../semantic_bev/depth_backproject.py`:
+
+    <out>/<image_stem>.npy        float32 (H, W) metric z-depth (m); <=0 / NaN = invalid
+    <out>/<image_stem>.conf.npy   optional float32 (H, W) confidence in [0, 1]
+
+## Files
+
+| file | role |
+|------|------|
+| `mono_depth.py`  | export dense metric depth for **all** frames (mono disparity → scale+shift fit to SfM) |
+| `depth_bench.py` | **rank depth models** by held-out SfM depth accuracy (no full pipeline) |
+
+## Commercial-friendly backends (licenses verified on the HF model card, 2026-07)
+
+| key | model | license | type | speed* |
+|-----|-------|---------|------|--------|
+| `da2-small`  | depth-anything/Depth-Anything-V2-Small-hf | **Apache-2.0** | rel. disparity | 0.10 s |
+| `dpt-large`  | Intel/dpt-large                           | **Apache-2.0** | rel. disparity | 0.22 s |
+| `dpt-beit-l` | Intel/dpt-beit-large-512                  | **MIT**        | rel. disparity | 0.59 s |
+| `marigold`   | prs-eth/marigold-depth-v1-0               | **Apache-2.0** | affine-inv depth | 1.61 s |
+
+\* per 960×720 frame on the local RTX 5060.
+
+> ⚠️ **Depth-Anything-V2 Base/Large are CC-BY-NC-4.0 (non-commercial)** — excluded. Only the
+> *Small* checkpoint is Apache-2.0. `mono_depth.py` defaults to it for that reason.
+
+## Rank the models (held-out SfM accuracy)
+
+Fits each model's scale+shift on half a frame's SfM points and scores metric error on the
+held-out half, aggregated over sampled frames. Metrics are stratified by distance because a
+walkable-ground BEV only depends on the **near/mid** regime (far = background trees, where
+mono depth *and* sparse SfM are both unreliable).
+
+```sh
+uv run --extra segmentation --with diffusers --with accelerate \
+  python script/depth/depth_bench.py --session maguro-park-after-itchy --frames 40
+```
+
+Writes `output/<name>-depthbench/`: `scorecard.md`, `results.json`, `sample_depths.png`.
+(`diffusers`/`accelerate` only needed if `marigold` is in `--backends`.)
+
+### Result on `maguro-park-after-itchy` (40 frames)
+
+Ranked by near-field (z<8 m) accuracy. δ1 = frac within 25 %; more robust than AbsRel,
+which is mean-of-ratio and tail-heavy on near foreground edges.
+
+| backend | license | near δ1 | near AbsRel | mid AbsRel | overall AbsRel | speed |
+|---------|---------|---------|-------------|------------|----------------|-------|
+| dpt-beit-l | MIT | **0.930** | 0.304 | 0.198 | **0.280** | 0.59 s |
+| da2-small | Apache-2.0 | 0.927 | 0.335 | 0.201 | 0.313 | **0.10 s** |
+| dpt-large | Apache-2.0 | 0.910 | 0.354 | 0.214 | 0.323 | 0.22 s |
+| marigold | Apache-2.0 | 0.680 | 0.390 | 0.206 | 0.319 | 1.61 s |
+
+**Takeaways.** (1) All models are best in the **mid-field** (~0.20 AbsRel) and tail-heavy
+near-field. (2) `dpt-beit-l` is marginally most accurate but 6× slower; `da2-small` is
+statistically tied on near-δ1, Apache-2.0, and fastest → the practical default. (3) Marigold
+in its fast 4-step config is worst here and slowest — not worth it. (4) Model choice matters
+less than the depth regime; none give better than ~20 % mid-field AbsRel on this park, so
+per-frame depth should be **fused across many views** (the back-projection harness does this)
+rather than trusted per-frame.
+
+## Export depth for the winner (feeds the BEV pipeline)
+
+```sh
+uv run --extra segmentation python script/depth/mono_depth.py \
+  --session maguro-park-after-itchy --data-factor 2                 # da2-small (default)
+# or a different backend:
+#   --model-name Intel/dpt-beit-large-512
+```
+
+Then run the BEV pipeline with `--source depth` and score with `eval_depth_bev.py`
+(see `../semantic_bev/README.md`).

--- a/script/depth/depth_bench.py
+++ b/script/depth/depth_bench.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Commercial-friendly monocular-depth bake-off, scored by held-out SfM depth accuracy.
+
+The question this answers: *which license-clean depth model gives the most metrically
+accurate depth on our park imagery?* — without running the whole BEV pipeline.
+
+Per sampled frame we have sparse but trustworthy metric depth at the SfM keypoints. We
+split those points 50/50 (deterministic per frame), fit the model's standard scale+shift
+alignment on one half, and measure error on the *held-out* half. That isolates depth
+quality from the alignment fit (a model can't cheat by being easy to scale). Metrics are
+the usual monocular-depth ones, aggregated (median, robust) over frames:
+
+    AbsRel   mean |pred - z| / z            (lower better)
+    RMSE     sqrt(mean (pred - z)^2)  [m]    (lower better)
+    delta1   frac( max(pred/z, z/pred) < 1.25 )   (higher better)
+
+Backends (all verified commercial-friendly on their HF model card, 2026-07):
+
+    da2-small   depth-anything/Depth-Anything-V2-Small-hf   apache-2.0   (rel. disparity)
+    dpt-large   Intel/dpt-large                             apache-2.0   (rel. disparity)
+    dpt-beit-l  Intel/dpt-beit-large-512                    mit          (rel. disparity)
+    marigold    prs-eth/marigold-depth-v1-0                 apache-2.0   (affine-inv depth)
+
+NOTE: Depth-Anything-V2 *Base/Large* are CC-BY-NC (non-commercial) — excluded on purpose.
+
+Run (transformers for the DPT/DA models; diffusers for Marigold):
+
+    uv run --extra segmentation --with diffusers --with accelerate \
+        python script/depth/depth_bench.py --session maguro-park-after-itchy --frames 40
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "semantic_bev"))
+from colmap_io import read_model                         # noqa: E402
+from mono_depth import sparse_samples                     # noqa: E402  (reuse SfM sampling)
+
+# name -> (hf/diffusers id, runner kind, output space, license)
+BACKENDS = {
+    "da2-small":  ("depth-anything/Depth-Anything-V2-Small-hf", "hf",       "disparity", "apache-2.0"),
+    "dpt-large":  ("Intel/dpt-large",                           "hf",       "disparity", "apache-2.0"),
+    "dpt-beit-l": ("Intel/dpt-beit-large-512",                  "hf",       "disparity", "mit"),
+    "marigold":   ("prs-eth/marigold-depth-v1-0",               "marigold", "depth",     "apache-2.0"),
+}
+
+
+def load_runner(kind: str, model_id: str):
+    """Return f(pil_rgb) -> HxW float32 raw prediction (disparity: high=near; depth: high=far)."""
+    import torch
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    if kind == "hf":
+        from transformers import pipeline
+        pipe = pipeline("depth-estimation", model=model_id, device=0 if dev == "cuda" else -1)
+
+        def run(pil):
+            pred = pipe(pil)["predicted_depth"]
+            return pred.squeeze().float().cpu().numpy()
+        return run
+
+    if kind == "marigold":
+        from diffusers import MarigoldDepthPipeline
+        dt = torch.float16 if dev == "cuda" else torch.float32
+        try:
+            pipe = MarigoldDepthPipeline.from_pretrained(model_id, variant="fp16", torch_dtype=dt)
+        except Exception:
+            pipe = MarigoldDepthPipeline.from_pretrained(model_id, torch_dtype=dt)
+        pipe = pipe.to(dev)
+        pipe.set_progress_bar_config(disable=True)
+
+        def run(pil):
+            out = pipe(pil, num_inference_steps=4, ensemble_size=1, output_type="np")
+            return np.asarray(out.prediction).squeeze().astype(np.float32)
+        return run
+
+    raise ValueError(kind)
+
+
+def robust_fit(x: np.ndarray, y: np.ndarray, trim: float = 0.1):
+    """Least-squares y ≈ a·x + b with one robust trim of the worst `trim` residuals."""
+    A = np.stack([x, np.ones_like(x)], axis=1)
+    ab, *_ = np.linalg.lstsq(A, y, rcond=None)
+    resid = np.abs(A @ ab - y)
+    keep = resid <= np.quantile(resid, 1 - trim)
+    if keep.sum() >= 2:
+        ab, *_ = np.linalg.lstsq(A[keep], y[keep], rcond=None)
+    return float(ab[0]), float(ab[1])
+
+
+# Distance bands (metres). Ground BEV cares about near/mid; far is mostly background
+# trees where both mono depth and sparse SfM triangulation are unreliable.
+BANDS = [("near", 0.0, 8.0), ("mid", 8.0, 20.0), ("far", 20.0, np.inf)]
+
+
+def _band_metrics(pred, zt):
+    out = {}
+    absrel = np.abs(pred - zt) / zt
+    ratio = np.maximum(pred / zt, zt / pred)
+    out["absrel"] = float(np.mean(absrel))
+    out["rmse"] = float(np.sqrt(np.mean((pred - zt) ** 2)))
+    out["delta1"] = float(np.mean(ratio < 1.25))
+    for name, lo, hi in BANDS:
+        m = (zt >= lo) & (zt < hi)
+        if m.sum() >= 5:
+            out[f"{name}_absrel"] = float(np.mean(absrel[m]))
+            out[f"{name}_delta1"] = float(np.mean(ratio[m] < 1.25))
+    return out
+
+
+def eval_frame(raw: np.ndarray, px, py, z, space: str, seed: int, min_test: int = 10):
+    """Fit scale+shift on half the SfM points, score metric error on the held-out half.
+
+    Metrics are reported overall and per distance band (near/mid/far) so the ranking
+    reflects the near-to-mid regime that a walkable-ground BEV actually depends on.
+    """
+    H, W = raw.shape
+    ix = np.clip(np.round(px).astype(int), 0, W - 1)
+    iy = np.clip(np.round(py).astype(int), 0, H - 1)
+    r = raw[iy, ix].astype(np.float64)
+    z = z.astype(np.float64)
+    good = np.isfinite(r) & np.isfinite(z) & (z > 0)
+    r, z = r[good], z[good]
+    n = len(z)
+    if n < 2 * min_test:
+        return None
+    rng = np.random.default_rng(seed)
+    perm = rng.permutation(n)
+    tr, te = perm[: n // 2], perm[n // 2:]
+
+    if space == "disparity":                         # 1/z ≈ a·disp + b
+        a, b = robust_fit(r[tr], 1.0 / z[tr])
+        denom = a * r[te] + b
+        pred = np.where(denom > 1e-6, 1.0 / denom, np.nan)
+    else:                                            # depth: z ≈ a·d + b
+        a, b = robust_fit(r[tr], z[tr])
+        pred = a * r[te] + b
+
+    zt = z[te]
+    ok = np.isfinite(pred) & (pred > 0)
+    if ok.sum() < min_test:
+        return None
+    return _band_metrics(pred[ok], zt[ok])
+
+
+def colorize(raw, space):
+    v = raw.astype(np.float32)
+    lo, hi = np.percentile(v, [2, 98])
+    n = np.clip((v - lo) / max(hi - lo, 1e-6), 0, 1)
+    if space == "depth":                              # show near=warm for both
+        n = 1.0 - n
+    return cv2.applyColorMap((n * 255).astype(np.uint8), cv2.COLORMAP_TURBO)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None)
+    ap.add_argument("--model", default=None, help="COLMAP text model with tracks (poses_txt)")
+    ap.add_argument("--images", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--backends", default=",".join(BACKENDS), help="comma list from " + ", ".join(BACKENDS))
+    ap.add_argument("--frames", type=int, default=40, help="evenly-spaced frames to sample")
+    ap.add_argument("--min-pts", type=int, default=60, help="min SfM points a frame needs to be used")
+    ap.add_argument("--data-factor", type=int, default=2)
+    args = ap.parse_args()
+
+    if args.session:
+        sys.path.insert(0, str(_ROOT))
+        from lar_session import Session
+        s = Session(args.session)
+        # Mono alignment needs SfM *tracks*: use the raw COLMAP model, not the refined one.
+        args.model = args.model or str(s.colmap_model)
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.root / "output" / f"{s.name}-depthbench")
+    if not (args.model and args.images and args.out):
+        ap.error("need --session or explicit --model/--images/--out")
+
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+    for b in backends:
+        if b not in BACKENDS:
+            ap.error(f"unknown backend {b!r}; choose from {list(BACKENDS)}")
+
+    print(f"reading tracked model {args.model} ...")
+    recon = read_model(args.model)
+    images_dir = Path(args.images)
+    f = args.data_factor
+
+    # Sample frames evenly across the trajectory, keeping only well-observed ones.
+    ordered = sorted(recon.images.values(), key=lambda im: im.name)
+    picks, seen = [], 0
+    for im in ordered[:: max(1, len(ordered) // (args.frames * 3))]:
+        cam = recon.cameras[im.camera_id]
+        sc = (cam.width // f) / cam.width
+        px, py, z = sparse_samples(recon, im, sc)
+        if len(z) >= args.min_pts:
+            picks.append((im, px, py, z))
+            if len(picks) >= args.frames:
+                break
+    print(f"using {len(picks)} frames (>= {args.min_pts} SfM pts each), data-factor {f}")
+    if len(picks) < 3:
+        raise SystemExit("too few usable frames; lower --min-pts or --data-factor")
+
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    # Cache resized RGB once (shared across backends).
+    frames = []
+    for im, px, py, z in picks:
+        bgr = cv2.imread(str(images_dir / im.name), cv2.IMREAD_COLOR)
+        if bgr is None:
+            continue
+        H, W = bgr.shape[0] // f, bgr.shape[1] // f
+        rgb = cv2.cvtColor(cv2.resize(bgr, (W, H)), cv2.COLOR_BGR2RGB)
+        frames.append((im, rgb, px, py, z))
+
+    from PIL import Image as PILImage
+    results = {}
+    sample_tiles = []
+    for b in backends:
+        model_id, kind, space, lic = BACKENDS[b]
+        print(f"\n=== {b}  ({model_id}, {lic}) ===")
+        run = load_runner(kind, model_id)
+        per, t0, nt = [], time.time(), 0
+        for i, (im, rgb, px, py, z) in enumerate(frames):
+            raw = run(PILImage.fromarray(rgb))
+            H, W = rgb.shape[:2]
+            if raw.shape != (H, W):
+                raw = cv2.resize(raw, (W, H), interpolation=cv2.INTER_LINEAR)
+            m = eval_frame(raw, px, py, z, space, seed=1000 + i)
+            if m:
+                per.append(m)
+            nt += 1
+            if i == 0:  # one sample depth preview per backend
+                tile = colorize(raw, space)
+                cv2.putText(tile, b, (6, 20), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+                sample_tiles.append(tile)
+        dt = (time.time() - t0) / max(nt, 1)
+        if not per:
+            print("  no usable frames"); continue
+        # Median across frames for every metric a frame reported (bands may be absent).
+        keys = set().union(*(p.keys() for p in per))
+        agg = {k: float(np.median([p[k] for p in per if k in p])) for k in keys}
+        agg["sec_per_frame"] = round(dt, 3)
+        agg["frames"] = len(per)
+        agg["license"] = lic
+        results[b] = agg
+        print(f"  near AbsRel {agg.get('near_absrel', float('nan')):.3f} "
+              f"(d1 {agg.get('near_delta1', float('nan')):.2f}) | "
+              f"mid {agg.get('mid_absrel', float('nan')):.3f} | "
+              f"overall {agg['absrel']:.3f} | {dt:.2f}s/frame")
+
+    if not results:
+        raise SystemExit("no results")
+
+    # Rank by near-field AbsRel (the regime a walkable-ground BEV depends on); fall back
+    # to overall for any backend that never had enough near points.
+    def rank_key(b):
+        return results[b].get("near_absrel", results[b]["absrel"])
+    order = sorted(results, key=rank_key)
+    cols = ["license", "near_absrel", "near_delta1", "mid_absrel",
+            "far_absrel", "absrel", "sec_per_frame", "frames"]
+    hdr = ["backend"] + [c.replace("absrel", "AbsRel").replace("delta1", "d1") for c in cols]
+    md = ["# Depth bake-off — held-out SfM depth accuracy",
+          f"\nSession `{Path(args.model).parent.parent.name}`, {len(frames)} frames, "
+          f"data-factor {f}. Ranked by **near-field** AbsRel (z<8 m; lower = better). "
+          f"Bands: near <8 m, mid 8–20 m, far >20 m.\n",
+          "| " + " | ".join(hdr) + " |", "|" + "---|" * len(hdr)]
+    for b in order:
+        r = results[b]
+        cells = [b] + [(f"{r[c]:.3f}" if isinstance(r.get(c), float) else str(r.get(c, "—")))
+                       for c in cols]
+        md.append("| " + " | ".join(cells) + " |")
+    (out / "scorecard.md").write_text("\n".join(md) + "\n")
+    (out / "results.json").write_text(json.dumps(results, indent=2))
+    if sample_tiles:
+        h = max(t.shape[0] for t in sample_tiles)
+        sample_tiles = [cv2.copyMakeBorder(t, 0, h - t.shape[0], 0, 4, cv2.BORDER_CONSTANT, value=0)
+                        for t in sample_tiles]
+        cv2.imwrite(str(out / "sample_depths.png"), np.hstack(sample_tiles))
+
+    print(f"\nRanking by AbsRel: {' > '.join(order)}")
+    print(f"scorecard -> {out}/scorecard.md  (+ results.json, sample_depths.png)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/depth/mono_depth.py
+++ b/script/depth/mono_depth.py
@@ -75,7 +75,10 @@ def main():
     ap.add_argument("--images", default=None)
     ap.add_argument("--out", default=None)
     ap.add_argument("--data-factor", type=int, default=2)
-    ap.add_argument("--model-name", default="depth-anything/Depth-Anything-V2-Large-hf")
+    # Default is the Apache-2.0 *Small* model: DA-V2 Base/Large are CC-BY-NC (non-commercial).
+    # Per script/depth/depth_bench.py it's ~tied on near-field accuracy with the best backend
+    # and ~6x faster. Swap in any HF depth model (e.g. Intel/dpt-beit-large-512, MIT) here.
+    ap.add_argument("--model-name", default="depth-anything/Depth-Anything-V2-Small-hf")
     args = ap.parse_args()
 
     if args.session:

--- a/script/depth/mono_depth.py
+++ b/script/depth/mono_depth.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Monocular metric depth (Depth Anything V2), scale-aligned to SfM -> bake-off contract.
+
+Per frame: run Depth Anything V2 (affine-invariant *disparity*), then fit it to the frame's
+sparse SfM depth so the result is **metric**. The fit is the standard MiDaS-style
+scale+shift in disparity space: for the SfM points observed in the frame we have metric
+depth ``z``; we solve ``1/z ≈ a·disp + b`` by least squares, then output
+``depth = 1/(a·disp + b)``. This gives dense depth — including thin structures (poles,
+chair legs) and low-texture regions MVS/GS miss — anchored to the SfM metric scale.
+
+  uv run --extra segmentation python script/depth/mono_depth.py \
+      --session maguro-park-after-itchy --data-factor 2
+
+Per-frame alignment means residual scale error between frames; the back-projection harness
+fuses many frames per voxel, which averages it down. Writes <out>/<stem>.npy (+ .conf.npy).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# SfM tracks (keypoint -> 3D point) come from the semantic_bev COLMAP reader.
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "semantic_bev"))
+from colmap_io import read_model  # noqa: E402
+
+
+def _qvec2rotmat(q):
+    w, x, y, z = q
+    return np.array([[1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                     [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                     [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)]])
+
+
+def sparse_samples(recon, img, scale):
+    """Observed SfM points -> (pixel_x, pixel_y at depth-res, metric z-depth)."""
+    R, t = _qvec2rotmat(img.qvec), img.tvec
+    pids, xys = img.point3d_ids, img.xys
+    keep = pids >= 0
+    if not keep.any():
+        return np.empty(0), np.empty(0), np.empty(0)
+    px, py, z = [], [], []
+    for pid, (u, v) in zip(pids[keep], xys[keep]):
+        p = recon.points3d.get(int(pid))
+        if p is None:
+            continue
+        zc = (R @ p.xyz + t)[2]
+        if zc > 0:
+            px.append(u * scale); py.append(v * scale); z.append(zc)
+    return np.array(px), np.array(py), np.array(z)
+
+
+def fit_metric(disp_at_pts, z, trim=0.1):
+    """Solve 1/z ≈ a·disp + b (least squares, one robust trim). Returns (a, b) or None."""
+    if len(z) < 20:
+        return None
+    inv = 1.0 / z
+    A = np.stack([disp_at_pts, np.ones_like(disp_at_pts)], axis=1)
+    ab, *_ = np.linalg.lstsq(A, inv, rcond=None)
+    resid = np.abs(A @ ab - inv)
+    keep = resid <= np.quantile(resid, 1 - trim)
+    ab, *_ = np.linalg.lstsq(A[keep], inv[keep], rcond=None)
+    return float(ab[0]), float(ab[1])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None)
+    ap.add_argument("--model", default=None, help="COLMAP text model (poses + tracks)")
+    ap.add_argument("--images", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--data-factor", type=int, default=2)
+    ap.add_argument("--model-name", default="depth-anything/Depth-Anything-V2-Large-hf")
+    args = ap.parse_args()
+
+    if args.session:
+        from lar_session import Session  # _ROOT (script/) already on path
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.depth_dir("mono"))
+    if not (args.model and args.images and args.out):
+        ap.error("need --session or explicit --model/--images/--out")
+
+    import torch
+    from transformers import pipeline
+    device = 0 if torch.cuda.is_available() else -1
+    pipe = pipeline("depth-estimation", model=args.model_name, device=device)
+
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    recon = read_model(args.model)
+    images_dir = Path(args.images)
+    f = args.data_factor
+    n_ok = n_skip = 0
+
+    for i, img in enumerate(sorted(recon.images.values(), key=lambda im: im.name)):
+        bgr = cv2.imread(str(images_dir / img.name), cv2.IMREAD_COLOR)
+        if bgr is None:
+            continue
+        H, W = bgr.shape[0] // f, bgr.shape[1] // f
+        rgb = cv2.cvtColor(cv2.resize(bgr, (W, H)), cv2.COLOR_BGR2RGB)
+        from PIL import Image as PILImage
+        pred = pipe(PILImage.fromarray(rgb))["predicted_depth"]  # disparity-like, higher=closer
+        disp = pred.squeeze().float().cpu().numpy()
+        if disp.shape != (H, W):
+            disp = cv2.resize(disp, (W, H), interpolation=cv2.INTER_LINEAR)
+
+        scale = W / recon.cameras[img.camera_id].width  # full-res keypoints -> depth res
+        px, py, z = sparse_samples(recon, img, scale)
+        ab = None
+        if len(z):
+            ix = np.clip(np.round(px).astype(int), 0, W - 1)
+            iy = np.clip(np.round(py).astype(int), 0, H - 1)
+            ab = fit_metric(disp[iy, ix], z)
+        if ab is None:
+            n_skip += 1
+            continue
+        a, b = ab
+        denom = a * disp + b
+        depth = np.where(denom > 1e-6, 1.0 / denom, 0.0).astype(np.float32)
+        depth[(depth <= 0) | ~np.isfinite(depth)] = 0.0
+        np.save(out / f"{Path(img.name).stem}.npy", depth)
+        n_ok += 1
+        if (i + 1) % 100 == 0 or i + 1 == len(recon.images):
+            print(f"  {i + 1}/{len(recon.images)} (aligned {n_ok}, skipped {n_skip})")
+    print(f"done -> {out}  (aligned {n_ok}, skipped {n_skip} frames with too few SfM points)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/download_models.py
+++ b/script/download_models.py
@@ -1,0 +1,149 @@
+"""Fetch the pretrained weights that live under ``models/`` (gitignored).
+
+``models/`` holds a few hundred MB of third-party checkpoints that have no business in git.
+Everything here is downloaded from its original host and verified by MD5, so a fresh clone
+can reproduce the directory with one command instead of a description of where to click.
+
+Only weights that are *not* pulled automatically belong here. Anything reached through
+``transformers.from_pretrained`` / ``torch.hub`` already caches itself under
+``~/.cache/huggingface`` and needs no entry.
+
+Run (from repo root):
+  uv run python script/download_models.py            # fetch whatever is missing
+  uv run python script/download_models.py --list     # show what is known, and its state
+  uv run python script/download_models.py --force footprints-handheld
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import shutil
+import sys
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MODELS_DIR = REPO_ROOT / "models"
+
+# name -> (url, md5 of the download, path that must exist afterwards, note)
+MODELS: dict[str, tuple[str, str, str, str]] = {
+    "footprints-handheld": (
+        "https://storage.googleapis.com/niantic-lon-static/research/footprints/handheld.zip",
+        "ab97945cf8f8f9e8d9bdedf8961506b6",
+        "handheld/model.pth",
+        "Niantic 'Footprints and Free Space from a Single Color Image' (CVPR 2020), "
+        "handheld variant — the closest baseline to our single-image ground head. "
+        "Non-commercial research licence: baseline comparison only, never shipped.",
+    ),
+    "footprints-kitti": (
+        "https://storage.googleapis.com/niantic-lon-static/research/footprints/kitti.zip",
+        "a52e3b04bffd86f62c62cf8859c47798",
+        "kitti/model.pth",
+        "Same, KITTI-trained (driving). Only useful for reproducing their published numbers.",
+    ),
+    "footprints-matterport": (
+        "https://storage.googleapis.com/niantic-lon-static/research/footprints/matterport.zip",
+        "e28929d0819392d2178c880725531c4e",
+        "matterport/model.pth",
+        "Same, Matterport-trained (indoor).",
+    ),
+}
+
+DEFAULT = ["footprints-handheld"]
+
+
+def md5sum(path: Path, chunk: int = 1 << 20) -> str:
+    h = hashlib.md5()
+    with open(path, "rb") as f:
+        while block := f.read(chunk):
+            h.update(block)
+    return h.hexdigest()
+
+
+def have(name: str) -> bool:
+    return (MODELS_DIR / MODELS[name][2]).exists()
+
+
+def fetch(name: str, force: bool = False) -> bool:
+    url, md5, marker, _ = MODELS[name]
+    target = MODELS_DIR / marker
+    if target.exists() and not force:
+        print(f"  [have] {name} -> {target.relative_to(REPO_ROOT)}")
+        return True
+    MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"  [get ] {name}\n         {url}")
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td) / "download.zip"
+        last = [-1]
+
+        def hook(count, bsize, total):
+            if total <= 0:
+                return
+            pct = min(100, int(count * bsize * 100 / total))
+            if pct >= last[0] + 10:
+                last[0] = pct
+                print(f"         {pct:3d}%  ({total/1e6:.0f} MB)", flush=True)
+
+        try:
+            urllib.request.urlretrieve(url, tmp, hook)
+        except Exception as e:                      # noqa: BLE001 - report and continue
+            print(f"         FAILED: {e}")
+            return False
+
+        got = md5sum(tmp)
+        if got != md5:
+            # A corrupt/truncated archive that silently unzips is worse than no archive.
+            print(f"         MD5 MISMATCH: expected {md5}, got {got} — discarded")
+            return False
+        print("         md5 ok, extracting")
+        with zipfile.ZipFile(tmp) as z:
+            z.extractall(MODELS_DIR)
+
+    if not target.exists():
+        print(f"         extracted but {marker} is missing — archive layout changed?")
+        return False
+    print(f"         -> {target.relative_to(REPO_ROOT)}")
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("names", nargs="*", default=None,
+                    help=f"models to fetch (default: {' '.join(DEFAULT)}; 'all' for everything)")
+    ap.add_argument("--list", action="store_true", help="show known models and exit")
+    ap.add_argument("--force", action="store_true", help="re-download even if present")
+    args = ap.parse_args()
+
+    if args.list:
+        print(f"models dir: {MODELS_DIR}")
+        for n, (_, _, marker, note) in MODELS.items():
+            mark = "have" if have(n) else "   -"
+            star = " *" if n in DEFAULT else "  "
+            print(f"  [{mark}]{star}{n:<24s} {marker}\n            {note}")
+        print("\n  * = fetched by default. ")
+        return 0
+
+    names = args.names or DEFAULT
+    if names == ["all"]:
+        names = list(MODELS)
+    unknown = [n for n in names if n not in MODELS]
+    if unknown:
+        print(f"unknown model(s): {', '.join(unknown)}\nknown: {', '.join(MODELS)}")
+        return 2
+
+    print(f"models dir: {MODELS_DIR}")
+    ok = [fetch(n, args.force) for n in names]
+    n_ok = sum(ok)
+    print(f"\n{n_ok}/{len(names)} ready"
+          + ("" if n_ok == len(names) else "  — see failures above"))
+    if n_ok and shutil.disk_usage(MODELS_DIR).free < 1 << 30:
+        print("warning: under 1 GB free on this filesystem")
+    return 0 if n_ok == len(names) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -27,6 +27,20 @@ pipelines. Output per Gaussian: an argmax class id (`_labels.npy`) + a taxonomy-
 `.ply`. That labelled point set is exactly the `(positions, labels, confidence)` geometry
 source `semantic_bev` is designed to consume, and a route into LAR localization.
 
+**Two-phase training (the reliable, canonical recipe).** Semantics is *not* trained jointly
+with geometry. Following LangSplat / Feature-3DGS / Gaussian Grouping:
+
+1. **Phase 1 (`--max-steps`)** — train RGB + geometry with MCMC densification. This is
+   identical to a plain RGB run; no semantic field exists yet.
+2. **Phase 2 (`--sem-steps`)** — attach a fresh semantic field to the *converged*
+   Gaussians and train only it, with the geometry **detached/frozen** (MCMC off). The 2D
+   masks are distilled onto fixed supports.
+
+Why: geometry from the dense photometric loss is far more reliable than the semantic CE,
+and freezing it means labelling becomes a clean multi-view fusion problem that **cannot
+move or degrade the reconstruction**. Phase 2 is cheap (a few thousand steps — no SSIM,
+no SH, no densification).
+
 ## Modules
 
 | file | role |

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -94,33 +94,30 @@ export TORCH_CUDA_ARCH_LIST=12.0     # Blackwell sm_120
 
 ## Run
 
-Smoke test (subset, few steps — proves the chain end to end):
+**Just pass `--session <name>`** and paths are filled from the canonical layout
+([`../lar_session.py`](../lar_session.py)): `--model` = the refined COLMAP model if it
+exists else the raw one, `--images` = `input/<name>`, `--out` = `output/<name>-gsplat[-sem]`.
+Any explicit flag overrides.
+
+Semantic park model (the usual command):
 
 ```sh
 cd script/gsplat
-uv run --extra gsplat python train.py \
-  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
-  --out   ../../output/maguro-gsplat-smoke \
-  --limit 40 --data-factor 4 --cap-max 80000 --max-steps 500 --preview-every 100
-```
-
-Coarse park model (RGB):
-
-```sh
-uv run --extra gsplat python train.py \
-  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
-  --out   ../../output/maguro-gsplat \
-  --data-factor 2 --cap-max 300000 --max-steps 30000
-```
-
-Semantic 3DGS (adds the distilled class head):
-
-```sh
 uv run --extra gsplat --extra segmentation python train.py \
-  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
-  --out   ../../output/maguro-gsplat-sem \
+  --session maguro-park-after-itchy \
   --data-factor 2 --cap-max 300000 --max-steps 30000 \
   --semantic --segmenter mask2former-large
+```
+
+RGB only — drop `--semantic` (writes to `output/<name>-gsplat`). Smoke test — add
+`--limit 40 --max-steps 500` (and `--out` if you don't want to overwrite the real run).
+
+Explicit paths still work instead of `--session`:
+
+```sh
+uv run --extra gsplat python train.py \
+  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
+  --out   ../../output/maguro-gsplat --data-factor 2 --cap-max 300000 --max-steps 30000
 ```
 
 `--segmenter` accepts any `semantic_bev` backend: `oneformer` / `oneformer-large` /

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -48,7 +48,43 @@ no SH, no densification).
 | `colmap_dataset.py` | read COLMAP **text** model (`poses_txt/`) → posed cameras + init points, RAM-cached at training resolution |
 | `model.py`          | Gaussian init from sparse points (k-NN scale seed); PLY + semantic-label export |
 | `semantic.py`       | cache per-image class masks via `semantic_bev` segmenters (shared taxonomy) |
-| `train.py`          | MCMC trainer (L1+SSIM RGB, optional semantic CE), CLI, exports |
+| `train.py`          | MCMC trainer (L1+SSIM RGB, optional semantic CE), 3DGS/2DGS modes, CLI, exports |
+| `export_depth.py`   | render per-view metric depth from a trained model (3DGS expected-depth / 2DGS median-depth) → depth bake-off contract |
+
+## 2DGS (surfel) mode — cleaner depth for the BEV
+
+`--mode 2dgs` swaps the volumetric 3D Gaussians for **2D Gaussian surfels** (flat disks
+that lie *on* surfaces) plus the 2DGS surface regularizers. The point is **geometry, not
+looks**: surfels give sharp, surface-aligned depth, which is what the `semantic_bev`
+depth back-projection needs for accurate ground height + object footprints. It keeps the
+exact same MCMC `--cap-max` VRAM budget and two-phase semantic recipe, and writes to a
+separate `output/<name>-gsplat2d[-sem]/` dir so it never clobbers a 3DGS model.
+
+```sh
+uv run --extra gsplat python train.py --session <name> --mode 2dgs          # RGB geometry
+uv run --extra gsplat --extra segmentation python train.py --session <name> --mode 2dgs --semantic
+```
+
+- `--normal-reg` (default **0.05**, the 2DGS paper value) — normal-consistency; this is
+  what flattens the surfels onto the surface. The safe, standard regularizer.
+- `--dist-reg` (default **0**) — distortion; sharpens depth further but, like the MCMC
+  regularizers, can misbehave on our un-normalized metric coordinates. Off by default;
+  turn up slowly and watch the depth previews.
+- `--reg-start` (default **500**) — delays both regularizers until the geometry has
+  roughly settled (fighting them too early stalls convergence).
+
+> **Implementation note.** gsplat 1.5.3's `rasterization_2dgs` has three sharp edges we
+> route around in `train.rasterize` (all verified on this build): its **packed** path
+> mis-gathers colours (`colors.shape[0] == nnz`), it only produces `surf_normals` under a
+> **depth render mode**, and with `sh_degree=None` it **omits the camera axis** on colours.
+> So 2DGS always renders unpacked, in `RGB+ED`, with non-SH colours shaped `(1, N, D)`.
+
+Render depth from any trained model for the bake-off:
+
+```sh
+uv run --extra gsplat python export_depth.py --session <name> --backend 2dgs   # 2dgs median depth
+uv run --extra gsplat python export_depth.py --session <name> --backend 3dgs   # 3dgs expected depth
+```
 
 ## Install
 

--- a/script/gsplat/colmap_dataset.py
+++ b/script/gsplat/colmap_dataset.py
@@ -101,11 +101,25 @@ class CameraView:
 
 
 def read_images(path: Path, cameras: dict[int, CameraModel]) -> list[CameraView]:
-    """Header line carries the pose; the following keypoint line is skipped."""
+    """Two *physical* lines per image: a pose header, then a POINTS2D line.
+
+    The POINTS2D line can be **empty** (a refined image that kept its pose but has no
+    surviving 2D points — valid COLMAP). So we pair by physical line position rather than
+    filtering blanks first: a blank-skipping pass would drop those empty lines and desync
+    every subsequent pose. Comments only appear in the header block, never mid-record.
+    """
     views: list[CameraView] = []
-    it = _iter_data_lines(path)
-    for header in it:
-        next(it)  # discard the POINTS2D line -- unused for 3DGS
+    with open(path) as f:
+        lines = f.read().split("\n")
+
+    i, n = 0, len(lines)
+    while i < n:
+        header = lines[i].strip()
+        if not header or header.startswith("#"):
+            i += 1
+            continue
+        i += 2  # consume the header AND its POINTS2D line (which may be empty)
+
         h = header.split()
         image_id = int(h[0])
         qw, qx, qy, qz = (float(x) for x in h[1:5])

--- a/script/gsplat/export_depth.py
+++ b/script/gsplat/export_depth.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from gsplat import rasterization
+from gsplat import rasterization, rasterization_2dgs
 from colmap_dataset import read_cameras, read_images
 
 
@@ -72,8 +72,10 @@ def main():
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
         from lar_session import Session
         s = Session(args.session)
+        # 2dgs backend reads the surfel model dir; 3dgs (or anything else) the volumetric one.
+        gs_mode = "2dgs" if args.backend == "2dgs" else "3dgs"
         args.model = args.model or str(s.best_model())
-        args.gs_dir = args.gs_dir or str(s.gsplat_out(semantic=True))
+        args.gs_dir = args.gs_dir or str(s.gsplat_out(semantic=True, mode=gs_mode))
         args.out = args.out or str(s.depth_dir(args.backend))
     if not (args.gs_dir and args.model and args.out):
         ap.error("need --session or explicit --gs-dir/--model/--out")
@@ -96,9 +98,18 @@ def main():
         K[1, :] *= H / v.height
         vm = torch.from_numpy(v.viewmat).float().to(device)[None]
         Kt = torch.from_numpy(K).float().to(device)[None]
-        render, _, _ = rasterization(means, quats, scales, opac, colors, vm, Kt, W, H,
-                                     sh_degree=None, packed=True, render_mode="RGB+ED")
-        depth = render[0, ..., 3].cpu().numpy().astype(np.float32)  # expected metric z-depth
+        if args.backend == "2dgs":
+            # Surfel rasterizer: median depth is the ray/surface intersection -- the
+            # sharpest, most surface-accurate depth a 2DGS model produces. gsplat 1.5.3's
+            # 2dgs path needs unpacked + a camera dim on non-SH colors (see train.rasterize).
+            _, _, _, _, _, median, _ = rasterization_2dgs(
+                means, quats, scales, opac, colors[None], vm, Kt, W, H,
+                sh_degree=None, packed=False, render_mode="RGB+ED")
+            depth = median[0, ..., 0].cpu().numpy().astype(np.float32)
+        else:
+            render, _, _ = rasterization(means, quats, scales, opac, colors, vm, Kt, W, H,
+                                         sh_degree=None, packed=True, render_mode="RGB+ED")
+            depth = render[0, ..., 3].cpu().numpy().astype(np.float32)  # expected metric z-depth
         np.save(out / f"{Path(v.name).stem}.npy", depth)
         if (i + 1) % 100 == 0 or i + 1 == len(views):
             print(f"  rendered depth {i + 1}/{len(views)}")

--- a/script/gsplat/export_depth.py
+++ b/script/gsplat/export_depth.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Render per-view metric depth from a trained 3DGS/2DGS model -> depth bake-off contract.
+
+Loads a trained ``point_cloud.ply`` (the geometry only — colors are irrelevant for depth)
+and renders each training view's **expected depth** (gsplat ``render_mode="RGB+ED"``, i.e.
+alpha-normalised metric z-depth). Writes ``<out>/<image_stem>.npy`` for the
+``semantic_bev`` depth back-projection harness. Serves the **3DGS** backend directly and
+the **2DGS** backend once a 2DGS model is trained (same .ply layout, surface-accurate depth).
+
+  uv run --extra gsplat python export_depth.py \
+      --session maguro-park-after-itchy --gs-dir ../../output/<name>-gsplat-sem \
+      --backend 3dgs --data-factor 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from gsplat import rasterization
+from colmap_dataset import read_cameras, read_images
+
+
+def _read_float_ply(path: Path) -> dict[str, np.ndarray]:
+    """Read an all-float32 binary_little_endian PLY (our exporter's format)."""
+    with open(path, "rb") as f:
+        if f.readline().strip() != b"ply":
+            raise ValueError(f"{path} is not a PLY")
+        if b"binary_little_endian" not in f.readline():
+            raise ValueError("only binary_little_endian PLY supported")
+        count, names = None, []
+        while True:
+            line = f.readline().strip()
+            if line.startswith(b"element vertex"):
+                count = int(line.split()[-1])
+            elif line.startswith(b"property"):
+                names.append(line.split()[-1].decode())
+            elif line == b"end_header":
+                break
+        dt = np.dtype([(n, "<f4") for n in names])
+        data = np.frombuffer(f.read(count * dt.itemsize), dtype=dt, count=count)
+    return {n: np.ascontiguousarray(data[n]) for n in names}
+
+
+def load_gaussians(ply_path: Path, device: str):
+    """Load geometry (means, quats, scales, opacities) from a 3DGS/2DGS .ply."""
+    p = _read_float_ply(ply_path)
+    means = np.stack([p["x"], p["y"], p["z"]], axis=1)
+    scales = np.stack([p[f"scale_{i}"] for i in range(3)], axis=1)  # log-space
+    quats = np.stack([p[f"rot_{i}"] for i in range(4)], axis=1)
+    opac = p["opacity"]                                             # logit
+    t = lambda a: torch.from_numpy(a).float().to(device)
+    return t(means), t(quats), torch.exp(t(scales)), torch.sigmoid(t(opac))
+
+
+@torch.no_grad()
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None, help="fills --model/--gs-dir/--out from the layout")
+    ap.add_argument("--backend", default="3dgs", help="tag for the output dir (3dgs/2dgs)")
+    ap.add_argument("--gs-dir", default=None, help="trained gsplat run dir (has point_cloud.ply)")
+    ap.add_argument("--model", default=None, help="COLMAP text model (cameras/poses)")
+    ap.add_argument("--out", default=None, help="depth output dir (<stem>.npy)")
+    ap.add_argument("--data-factor", type=int, default=2)
+    args = ap.parse_args()
+
+    if args.session:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.gs_dir = args.gs_dir or str(s.gsplat_out(semantic=True))
+        args.out = args.out or str(s.depth_dir(args.backend))
+    if not (args.gs_dir and args.model and args.out):
+        ap.error("need --session or explicit --gs-dir/--model/--out")
+
+    assert torch.cuda.is_available(), "depth render needs a CUDA GPU"
+    device = "cuda"
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    means, quats, scales, opac = load_gaussians(Path(args.gs_dir) / "point_cloud.ply", device)
+    print(f"loaded {means.shape[0]} Gaussians from {args.gs_dir}")
+    colors = torch.zeros(means.shape[0], 3, device=device)  # unused; depth only
+
+    cams = read_cameras(Path(args.model) / "cameras.txt")
+    views = read_images(Path(args.model) / "images.txt", cams)
+    f = args.data_factor
+    for i, v in enumerate(views):
+        W, H = v.width // f, v.height // f
+        K = v.K.copy()
+        K[0, :] *= W / v.width
+        K[1, :] *= H / v.height
+        vm = torch.from_numpy(v.viewmat).float().to(device)[None]
+        Kt = torch.from_numpy(K).float().to(device)[None]
+        render, _, _ = rasterization(means, quats, scales, opac, colors, vm, Kt, W, H,
+                                     sh_degree=None, packed=True, render_mode="RGB+ED")
+        depth = render[0, ..., 3].cpu().numpy().astype(np.float32)  # expected metric z-depth
+        np.save(out / f"{Path(v.name).stem}.npy", depth)
+        if (i + 1) % 100 == 0 or i + 1 == len(views):
+            print(f"  rendered depth {i + 1}/{len(views)}")
+    print(f"done -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gsplat/model.py
+++ b/script/gsplat/model.py
@@ -149,9 +149,14 @@ def export_semantic(params: nn.ParameterDict, path_stem: str | Path, color_lut) 
     """
     path_stem = Path(path_stem)
     means = params["means"].detach().cpu().numpy()
-    labels = params["sem"].detach().argmax(dim=1).cpu().numpy().astype(np.uint8)
+    logits = params["sem"].detach()
+    labels = logits.argmax(dim=1).cpu().numpy().astype(np.uint8)
+    # Confidence = peak softmax prob. Poorly-observed Gaussians have near-flat logits
+    # (~1/num_classes), so this down-weights them when the BEV builder votes per cell.
+    conf = torch.softmax(logits, dim=1).max(dim=1).values.cpu().numpy().astype(np.float32)
 
     np.save(path_stem.with_name(path_stem.name + "_labels.npy"), labels)
+    np.save(path_stem.with_name(path_stem.name + "_confidence.npy"), conf)
 
     lut = np.asarray(color_lut, dtype=np.float32) / 255.0
     rgb = lut[labels]

--- a/script/gsplat/prune_gaussians.py
+++ b/script/gsplat/prune_gaussians.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Post-hoc prune outlier Gaussians from a trained point_cloud.ply.
+
+The metric (un-normalized) park reconstruction is fundamentally good -- opaque, sharp,
+median scale ~0.1 m -- but carries a heavy tail of pathological Gaussians (max scale
+tens of km, anisotropy in the thousands). Those giant/needle splats smear across the
+frame as the near-camera "veil" and the starburst spikes. Training regularizers meant
+to prevent them (opacity_reg/scale_reg) are tuned for scenes normalized to unit scale
+and collapse this metric scene instead -- so we clean up after the fact rather than
+fight the optimizer.
+
+Keeps a Gaussian iff:  max_axis_scale < --max-scale  AND  anisotropy < --max-aniso
+(anisotropy = largest/smallest axis; flat ground/canopy disks are legitimately ~8-10x,
+so the cut targets only the extreme needles). Optionally also drop opacity < --min-opacity.
+
+Preserves every PLY field, so the output re-opens in any 3DGS viewer. If a row-aligned
+<stem>_labels.npy / _confidence.npy sit alongside the input, they're filtered too.
+
+  uv run --extra gsplat python prune_gaussians.py \
+      --ply ../../output/<run>/point_cloud.ply \
+      --max-scale 2.0 --max-aniso 100 --min-opacity 0.0 \
+      --out ../../output/<run>/point_cloud_pruned.ply
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+
+def read_ply(path: Path):
+    with open(path, "rb") as f:
+        assert f.readline().strip() == b"ply"
+        fields, n = [], 0
+        while True:
+            line = f.readline().decode("ascii").strip()
+            if line == "end_header":
+                break
+            if line.startswith("element vertex"):
+                n = int(line.split()[-1])
+            elif line.startswith("property float"):
+                fields.append(line.split()[-1])
+        data = np.fromfile(f, dtype="<f4", count=n * len(fields)).reshape(n, len(fields))
+    return data, fields
+
+
+def write_ply(path: Path, data: np.ndarray, fields: list[str]) -> None:
+    data = np.ascontiguousarray(data, dtype="<f4")
+    header = (
+        "ply\nformat binary_little_endian 1.0\n"
+        f"element vertex {data.shape[0]}\n"
+        + "".join(f"property float {f}\n" for f in fields)
+        + "end_header\n"
+    )
+    with open(path, "wb") as f:
+        f.write(header.encode("ascii"))
+        data.tofile(f)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--ply", required=True)
+    p.add_argument("--out", default=None, help="default: <ply stem>_pruned.ply")
+    p.add_argument("--max-scale", type=float, default=2.0,
+                   help="drop Gaussians whose largest axis (metres) exceeds this")
+    p.add_argument("--max-aniso", type=float, default=100.0,
+                   help="drop Gaussians whose largest/smallest axis ratio exceeds this")
+    p.add_argument("--min-opacity", type=float, default=0.0,
+                   help="also drop Gaussians below this opacity (0 = keep all opacities)")
+    args = p.parse_args()
+
+    ply = Path(args.ply)
+    out = Path(args.out) if args.out else ply.with_name(ply.stem + "_pruned.ply")
+
+    data, fields = read_ply(ply)
+    c = {k: i for i, k in enumerate(fields)}
+    n = data.shape[0]
+
+    sc = np.exp(data[:, [c["scale_0"], c["scale_1"], c["scale_2"]]])
+    smax = sc.max(1)
+    aniso = smax / np.clip(sc.min(1), 1e-9, None)
+    opacity = 1.0 / (1.0 + np.exp(-data[:, c["opacity"]]))
+
+    keep = (smax < args.max_scale) & (aniso < args.max_aniso)
+    if args.min_opacity > 0.0:
+        keep &= opacity > args.min_opacity
+
+    write_ply(out, data[keep], fields)
+    print(f"{ply.name}: kept {keep.sum()}/{n} ({keep.mean() * 100:.1f}%), "
+          f"dropped {(~keep).sum()} -> {out}")
+
+    # Filter any row-aligned semantic sidecars so labels stay in sync with the splats.
+    stem = ply.with_name(ply.stem)
+    for suffix in ("_labels.npy", "_confidence.npy"):
+        side = stem.with_name(stem.name + suffix)
+        if side.exists():
+            arr = np.load(side)
+            if arr.shape[0] == n:
+                np.save(out.with_name(out.stem + suffix), arr[keep])
+                print(f"  filtered sidecar {side.name} -> {out.stem + suffix}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gsplat/render_previews.py
+++ b/script/gsplat/render_previews.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Render a few RGB previews from an already-trained point_cloud.ply.
+
+Reloads the exported INRIA-layout Gaussians and rasterises them from a spread of
+training cameras -- a quick way to eyeball a finished run from more than the single
+end-of-training view train.py dumps.
+
+  uv run --extra gsplat python render_previews.py \
+      --ply   ../../output/<run>/point_cloud.ply \
+      --model ../../output/<run-refined>/colmap/sparse/0 \
+      --num 8 --data-factor 2
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+from gsplat import rasterization
+from colmap_dataset import read_cameras, read_images
+
+
+def load_ply(path: Path, device: str):
+    """Parse an INRIA 3DGS binary PLY back into gsplat rasterization inputs."""
+    with open(path, "rb") as f:
+        assert f.readline().strip() == b"ply"
+        fields, n = [], 0
+        while True:
+            line = f.readline().decode("ascii").strip()
+            if line == "end_header":
+                break
+            if line.startswith("element vertex"):
+                n = int(line.split()[-1])
+            elif line.startswith("property float"):
+                fields.append(line.split()[-1])
+        data = np.fromfile(f, dtype="<f4", count=n * len(fields)).reshape(n, len(fields))
+
+    col = {name: i for i, name in enumerate(fields)}
+    means = torch.from_numpy(data[:, [col["x"], col["y"], col["z"]]].copy())
+    f_dc = data[:, [col["f_dc_0"], col["f_dc_1"], col["f_dc_2"]]]          # (N, 3)
+    rest_names = sorted((k for k in col if k.startswith("f_rest_")),
+                        key=lambda s: int(s.split("_")[-1]))
+    f_rest = data[:, [col[k] for k in rest_names]]                          # (N, 3*(K-1))
+    k_minus1 = f_rest.shape[1] // 3
+    # INRIA lays f_rest out channel-major: [R band coeffs, G band coeffs, B band coeffs].
+    shN = f_rest.reshape(n, 3, k_minus1).transpose(0, 2, 1)                 # (N, K-1, 3)
+    sh = np.concatenate([f_dc[:, None, :], shN], axis=1)                    # (N, K, 3)
+    sh_degree = int(round(sh.shape[1] ** 0.5)) - 1
+
+    opacities = torch.sigmoid(torch.from_numpy(data[:, [col["opacity"]]].copy()).squeeze(-1))
+    scales = torch.exp(torch.from_numpy(
+        data[:, [col["scale_0"], col["scale_1"], col["scale_2"]]].copy()))
+    quats = torch.from_numpy(data[:, [col["rot_0"], col["rot_1"], col["rot_2"], col["rot_3"]]].copy())
+    return dict(
+        means=means.to(device), colors=torch.from_numpy(sh.copy()).to(device),
+        opacities=opacities.to(device), scales=scales.to(device), quats=quats.to(device),
+        sh_degree=sh_degree, n=n,
+    )
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--ply", required=True)
+    p.add_argument("--model", required=True, help="COLMAP text model dir (cameras.txt/images.txt)")
+    p.add_argument("--out", default=None, help="output dir (default: alongside the ply)")
+    p.add_argument("--num", type=int, default=8, help="number of views to render")
+    p.add_argument("--data-factor", type=int, default=2)
+    args = p.parse_args()
+
+    device = "cuda"
+    ply = Path(args.ply)
+    out = Path(args.out) if args.out else ply.parent
+    out.mkdir(parents=True, exist_ok=True)
+
+    g = load_ply(ply, device)
+    print(f"loaded {g['n']} Gaussians (sh_degree={g['sh_degree']}) from {ply}")
+
+    model_dir = Path(args.model)
+    cameras = read_cameras(model_dir / "cameras.txt")
+    views = read_images(model_dir / "images.txt", cameras)
+    idxs = np.linspace(0, len(views) - 1, args.num).round().astype(int)
+    print(f"{len(views)} cameras; rendering {len(idxs)} evenly-spaced views")
+
+    f = args.data_factor
+    for j, vi in enumerate(idxs):
+        v = views[int(vi)]
+        W, H = v.width // f, v.height // f
+        K = v.K.copy()
+        K[0, :] *= W / v.width
+        K[1, :] *= H / v.height
+        viewmat = torch.from_numpy(v.viewmat).float().to(device)
+        Kt = torch.from_numpy(K).float().to(device)
+        with torch.no_grad():
+            renders, _, _ = rasterization(
+                means=g["means"], quats=g["quats"], scales=g["scales"],
+                opacities=g["opacities"], colors=g["colors"],
+                viewmats=viewmat[None], Ks=Kt[None], width=W, height=H,
+                sh_degree=g["sh_degree"], packed=True, render_mode="RGB",
+            )
+        rgb = renders[0].clamp(0, 1).cpu().numpy()
+        img = (rgb * 255).clip(0, 255).astype(np.uint8)
+        path = out / f"render_{j:02d}_{Path(v.name).stem}.png"
+        cv2.imwrite(str(path), cv2.cvtColor(img, cv2.COLOR_RGB2BGR))
+        print(f"  [{j + 1}/{len(idxs)}] {v.name} -> {path.name}")
+
+    print(f"done -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gsplat/train.py
+++ b/script/gsplat/train.py
@@ -15,6 +15,13 @@ size, trading detail for a coarse-but-complete model that fits an 8 GB laptop GP
   uv run --extra gsplat --extra segmentation python train.py ... \
       --semantic --segmenter mask2former-large
 
+  # 2DGS (surfel) mode: cleaner surface-aligned depth for the BEV back-projection.
+  uv run --extra gsplat python train.py --session <name> --mode 2dgs
+
+``--mode 2dgs`` swaps the volumetric rasterizer for the surfel (2D Gaussian) one and adds
+the normal-consistency / distortion surface regularizers, keeping the same MCMC ``--cap-max``
+VRAM budget. It writes to a separate ``-gsplat2d`` dir so it never clobbers a 3DGS model.
+
 Semantic training is two-phase (the reliable, canonical recipe):
   Phase 1 (--max-steps) trains RGB + geometry with MCMC densification -- identical to a
     plain RGB run, no semantic field involved.
@@ -39,11 +46,43 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from gsplat import rasterization
+from gsplat import rasterization, rasterization_2dgs
 from gsplat.strategy import MCMCStrategy
 
 import model as gmodel
 from colmap_dataset import ColmapDataset
+
+
+def rasterize(mode, *, colors, sh_degree, packed=True, render_mode="RGB", **kw):
+    """Dispatch to the 3DGS or 2DGS rasterizer, returning a uniform 4-tuple.
+
+    Both paths return ``(colors, alphas, info, aux)``. For 2DGS ``aux`` carries the
+    surfel extras used by the surface regularizers -- rendered normals, the normals
+    implied by the depth map, and the per-pixel distortion. For 3DGS ``aux`` is ``None``.
+    MCMC's densification never reads ``info``, so the two rasterizers' differing meta
+    dicts are interchangeable here.
+
+    gsplat 1.5.3's ``rasterization_2dgs`` has three sharp edges that this wrapper hides so
+    the trainer never has to think about them (all verified empirically on this build):
+      * **packed is buggy** -- the packed path mis-gathers colors to the intersection count
+        (``colors.shape[0] == nnz`` assert) and fails on most inputs. Force ``packed=False``.
+      * **needs a depth render mode** -- ``surf_normals`` (normal-from-depth, required by the
+        normal-consistency reg) is only produced when depth is rendered, and the internal
+        colors/depth ``cat`` only lines up then. Force ``RGB+ED`` and slice the depth back off.
+      * **non-SH colors need a camera dim** -- with ``sh_degree=None`` gsplat forgets to add
+        the ``C`` axis, so ``(N, D)`` collides with depth ``(1, N, 1)``. Pass ``(1, N, D)``.
+    """
+    if mode == "2dgs":
+        c_in = colors if sh_degree is not None else colors[None]      # (N,D) -> (1,N,D)
+        colors_out, alphas, normals, surf_normals, distort, median, info = rasterization_2dgs(
+            colors=c_in, sh_degree=sh_degree, packed=False, render_mode="RGB+ED", **kw)
+        n_ch = 3 if sh_degree is not None else colors.shape[-1]       # strip appended depth
+        aux = {"normals": normals, "surf_normals": surf_normals,
+               "distort": distort, "median": median}
+        return colors_out[..., :n_ch], alphas, info, aux
+    colors, alphas, info = rasterization(
+        colors=colors, sh_degree=sh_degree, packed=packed, render_mode=render_mode, **kw)
+    return colors, alphas, info, None
 
 
 # --------------------------------------------------------------------------- metrics
@@ -106,7 +145,7 @@ def train(args):
     out.mkdir(parents=True, exist_ok=True)
     image_dir = Path(args.images) if args.images else Path(args.model).parent
 
-    print(f"gsplat 3DGS training -> {out}")
+    print(f"gsplat {args.mode.upper()} training -> {out}")
     ds = ColmapDataset(args.model, image_dir, data_factor=args.data_factor, limit=args.limit)
 
     # Optionally subsample the init cloud. MCMC's --cap-max only bounds *growth*, so if
@@ -185,7 +224,8 @@ def train(args):
         H, W = v.height, v.width
 
         colors = torch.cat([params["sh0"], params["shN"]], dim=1)  # (N, K, 3)
-        renders, alphas, info = rasterization(
+        renders, alphas, info, aux = rasterize(
+            args.mode,
             means=params["means"],
             quats=params["quats"],
             scales=torch.exp(params["scales"]),
@@ -198,11 +238,36 @@ def train(args):
             packed=True,
             render_mode="RGB",
         )
-        rgb = renders[0].clamp(0.0, 1.0)  # (H, W, 3)
+        # Random-background compositing: add bkgd*(1-alpha) to the render only (GT is the
+        # raw image). Where real content exists this forces alpha->1; the leftover sky
+        # fill is randomized so floaters can't settle on one convenient background colour.
+        raw_rgb = renders[0].clamp(0.0, 1.0)  # clean render, for preview/PSNR logging
+        rgb = renders[0]
+        if args.random_bkgd:
+            bkgd = torch.rand(3, device=device)
+            rgb = rgb + bkgd * (1.0 - alphas[0])
+        rgb = rgb.clamp(0.0, 1.0)  # (H, W, 3), background-composited -> loss
 
         l1 = F.l1_loss(rgb, gt)
         ssim_val = ssim(rgb.permute(2, 0, 1)[None], gt.permute(2, 0, 1)[None])
         loss = (1.0 - lam) * l1 + lam * (1.0 - ssim_val)
+        # MCMC regularizers on the raw (positive) opacity/scale values.
+        if args.opacity_reg:
+            loss = loss + args.opacity_reg * torch.sigmoid(params["opacities"]).mean()
+        if args.scale_reg:
+            loss = loss + args.scale_reg * torch.exp(params["scales"]).mean()
+        # 2DGS surface regularizers (paper §3.3), warmed up so they only bite once the
+        # geometry has roughly settled: normal consistency snaps the disks flush to the
+        # surface (this is what makes 2DGS depth cleaner than 3DGS); distortion pulls the
+        # ray's mass onto a single depth. Both default OFF-ish -- see the arg help.
+        nloss = dloss = None
+        if aux is not None and step >= args.reg_start:
+            if args.normal_reg:
+                nloss = (1.0 - (aux["normals"] * aux["surf_normals"]).sum(dim=-1)).mean()
+                loss = loss + args.normal_reg * nloss
+            if args.dist_reg:
+                dloss = aux["distort"].mean()
+                loss = loss + args.dist_reg * dloss
 
         strategy.step_pre_backward(params, optimizers, strategy_state, step, info)
         loss.backward()
@@ -218,10 +283,15 @@ def train(args):
         if step % args.log_every == 0 or step == args.max_steps - 1:
             n = params["means"].shape[0]
             rate = (step + 1) / (time.time() - t0)
+            extra = ""
+            if nloss is not None:
+                extra += f" nrm={nloss.item():.3f}"
+            if dloss is not None:
+                extra += f" dist={dloss.item():.4f}"
             print(f"[P1 {step:6d}/{args.max_steps}] loss={loss.item():.4f} "
-                  f"psnr={psnr(rgb, gt):.2f} gaussians={n} {rate:.1f} it/s")
+                  f"psnr={psnr(raw_rgb, gt):.2f} gaussians={n}{extra} {rate:.1f} it/s")
         if args.preview_every and (step % args.preview_every == 0 or step == args.max_steps - 1):
-            _save_preview(rgb, out / f"preview_{step:06d}.png")
+            _save_preview(raw_rgb, out / f"preview_{step:06d}.png")
         # Periodic geometry checkpoint so a long RGB phase survives a late crash/OOM.
         if args.save_every and step > 0 and step % args.save_every == 0:
             gmodel.export_gaussian_ply(params, out / "point_cloud.ply")
@@ -254,7 +324,8 @@ def train(args):
                 order = np.random.permutation(n_views)
             v = ds.views[idx]
 
-            sem_render, _, _ = rasterization(
+            sem_render, _, _, _ = rasterize(
+                args.mode,
                 means=geo["means"], quats=geo["quats"], scales=geo["scales"],
                 opacities=geo["opacities"], colors=params["sem"],
                 viewmats=viewmats[idx][None], Ks=Ks[idx][None],
@@ -312,6 +383,11 @@ def main():
     p.add_argument("--limit", type=int, default=None,
                    help="use only the first N images (smoke tests)")
 
+    p.add_argument("--mode", choices=["3dgs", "2dgs"], default="3dgs",
+                   help="Gaussian primitive: 3dgs (volumetric ellipsoids) or 2dgs "
+                        "(surfels/flat disks). 2dgs gives cleaner surface-aligned depth for "
+                        "the BEV back-projection, at some RGB fidelity. Same MCMC/--cap-max "
+                        "VRAM budget either way; writes to a separate -gsplat2d output dir.")
     p.add_argument("--max-steps", type=int, default=30000)
     p.add_argument("--cap-max", type=int, default=1_000_000,
                    help="hard cap on Gaussian count (MCMC). Lower = coarser + less VRAM.")
@@ -324,6 +400,34 @@ def main():
     p.add_argument("--ssim-weight", type=float, default=0.2)
     p.add_argument("--refine-start", type=int, default=500)
     p.add_argument("--refine-every", type=int, default=100)
+    # MCMC regularizers (the official recipe treats these as mandatory): opacity-reg
+    # pushes surplus Gaussians toward zero opacity so pruning removes the near-camera
+    # floater veil; scale-reg penalizes large scales so Gaussians stop growing into the
+    # view-ray needles/spikes. Omitting them is what wrecks an otherwise-correct scene.
+    # NOTE (2026-07-06): these three all DEGRADED the metric park scene and are OFF by
+    # default. gsplat's 0.01 reg defaults assume a scene normalized to ~unit scale; on our
+    # un-normalized metric coords they collapse opacity (median 1.0->0.015) and explode
+    # anisotropy. Random-bkgd just produced hazy fog on view-inconsistent foliage. Prefer
+    # post-hoc prune_gaussians.py for the veil/spike artifacts. See gsplat-pipeline memory.
+    p.add_argument("--opacity-reg", type=float, default=0.0,
+                   help="MCMC opacity regulariser (0 = off; >0 collapsed opacity on this scene)")
+    p.add_argument("--scale-reg", type=float, default=0.0,
+                   help="MCMC scale regulariser (0 = off; >0 exploded anisotropy on this scene)")
+    p.add_argument("--random-bkgd", action=argparse.BooleanOptionalAction, default=False,
+                   help="composite a random background onto the render each step (default off; "
+                        "on produced hazy fog here)")
+
+    # 2DGS surface regularizers (ignored when --mode 3dgs). normal-reg is the safe,
+    # standard one (0.05, the 2DGS paper value) and is what actually flattens the surfels
+    # onto the surface for clean depth. dist-reg (distortion) sharpens depth further but,
+    # like the MCMC regs above, can misbehave on our un-normalized metric coords, so it's
+    # OFF by default -- turn it on cautiously and watch the depth previews.
+    p.add_argument("--normal-reg", type=float, default=0.05,
+                   help="2DGS normal-consistency weight (0 = off; 0.05 = paper default)")
+    p.add_argument("--dist-reg", type=float, default=0.0,
+                   help="2DGS distortion weight (0 = off; risky on metric coords, tune up slowly)")
+    p.add_argument("--reg-start", type=int, default=500,
+                   help="delay the 2DGS surface regularizers until this step (let geometry settle first)")
 
     p.add_argument("--semantic", action="store_true",
                    help="train a per-Gaussian semantic head distilled from a 2D segmenter")
@@ -359,7 +463,7 @@ def _resolve_session(args, parser):
         s = Session(args.session)
         args.model = args.model or str(s.best_model())
         args.images = args.images or str(s.images)
-        args.out = args.out or str(s.gsplat_out(semantic=args.semantic))
+        args.out = args.out or str(s.gsplat_out(semantic=args.semantic, mode=args.mode))
         print(f"session '{args.session}':\n  model  = {args.model}\n"
               f"  images = {args.images}\n  out    = {args.out}")
     missing = [m for m in ("model", "out") if not getattr(args, m)]

--- a/script/gsplat/train.py
+++ b/script/gsplat/train.py
@@ -11,9 +11,16 @@ size, trading detail for a coarse-but-complete model that fits an 8 GB laptop GP
       --out    ../../output/<session>-gsplat \
       --data-factor 2 --cap-max 300000 --max-steps 30000
 
-  # Semantic 3DGS: also distil a segmenter into per-Gaussian class logits
+  # Semantic 3DGS: distil a segmenter into per-Gaussian class logits
   uv run --extra gsplat --extra segmentation python train.py ... \
       --semantic --segmenter mask2former-large
+
+Semantic training is two-phase (the reliable, canonical recipe):
+  Phase 1 (--max-steps) trains RGB + geometry with MCMC densification -- identical to a
+    plain RGB run, no semantic field involved.
+  Phase 2 (--sem-steps) attaches a fresh semantic field to the CONVERGED Gaussians and
+    trains only it, with geometry detached (MCMC off). Cross-entropy distils the 2D masks
+    onto fixed supports, so semantics can never move or degrade the reconstruction.
 
 See README.md. Requires a CUDA toolchain (nvcc) matching the installed torch, because
 gsplat compiles kernels on first import.
@@ -112,14 +119,17 @@ def train(args):
         points_xyz, points_rgb = points_xyz[sel], points_rgb[sel]
         print(f"subsampled init cloud {len(ds.points_xyz)} -> {init_max} points (<= cap_max)")
 
-    # Semantic head: cache masks + per-view targets up front.
+    # Semantic supervision (Phase 2): cache masks up front so a misconfigured segmenter
+    # fails fast, not after a multi-hour RGB phase.
     masks = None
     num_classes = None
     color_lut = None
+    ignore_index = 0
     if args.semantic:
         import semantic as sem_mod
         num_classes = sem_mod.NUM_CLASSES
         color_lut = sem_mod.SEMANTIC_COLOR_LUT
+        ignore_index = sem_mod.IGNORE_INDEX
         # Namespace the cache by segmenter so switching backends (oneformer ->
         # mask2former-large) against the same --out never silently reuses stale masks.
         store = sem_mod.build_mask_cache(
@@ -130,16 +140,16 @@ def train(args):
             torch.from_numpy(sem_mod.load_mask(store, v.name, v.width, v.height).astype(np.int64))
             for v in ds.views
         ]
-        ignore_index = sem_mod.IGNORE_INDEX
-        print(f"semantic head enabled: {num_classes} classes, segmenter={args.segmenter}")
+        print(f"semantic enabled: {num_classes} classes, segmenter={args.segmenter}")
 
+    # Phase 1 Gaussians carry no semantic field -- this phase is identical to a plain,
+    # well-tested RGB run. The semantic field is attached afterwards (Phase 2).
     params = gmodel.init_gaussians(
-        points_xyz, points_rgb, sh_degree=args.sh_degree,
-        num_classes=num_classes, device=device,
+        points_xyz, points_rgb, sh_degree=args.sh_degree, num_classes=None, device=device,
     )
     print(f"initialised {params['means'].shape[0]} Gaussians (sh_degree={args.sh_degree})")
 
-    optimizers, lrs = build_optimizers(params, ds.scene_scale, args.semantic)
+    optimizers, lrs = build_optimizers(params, ds.scene_scale, sem=False)
     # Exponential decay of the means lr (positions settle as training progresses).
     means_gamma = (0.01) ** (1.0 / args.max_steps)
 
@@ -160,9 +170,11 @@ def train(args):
 
     lam = args.ssim_weight
     n_views = len(ds.views)
-    order = np.random.permutation(n_views)
     t0 = time.time()
 
+    # ===================== Phase 1: RGB + geometry (MCMC densification) =====================
+    print(f"\nPhase 1 — RGB/geometry, {args.max_steps} steps")
+    order = np.random.permutation(n_views)
     for step in range(args.max_steps):
         idx = int(order[step % n_views])
         if step % n_views == 0 and step > 0:
@@ -192,59 +204,74 @@ def train(args):
         ssim_val = ssim(rgb.permute(2, 0, 1)[None], gt.permute(2, 0, 1)[None])
         loss = (1.0 - lam) * l1 + lam * (1.0 - ssim_val)
 
-        sem_loss = torch.tensor(0.0, device=device)
-        if args.semantic and step >= args.sem_start:
-            sem_render, _, _ = rasterization(
-                means=params["means"],
-                quats=params["quats"],
-                scales=torch.exp(params["scales"]),
-                opacities=torch.sigmoid(params["opacities"]),
-                colors=params["sem"],
-                viewmats=viewmats[idx][None],
-                Ks=Ks[idx][None],
-                width=W, height=H,
-                sh_degree=None,
-                packed=True,
-                render_mode="RGB",
-            )
-            logits = sem_render.permute(0, 3, 1, 2)              # (1, C, H, W)
-            target = masks[idx].to(device)[None]                 # (1, H, W)
-            sem_loss = F.cross_entropy(logits, target, ignore_index=ignore_index)
-            loss = loss + args.sem_weight * sem_loss
-
         strategy.step_pre_backward(params, optimizers, strategy_state, step, info)
         loss.backward()
-
         for opt in optimizers.values():
             opt.step()
             opt.zero_grad(set_to_none=True)
 
-        # Decay means lr.
         cur_means_lr = lrs["means"] * (means_gamma ** step)
         for g in optimizers["means"].param_groups:
             g["lr"] = cur_means_lr
-
-        strategy.step_post_backward(
-            params, optimizers, strategy_state, step, info, lr=cur_means_lr
-        )
+        strategy.step_post_backward(params, optimizers, strategy_state, step, info, lr=cur_means_lr)
 
         if step % args.log_every == 0 or step == args.max_steps - 1:
             n = params["means"].shape[0]
             rate = (step + 1) / (time.time() - t0)
-            msg = (f"[{step:6d}/{args.max_steps}] loss={loss.item():.4f} "
-                   f"psnr={psnr(rgb, gt):.2f} gaussians={n} {rate:.1f} it/s")
-            if args.semantic and step >= args.sem_start:
-                msg += f" sem_ce={sem_loss.item():.4f}"
-            print(msg)
-
+            print(f"[P1 {step:6d}/{args.max_steps}] loss={loss.item():.4f} "
+                  f"psnr={psnr(rgb, gt):.2f} gaussians={n} {rate:.1f} it/s")
         if args.preview_every and (step % args.preview_every == 0 or step == args.max_steps - 1):
             _save_preview(rgb, out / f"preview_{step:06d}.png")
-
-        # Periodic checkpoint so a long train survives a late crash/OOM (don't wait
-        # until the very end to write anything to disk).
+        # Periodic geometry checkpoint so a long RGB phase survives a late crash/OOM.
         if args.save_every and step > 0 and step % args.save_every == 0:
-            save_outputs(params, out, args.semantic, color_lut, num_classes,
-                         label=f"checkpoint @ step {step}")
+            gmodel.export_gaussian_ply(params, out / "point_cloud.ply")
+
+    gmodel.export_gaussian_ply(params, out / "point_cloud.ply")
+    print(f"Phase 1 done in {time.time() - t0:.1f}s")
+
+    # ============= Phase 2: semantic field on FROZEN geometry (canonical recipe) =============
+    # Attach a fresh semantic field to the final Gaussians and train only it, with the
+    # geometry inputs detached: cross-entropy can label the supports but can never move
+    # or degrade them, and MCMC is off. This is the reliable LangSplat/Feature-3DGS recipe.
+    if args.semantic:
+        n = params["means"].shape[0]
+        params["sem"] = torch.nn.Parameter(torch.zeros(n, num_classes, device=device))
+        sem_opt = torch.optim.Adam([params["sem"]], lr=args.sem_lr, eps=1e-15)
+
+        geo = dict(  # frozen snapshot of the converged geometry
+            means=params["means"].detach(),
+            quats=params["quats"].detach(),
+            scales=torch.exp(params["scales"]).detach(),
+            opacities=torch.sigmoid(params["opacities"]).detach(),
+        )
+
+        print(f"\nPhase 2 — semantic ({args.segmenter}), {args.sem_steps} steps, geometry frozen")
+        t1 = time.time()
+        order = np.random.permutation(n_views)
+        for step in range(args.sem_steps):
+            idx = int(order[step % n_views])
+            if step % n_views == 0 and step > 0:
+                order = np.random.permutation(n_views)
+            v = ds.views[idx]
+
+            sem_render, _, _ = rasterization(
+                means=geo["means"], quats=geo["quats"], scales=geo["scales"],
+                opacities=geo["opacities"], colors=params["sem"],
+                viewmats=viewmats[idx][None], Ks=Ks[idx][None],
+                width=v.width, height=v.height, sh_degree=None, packed=True, render_mode="RGB",
+            )
+            logits = sem_render.permute(0, 3, 1, 2)          # (1, C, H, W)
+            target = masks[idx].to(device)[None]             # (1, H, W)
+            ce = F.cross_entropy(logits, target, ignore_index=ignore_index)
+            ce.backward()
+            sem_opt.step()
+            sem_opt.zero_grad(set_to_none=True)
+
+            if step % args.log_every == 0 or step == args.sem_steps - 1:
+                rate = (step + 1) / (time.time() - t1)
+                print(f"[P2 {step:6d}/{args.sem_steps}] sem_ce={ce.item():.4f} {rate:.1f} it/s")
+            if args.save_every and step > 0 and step % args.save_every == 0:
+                gmodel.export_semantic(params, out / "point_cloud", color_lut)
 
     save_outputs(params, out, args.semantic, color_lut, num_classes, label="final")
     (out / "config.json").write_text(json.dumps(vars(args), indent=2, default=str))
@@ -300,9 +327,9 @@ def main():
     p.add_argument("--segmenter", default="mask2former-large",
                    help="semantic_bev segmenter kind (default: mask2former-large; also "
                         "oneformer[-large]/mask2former/clipseg)")
-    p.add_argument("--sem-weight", type=float, default=1.0, help="semantic CE loss weight")
-    p.add_argument("--sem-start", type=int, default=0,
-                   help="step to start semantic supervision (let geometry form first)")
+    p.add_argument("--sem-steps", type=int, default=7000,
+                   help="Phase 2 steps: train the semantic field on the frozen geometry")
+    p.add_argument("--sem-lr", type=float, default=1e-2, help="learning rate for semantic logits")
     p.add_argument("--overwrite-masks", action="store_true",
                    help="re-run the segmenter even if masks are cached")
 

--- a/script/gsplat/train.py
+++ b/script/gsplat/train.py
@@ -299,11 +299,14 @@ def _save_preview(rgb: torch.Tensor, path: Path) -> None:
 def main():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--model", required=True,
-                   help="COLMAP text model dir (…/colmap/poses_txt)")
+    p.add_argument("--session", default=None,
+                   help="LAR session name: fills --model/--images/--out from the canonical "
+                        "layout (script/lar_session.py). Explicit flags override.")
+    p.add_argument("--model", default=None,
+                   help="COLMAP text model dir (…/colmap/sparse/0 or …/poses_txt)")
     p.add_argument("--images", default=None,
-                   help="image dir (default: parent of --model, i.e. …/colmap)")
-    p.add_argument("--out", required=True, help="output dir for plys/previews/config")
+                   help="image dir (default: session images, else parent of --model)")
+    p.add_argument("--out", default=None, help="output dir for plys/previews/config")
     p.add_argument("--data-factor", type=int, default=2,
                    help="downscale images by this integer factor (default: 2; use >=2 at park scale)")
     p.add_argument("--limit", type=int, default=None,
@@ -341,9 +344,27 @@ def main():
                         "survives a late crash (default 5000; 0 = only at the end)")
 
     args = p.parse_args()
+    _resolve_session(args, p)
     if args.preview_every == 0:
         args.preview_every = args.max_steps  # still dump one at the end
     train(args)
+
+
+def _resolve_session(args, parser):
+    """Fill --model/--images/--out from --session (canonical layout); explicit flags win."""
+    if args.session:
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.gsplat_out(semantic=args.semantic))
+        print(f"session '{args.session}':\n  model  = {args.model}\n"
+              f"  images = {args.images}\n  out    = {args.out}")
+    missing = [m for m in ("model", "out") if not getattr(args, m)]
+    if missing:
+        parser.error("need --session or explicit " + " ".join(f"--{m}" for m in missing))
 
 
 if __name__ == "__main__":

--- a/script/lar_session.py
+++ b/script/lar_session.py
@@ -62,5 +62,10 @@ class Session:
     def gsplat_out(self, semantic: bool = False) -> Path:
         return self.root / "output" / f"{self.name}-gsplat{'-sem' if semantic else ''}"
 
-    def sbev_out(self, source: str = "colmap") -> Path:
-        return self.root / "output" / f"{self.name}-sbev{'-gsplat' if source == 'gsplat' else ''}"
+    def sbev_out(self, source: str = "colmap", tag: str | None = None) -> Path:
+        suffix = f"-{tag}" if tag else ("-gsplat" if source == "gsplat" else "")
+        return self.root / "output" / f"{self.name}-sbev{suffix}"
+
+    def depth_dir(self, backend: str) -> Path:
+        """Per-backend per-view depth maps for the depth bake-off (mvs/2dgs/mono/3dgs)."""
+        return self.root / "output" / f"{self.name}-depth-{backend}"

--- a/script/lar_session.py
+++ b/script/lar_session.py
@@ -1,0 +1,66 @@
+"""Canonical directory layout for a LAR capture session — one source of truth.
+
+Every phase of the pipeline reads/writes paths derived from a single **session name**
+(e.g. ``maguro-park-after-itchy``). Encoding the convention here means each tool can accept
+just ``--session <name>`` instead of re-specifying ``--model``/``--images``/``--out`` every
+time. Explicit flags still override whatever the session resolves.
+
+Layout (relative to the repo root that contains ``input/`` and ``output/``):
+
+    input/<name>/                         raw capture (images, frames.json, gps.json, map.json)
+    input/<name>/colmap/poses_txt/        COLMAP text model from script/colmap/colmap.py
+    output/<name>-refined/                lar_refine_colmap output
+    output/<name>-refined/colmap/sparse/0/  refined COLMAP text model (bundle-adjusted)
+    output/<name>-gsplat[-sem]/           script/gsplat/train.py output
+    output/<name>-sbev[-gsplat]/          script/semantic_bev/pipeline.py output
+
+``best_model()`` prefers the refined (bundle-adjusted) model when present, else the raw
+COLMAP model — that's the sensible default input for the gsplat/BEV phases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# script/lar_session.py -> repo root is two levels up (root/script/lar_session.py).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class Session:
+    def __init__(self, name: str, root: Path | str = REPO_ROOT):
+        self.name = name
+        self.root = Path(root)
+
+    # ---- inputs -------------------------------------------------------------
+    @property
+    def input_dir(self) -> Path:
+        return self.root / "input" / self.name
+
+    @property
+    def images(self) -> Path:
+        return self.input_dir
+
+    @property
+    def colmap_model(self) -> Path:
+        """Raw COLMAP text model from the reconstruction phase."""
+        return self.input_dir / "colmap" / "poses_txt"
+
+    @property
+    def refined_dir(self) -> Path:
+        return self.root / "output" / f"{self.name}-refined"
+
+    @property
+    def refined_model(self) -> Path:
+        """Bundle-adjusted COLMAP text model from lar_refine_colmap (the richer one)."""
+        return self.refined_dir / "colmap" / "sparse" / "0"
+
+    def best_model(self) -> Path:
+        """Refined model if it exists, else the raw COLMAP model."""
+        return self.refined_model if (self.refined_model / "images.txt").exists() else self.colmap_model
+
+    # ---- outputs ------------------------------------------------------------
+    def gsplat_out(self, semantic: bool = False) -> Path:
+        return self.root / "output" / f"{self.name}-gsplat{'-sem' if semantic else ''}"
+
+    def sbev_out(self, source: str = "colmap") -> Path:
+        return self.root / "output" / f"{self.name}-sbev{'-gsplat' if source == 'gsplat' else ''}"

--- a/script/lar_session.py
+++ b/script/lar_session.py
@@ -59,8 +59,10 @@ class Session:
         return self.refined_model if (self.refined_model / "images.txt").exists() else self.colmap_model
 
     # ---- outputs ------------------------------------------------------------
-    def gsplat_out(self, semantic: bool = False) -> Path:
-        return self.root / "output" / f"{self.name}-gsplat{'-sem' if semantic else ''}"
+    def gsplat_out(self, semantic: bool = False, mode: str = "3dgs") -> Path:
+        # 2DGS (surfel) models live in a sibling dir so a 2dgs run never clobbers the 3dgs one.
+        kind = "gsplat2d" if mode == "2dgs" else "gsplat"
+        return self.root / "output" / f"{self.name}-{kind}{'-sem' if semantic else ''}"
 
     def sbev_out(self, source: str = "colmap", tag: str | None = None) -> Path:
         suffix = f"-{tag}" if tag else ("-gsplat" if source == "gsplat" else "")

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -94,6 +94,16 @@ class, so this skips segmentation/voting entirely and feeds a much denser, pre-l
 cloud straight into the *same* `build_level`. `--model` is still used (cameras only) to
 detect gravity/up, unless you pass `--up-axis`/`--up-sign`.
 
+**Just pass `--session <name>`** (canonical layout, [`../lar_session.py`](../lar_session.py)):
+it fills `--gsplat-dir` = `output/<name>-gsplat-sem`, `--model` = the refined model (for
+gravity), and `--out` = `output/<name>-sbev-gsplat`. Explicit flags override.
+
+```sh
+uv run python pipeline.py --session maguro-park-after-itchy --source gsplat --cell-size 0.5
+```
+
+Equivalent explicit form:
+
 ```sh
 uv run python pipeline.py --source gsplat \
   --gsplat-dir ../../output/<session>-gsplat-sem \

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -26,6 +26,8 @@ export — and the semantic labels are intended to feed back into localization.
 
 | file | role |
 |------|------|
+| `geometry.py`    | **pure-geometry front-end**: gravity-align + robust ground DEM + ground/vertical split (no semantics) |
+| `geometry_cli.py`| run `geometry.py` on a COLMAP model → DEM hillshade, structure-height, ground/vertical, trajectory, cross-sections |
 | `colmap_io.py`   | read COLMAP text model; tracks give exact observed pixel per point |
 | `taxonomy.py`    | **the semantic contract**: prompts → internal class → IMDF category |
 | `segmentation.py`| `Segmenter` interface + `Heuristic`/`ClipSeg`/`OneFormer` backends |
@@ -36,6 +38,41 @@ export — and the semantic labels are intended to feed back into localization.
 | `pipeline.py`    | end-to-end driver + CLI (auto up-axis/sign detection) |
 | `compare_segmenters.py` | run backends side-by-side on sample images → comparison grid |
 | `verify_orientation.py` | overlay camera trajectory on the BEV (orientation sanity) |
+
+## Geometry front-end (`geometry.py` / `geometry_cli.py`)
+
+"Master the geometry first" — a semantics-free ground model, so the DEM / ground mask /
+obstacle mask are correct *before* any labels are projected onto them. Three products:
+
+1. **Gravity-aligned frame** — up is measured from camera image-up averaged over all
+   frames (not axis-snapped). On `maguro-park-after-itchy-refined` gravity is only 0.92°
+   off −Y, but that's ~1.5 m of false slope across the 90 m park, so we rotate by the full
+   vector and keep the horizontal axes level.
+2. **Ground DEM** — robust *lower envelope*: a low per-cell quantile seeds the surface,
+   then an iterative refit inside an asymmetric band (tight below, looser above) locks it
+   to the ground cluster without climbing into the bush/canopy layer. Smoothing is
+   normalised-convolution (blur observed ÷ blur mask) so unobserved cells never drag real
+   ground up. Sharp to ~15–20 cm where cameras walked; the rest is marked extrapolated.
+3. **Ground / vertical / floater split** — per-point height-above-ground: within the band
+   = ground, above = vertical structure, below = floater/outlier.
+
+```sh
+uv run python geometry_cli.py \
+  --model ../../output/maguro-park-after-itchy-refined/sparse/0 \
+  --out   ../../output/maguro-park-after-itchy-geom --cell-size 0.5
+```
+
+Emits `ground_field.npz` (dem, coverage, R, up, origin, cell_size) + previews:
+`dem_hillshade`, `structure_height`, `ground_vs_vertical`, `camera_trajectory`,
+`cross_sections` (the real ground-quality test — DEM vs. class-coloured points). No
+matplotlib dependency (renders via cv2).
+
+> **Note — the refined LAR model has no tracks.** `…-refined/sparse/0` stores poses +
+> point *positions* only: `points3D.txt` has no track, colour, or reproj-error (all
+> RGB=180,180,180, error=1.0) and `images.txt` has empty POINTS2D. So track-pixel
+> semantic voting (`labeling.py`) **cannot run on the refined model** — semantics there
+> must come from dense-mask projection (poses + intrinsics), which needs no tracks. The
+> geometry front-end uses only positions + camera orientations, so it works fine.
 
 ## Semantic raster modes (`--semantic-mode`)
 

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -155,10 +155,31 @@ at the cost of first training a semantic splat model.
 
 ## Output (`<out>/`)
 
-- `level0.npz` — `height` (m, nan=unobserved), `semantic` (Klass id), `occupancy`
-  (free/blocked/unknown), `coverage` (observed vs interpolated)
+- `level0.npz` — `height` (m, nan=unobserved), `semantic` (ground Klass), `structure`
+  (dominant *vertical* Klass per cell, UNKNOWN=none), `occupancy` (free/blocked/unknown),
+  `coverage` (observed vs interpolated)
 - `level0.meta.json` — grid spec (cell size, origin, up-axis/sign, dims)
-- `level0_{height,semantic,occupancy}.png` — previews (north-up)
+- `level0_{height,semantic,structure,occupancy}.png` — previews (north-up)
+
+### Vertical structures: labelled *and* walkability-tested (3 layers)
+
+A building/tree/wall is two independent facts, kept in two rasters (IMDF keeps them apart
+too — `unit.structure`/`fixture.wall` vs `amenity.landmark`):
+
+- **`structure`** — *what* vertical thing is here: the dominant obstacle class per cell
+  (BUILDING/WALL/TREE/FURNITURE), recorded wherever obstacle points land.
+- **`occupancy`** — *can you walk here*: a cell is BLOCKED only if obstacle points sit in the
+  **body-height clearance band** (`clearance_band`, default 0.4–2.0 m above ground). Tree
+  canopy overhanging a path is *above* the band → the path stays FREE (you walk under it);
+  a trunk/wall/building/bush fills the band → BLOCKED. No morphological *close* (it would fill
+  thin free paths — a walkable corridor is a hole in the blocked forest).
+
+**Occupancy/structure want accurate geometry; height wants density → use different sources.**
+On `maguro-park-after-itchy`, `--source colmap` (sparse but geometrically exact) gives sane
+occupancy (~3.6k blocked, paths free) and clean structure; `--source depth` mono is the best
+*height/coverage* source (dense, smooth) but its ~20% vertical depth noise scatters canopy
+into the body-height band → over-blocks (~80% of cells) and over-labels TREE everywhere.
+Recommended: **mono for `height`+`coverage`, colmap for `structure`+`occupancy`** (hybrid).
 - `masks/` — cached per-image class-id PNGs (+ colour previews); segmentation runs once
 
 ## Status / next

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -85,6 +85,27 @@ uv run python pipeline.py ... --segmenter clipseg --clip-threshold 0.3
 
 Add `--limit N` to process only the first N images while iterating.
 
+### Geometry source: COLMAP points (default) or semantic 3DGS
+
+`--source` selects where `(positions, labels, confidence)` come from. The default
+`colmap` path is above. `--source gsplat` instead consumes a trained **semantic 3DGS**
+export ([`../gsplat`](../gsplat/) `train.py --semantic`): every Gaussian already carries a
+class, so this skips segmentation/voting entirely and feeds a much denser, pre-labelled
+cloud straight into the *same* `build_level`. `--model` is still used (cameras only) to
+detect gravity/up, unless you pass `--up-axis`/`--up-sign`.
+
+```sh
+uv run python pipeline.py --source gsplat \
+  --gsplat-dir ../../output/<session>-gsplat-sem \
+  --model      ../../output/<session>-refined/colmap/sparse/0 \
+  --out        ../../output/<session>-sbev-gsplat \
+  --cell-size 0.5 --min-opacity 0.1
+```
+
+`--min-opacity` drops faint Gaussians (3DGS floaters) before rasterising. This is the
+optional "3DGS geometry source" tier: denser height/occupancy than sparse COLMAP tracks,
+at the cost of first training a semantic splat model.
+
 ## Output (`<out>/`)
 
 - `level0.npz` — `height` (m, nan=unobserved), `semantic` (Klass id), `occupancy`

--- a/script/semantic_bev/colmap_io.py
+++ b/script/semantic_bev/colmap_io.py
@@ -87,11 +87,25 @@ def read_cameras_text(path: Path) -> dict[int, Camera]:
 
 
 def read_images_text(path: Path) -> dict[int, Image]:
-    """Two lines per image: pose line, then a flat (X, Y, POINT3D_ID) triple list."""
+    """Two *physical* lines per image: a pose header, then a (X, Y, POINT3D_ID) list.
+
+    The POINTS2D line can be **empty** (a refined image with a pose but no surviving 2D
+    points -- valid COLMAP). Pair by physical line position, not by filtering blanks first,
+    or those empty lines desync every subsequent pose.
+    """
     images: dict[int, Image] = {}
-    it = _read_lines(path)
-    for header in it:
-        pts_line = next(it)
+    with open(path) as f:
+        lines = f.read().split("\n")
+
+    i, n = 0, len(lines)
+    while i < n:
+        header = lines[i].strip()
+        if not header or header.startswith("#"):
+            i += 1
+            continue
+        pts_line = lines[i + 1] if i + 1 < n else ""
+        i += 2
+
         h = header.split()
         img_id = int(h[0])
         qvec = np.array(h[1:5], dtype=np.float64)
@@ -99,15 +113,15 @@ def read_images_text(path: Path) -> dict[int, Image]:
         camera_id = int(h[8])
         name = h[9]
 
-        vals = np.array(pts_line.split(), dtype=np.float64).reshape(-1, 3)
+        toks = pts_line.split()
+        if toks:
+            vals = np.array(toks, dtype=np.float64).reshape(-1, 3)
+            xys, pids = vals[:, :2].copy(), vals[:, 2].astype(np.int64)
+        else:
+            xys, pids = np.empty((0, 2)), np.empty((0,), dtype=np.int64)
         images[img_id] = Image(
-            id=img_id,
-            qvec=qvec,
-            tvec=tvec,
-            camera_id=camera_id,
-            name=name,
-            xys=vals[:, :2].copy(),
-            point3d_ids=vals[:, 2].astype(np.int64),
+            id=img_id, qvec=qvec, tvec=tvec, camera_id=camera_id, name=name,
+            xys=xys, point3d_ids=pids,
         )
     return images
 

--- a/script/semantic_bev/dense_projection.py
+++ b/script/semantic_bev/dense_projection.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import numpy as np
 
 from colmap_io import Reconstruction, qvec2rotmat
+from grid_transform import cell_to_world
 from ground_model import Level
 from labeling import MaskStore
 from taxonomy import Klass, Role, role_of
@@ -35,8 +36,9 @@ def project_dense_semantics(recon: Reconstruction, store: MaskStore, level: Leve
     # World-space centre of every cell (height from the Level's field).
     jj, ii = np.meshgrid(np.arange(cols), np.arange(rows))  # jj=col(=u), ii=row(=v)
     P = np.zeros((rows * cols, 3))
-    P[:, u_axis] = (spec.origin_u + (jj.ravel() + 0.5) * spec.cell_size)
-    P[:, v_axis] = (spec.origin_v + (ii.ravel() + 0.5) * spec.cell_size)
+    u_world, v_world = cell_to_world(jj.ravel() + 0.5, ii.ravel() + 0.5, spec)  # cell centres
+    P[:, u_axis] = u_world
+    P[:, v_axis] = v_world
     P[:, spec.up_axis] = level.height.ravel() * spec.up_sign  # world up-coord = height*sign
 
     ncells = rows * cols

--- a/script/semantic_bev/depth_backproject.py
+++ b/script/semantic_bev/depth_backproject.py
@@ -1,0 +1,132 @@
+"""Depth back-projection geometry source — the shared harness for the depth bake-off.
+
+Every "real geometry" approach (COLMAP MVS, 2DGS, mono-depth, 3DGS) reduces to the same
+thing: **per-view metric depth**. This module is the common back-end. It back-projects
+every labelled pixel to its *true* 3D position using that depth — instead of assuming the
+pixel lies on the ground, which is what makes `dense_projection` smear above-ground
+objects. Output is the standard ``(positions, labels, confidence)`` triple, so
+``ground_model.build_level`` is unchanged and every backend is compared apples-to-apples.
+
+Depth-map contract (one directory per backend, produced by that backend's exporter):
+
+    <depth_dir>/<image_stem>.npy        float32 (H, W) metric z-depth in metres; <=0 / NaN = invalid
+    <depth_dir>/<image_stem>.conf.npy   optional float32 (H, W) confidence in [0, 1]
+
+Depth resolution may differ from the source image; the pinhole intrinsics are scaled to
+the depth resolution. Points are accumulated across all frames and voxel-deduped (mean
+position, confidence-weighted majority label per voxel) so memory stays bounded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from colmap_io import Reconstruction
+from labeling import MaskStore
+from taxonomy import Klass
+
+
+def _qvec2rotmat(q: np.ndarray) -> np.ndarray:
+    w, x, y, z = q
+    return np.array([[1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                     [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                     [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)]])
+
+
+def _pinhole_params(cam) -> tuple[float, float, float, float]:
+    """(fx, fy, cx, cy) from a PINHOLE / SIMPLE_PINHOLE camera."""
+    p = cam.params
+    if cam.model == "PINHOLE":
+        return float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    if cam.model == "SIMPLE_PINHOLE":
+        return float(p[0]), float(p[0]), float(p[1]), float(p[2])
+    raise ValueError(f"camera model {cam.model!r} not supported for back-projection")
+
+
+def _load_depth(depth_dir: Path, stem: str):
+    dp = depth_dir / f"{stem}.npy"
+    if not dp.exists():
+        return None, None
+    depth = np.load(dp).astype(np.float32)
+    cp = depth_dir / f"{stem}.conf.npy"
+    conf = np.load(cp).astype(np.float32) if cp.exists() else None
+    return depth, conf
+
+
+def backproject_labeled_points(
+    recon: Reconstruction, store: MaskStore, depth_dir: str | Path, image_ids: list[int],
+    *, stride: int = 4, voxel: float = 0.05, min_conf: float = 0.0, log=print,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Back-project labelled pixels via per-view depth -> voxel-deduped labelled cloud."""
+    depth_dir = Path(depth_dir)
+    n_klass = int(max(Klass)) + 1
+    all_pos, all_lab, all_conf = [], [], []
+    n_frames = raw = 0
+
+    for img_id in image_ids:
+        im = recon.images[img_id]
+        depth, conf = _load_depth(depth_dir, Path(im.name).stem)
+        if depth is None:
+            continue
+        H, W = depth.shape
+        cam = recon.cameras[im.camera_id]
+        fx, fy, cx, cy = _pinhole_params(cam)
+        sx, sy = W / cam.width, H / cam.height           # scale intrinsics to depth res
+        fx, fy, cx, cy = fx * sx, fy * sy, cx * sx, cy * sy
+
+        mask = store.load(im.name)
+        if mask.shape != (H, W):
+            mask = cv2.resize(mask, (W, H), interpolation=cv2.INTER_NEAREST)
+
+        ys = np.arange(0, H, stride)
+        xs = np.arange(0, W, stride)
+        gx, gy = np.meshgrid(xs, ys)
+        gx, gy = gx.ravel(), gy.ravel()
+        d = depth[gy, gx]
+        lab = mask[gy, gx]
+        valid = (d > 0) & np.isfinite(d) & (lab != int(Klass.UNKNOWN))
+        if conf is not None:
+            cvals = conf[gy, gx]
+            valid &= cvals >= min_conf
+        if not valid.any():
+            continue
+
+        u, v, dd, ll = gx[valid].astype(np.float32), gy[valid].astype(np.float32), d[valid], lab[valid]
+        cw = conf[gy, gx][valid].astype(np.float32) if conf is not None else np.ones(len(dd), np.float32)
+        # pixel + metric z-depth -> camera coords -> world coords.
+        cam_pts = np.stack([(u - cx) / fx * dd, (v - cy) / fy * dd, dd], axis=1)
+        R = _qvec2rotmat(im.qvec)
+        C = -R.T @ im.tvec
+        world = cam_pts @ R + C                          # world_i = R^T @ cam_i + C
+
+        all_pos.append(world.astype(np.float32))
+        all_lab.append(ll.astype(np.int64))
+        all_conf.append(cw)
+        n_frames += 1
+        raw += len(world)
+
+    if not all_pos:
+        raise ValueError(f"no depth maps found in {depth_dir} for the requested images")
+
+    pos = np.concatenate(all_pos)
+    lab = np.concatenate(all_lab)
+    cw = np.concatenate(all_conf)
+    log(f"  back-projected {raw} points from {n_frames} depth maps (stride {stride})")
+
+    # Voxel dedup: mean position + confidence-weighted majority label per voxel.
+    vox = np.floor(pos / voxel).astype(np.int64)
+    uniq, inv = np.unique(vox, axis=0, return_inverse=True)
+    counts = np.bincount(inv)
+    sums = np.zeros((len(uniq), 3), np.float64)
+    np.add.at(sums, inv, pos)
+    positions = (sums / counts[:, None]).astype(np.float32)
+
+    flat = inv * n_klass + lab
+    votes = np.bincount(flat, weights=cw, minlength=len(uniq) * n_klass).reshape(len(uniq), n_klass)
+    labels = votes.argmax(1).astype(np.uint8)
+    confidence = (votes.max(1) / votes.sum(1)).astype(np.float32)
+    log(f"  voxel-deduped to {len(positions)} points @ {voxel} m")
+    return positions, labels, confidence

--- a/script/semantic_bev/eval_depth_bev.py
+++ b/script/semantic_bev/eval_depth_bev.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Score the depth bake-off: compare BEV levels from each geometry backend side by side.
+
+Loads each backend's ``level0.npz`` (from ``pipeline.py`` with the corresponding source)
+and reports, per backend:
+
+  - coverage %       -- fraction of grid cells with observed ground geometry
+  - ground cells     -- absolute observed count (denser depth -> more)
+  - blocked cells    -- occupancy footprints (obstacles/objects)
+  - height roughness -- median |∇height| over observed cells (proxy for surface noise;
+                        lower = smoother, so MVS/2DGS should beat mono/3DGS if cleaner)
+  - class mix        -- semantic distribution over observed ground
+
+and renders a combined semantic+height comparison image. Footprint IoU vs. hand-marked
+objects is a later addition (needs instance segmentation), flagged as TODO.
+
+  uv run python eval_depth_bev.py --session maguro-park-after-itchy \
+      --backends colmap,mvs,mono,3dgs,2dgs --out ../../output/<name>-bakeoff
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from taxonomy import Klass, color_lut
+
+BLOCKED = 1
+
+
+def _sbev_dir(session, backend):
+    if backend in ("colmap", "gsplat"):
+        return session.sbev_out(backend)
+    return session.sbev_out("depth", tag=backend)
+
+
+def load_level(d: Path):
+    npz = np.load(d / "level0.npz")
+    meta = json.loads((d / "level0.meta.json").read_text())
+    return dict(height=npz["height"], semantic=npz["semantic"],
+                occupancy=npz["occupancy"], coverage=npz["coverage"], meta=meta)
+
+
+def metrics(lv) -> dict:
+    cov = lv["coverage"]
+    h = lv["height"].astype(np.float32)
+    obs = cov & np.isfinite(h)
+    gy, gx = np.gradient(np.nan_to_num(h))
+    grad = np.sqrt(gy ** 2 + gx ** 2)
+    rough = float(np.median(grad[obs])) if obs.any() else float("nan")
+    classes = np.bincount(lv["semantic"][cov], minlength=int(max(Klass)) + 1)
+    top = sorted(((c, int(n)) for c, n in enumerate(classes) if n), key=lambda x: -x[1])[:4]
+    return {
+        "cells": int(cov.size),
+        "coverage_%": round(100 * cov.mean(), 1),
+        "ground_cells": int(cov.sum()),
+        "blocked_cells": int((lv["occupancy"] == BLOCKED).sum()),
+        "height_roughness_m": round(rough, 3),
+        "top_classes": ", ".join(f"{Klass(c).name}:{n}" for c, n in top),
+    }
+
+
+def render_comparison(levels: dict, out: Path):
+    lut = np.array(color_lut(), np.uint8)
+    tiles = []
+    for name, lv in levels.items():
+        sem = lut[lv["semantic"]]
+        sem[~lv["coverage"]] = (30, 30, 30)
+        sem = cv2.cvtColor(sem, cv2.COLOR_RGB2BGR)
+        sem = cv2.copyMakeBorder(sem, 24, 4, 4, 4, cv2.BORDER_CONSTANT, value=(0, 0, 0))
+        cv2.putText(sem, name, (6, 17), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 1)
+        tiles.append(sem)
+    h = max(t.shape[0] for t in tiles)
+    tiles = [cv2.copyMakeBorder(t, 0, h - t.shape[0], 0, 0, cv2.BORDER_CONSTANT, value=(0, 0, 0)) for t in tiles]
+    cv2.imwrite(str(out / "bakeoff_semantic.png"), np.hstack(tiles))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", required=True)
+    ap.add_argument("--backends", default="colmap,mvs,mono,3dgs,2dgs",
+                    help="comma list; each resolves to its sbev output dir")
+    ap.add_argument("--out", default=None, help="scorecard dir (default: <name>-bakeoff)")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from lar_session import Session
+    s = Session(args.session)
+    out = Path(args.out) if args.out else s.root / "output" / f"{s.name}-bakeoff"
+    out.mkdir(parents=True, exist_ok=True)
+
+    levels, rows = {}, []
+    for b in [x.strip() for x in args.backends.split(",") if x.strip()]:
+        d = _sbev_dir(s, b)
+        if not (d / "level0.npz").exists():
+            print(f"skip {b}: no level0.npz at {d}")
+            continue
+        lv = load_level(d)
+        levels[b] = lv
+        m = metrics(lv)
+        rows.append((b, m))
+        print(f"\n[{b}]  {d.name}")
+        for k, v in m.items():
+            print(f"    {k:20} {v}")
+
+    if not levels:
+        raise SystemExit("no backend outputs found — run pipeline.py per backend first")
+
+    # Markdown scorecard.
+    cols = ["coverage_%", "ground_cells", "blocked_cells", "height_roughness_m", "top_classes"]
+    md = ["| backend | " + " | ".join(cols) + " |", "|" + "---|" * (len(cols) + 1)]
+    for b, m in rows:
+        md.append(f"| {b} | " + " | ".join(str(m[c]) for c in cols) + " |")
+    (out / "scorecard.md").write_text("\n".join(md) + "\n")
+    render_comparison(levels, out)
+    print(f"\nscorecard -> {out}/scorecard.md + bakeoff_semantic.png")
+    print("TODO: footprint IoU vs hand-marked objects (needs instance segmentation)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/semantic_bev/geometry.py
+++ b/script/semantic_bev/geometry.py
@@ -1,0 +1,252 @@
+"""Pure-geometry ground model: gravity-aligned DEM + ground/vertical split.
+
+This is the *geometry front-end* for the semantic-BEV pipeline, deliberately kept
+independent of semantics. Given a point cloud (COLMAP sparse points today, MVS/2DGS
+surfels later) it produces three things the rest of the pipeline consumes:
+
+  1. a **gravity-aligned frame** (full rotation, not axis-snapping) so "up" is true
+     gravity and the two horizontal axes are level;
+  2. a robust **ground height field** (DEM) -- the lower envelope of the cloud, pinned
+     to the ground and smoothed only across *observed* cells;
+  3. a per-point **height-above-ground (HAG)** and a ground / vertical / floater split.
+
+Why geometry-first (vs. the semantics-defines-ground design in ground_model.py):
+On the refined LAR model the point tracks/colours/errors are stripped, so track-pixel
+semantic voting cannot run -- but the geometry is still excellent (ground sharp to
+~15-20 cm where cameras walked). Nailing the DEM + HAG first gives every later stage a
+clean scaffold: height for the BEV, a ground mask for semantic projection, and a
+vertical/obstacle mask for occupancy. Semantics then colours this surface via dense-mask
+projection (poses + intrinsics), which needs no tracks.
+
+Design notes that matter:
+- **Gravity is measured, not guessed.** ``gravity_up`` averages camera image-up over all
+  frames (phones held upright). A 1 deg residual tilt is ~1.5 m of false slope across a
+  90 m park, so we rotate by the *full* vector and keep the horizontal axes level.
+- **DEM = robust lower envelope.** Ground points form a razor-sharp bottom cluster;
+  vegetation stacks above it. A low per-cell quantile seeds the surface; an iterative
+  refit inside an *asymmetric* band (tight below, looser above) locks it to the ground
+  without climbing into the bush/canopy layer.
+- **Smooth only within coverage.** Most cells (a walked park is mostly unvisited) have no
+  ground points; naive blurring bleeds the flat extrapolated fill up into real ground.
+  We use normalised convolution (blur observed / blur mask) so unobserved cells never
+  drag the surface, then nearest-fill the remainder purely for a continuous raster.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+# ----- gravity alignment -------------------------------------------------------
+
+def _qvec2rotmat(q: np.ndarray) -> np.ndarray:
+    w, x, y, z = q
+    return np.array([[1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                     [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                     [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)]])
+
+
+def gravity_up(qvecs: np.ndarray) -> np.ndarray:
+    """World-space up unit vector, averaged over camera orientations.
+
+    COLMAP cameras look +Z_cam with +Y_cam pointing *down* in the image, so world-up for
+    an upright phone is ``-R[1, :]``. Averaging over frames cancels per-frame tilt.
+    ``qvecs`` is (N, 4) COLMAP quaternions [qw, qx, qy, qz].
+    """
+    ups = np.array([-_qvec2rotmat(q)[1, :] for q in qvecs])
+    m = ups.mean(0)
+    return m / (np.linalg.norm(m) + 1e-12)
+
+
+def align_rotation(up: np.ndarray) -> np.ndarray:
+    """3x3 rotation mapping world -> local so gravity-up becomes +Z, horizontals level.
+
+    Rows are the local axes in world coords; ``local = R @ world``.
+    """
+    up = up / np.linalg.norm(up)
+    a = np.array([1.0, 0, 0]) if abs(up[0]) < 0.9 else np.array([0, 1.0, 0])
+    x = a - up * (a @ up)
+    x /= np.linalg.norm(x)
+    y = np.cross(up, x)
+    return np.stack([x, y, up])
+
+
+# ----- grid / DEM --------------------------------------------------------------
+
+@dataclass
+class GridSpec:
+    cell_size: float
+    origin_u: float           # world (local-frame) coord of column 0
+    origin_v: float           # world (local-frame) coord of row 0
+    cols: int
+    rows: int
+
+
+@dataclass
+class GroundField:
+    spec: GridSpec
+    dem: np.ndarray           # (rows, cols) float32 ground height (metres, +up)
+    coverage: np.ndarray      # (rows, cols) bool: cell had ground points (DEM trusted)
+    R: np.ndarray             # (3,3) world->local gravity-aligned rotation
+    up: np.ndarray            # (3,) world-space gravity-up unit vector
+
+    def cell_of(self, uv: np.ndarray) -> np.ndarray:
+        """Map local-frame (N,2) horizontal coords -> flat cell ids (clipped)."""
+        ix = np.clip(((uv[:, 0] - self.spec.origin_u) / self.spec.cell_size).astype(np.int64),
+                     0, self.spec.cols - 1)
+        iy = np.clip(((uv[:, 1] - self.spec.origin_v) / self.spec.cell_size).astype(np.int64),
+                     0, self.spec.rows - 1)
+        return iy * self.spec.cols + ix
+
+    def height_at(self, uv: np.ndarray) -> np.ndarray:
+        """Ground height sampled at local-frame (N,2) horizontal coords."""
+        return self.dem.reshape(-1)[self.cell_of(uv)]
+
+
+def _cell_quantile(cell_ids: np.ndarray, values: np.ndarray, ncells: int,
+                   q: float, mincount: int) -> tuple[np.ndarray, np.ndarray]:
+    """Per-cell quantile + count (vectorised group-by via sort)."""
+    out = np.full(ncells, np.nan, np.float32)
+    cnt = np.zeros(ncells, np.int32)
+    if len(cell_ids) == 0:
+        return out, cnt
+    order = np.argsort(cell_ids, kind="stable")
+    cs, vs = cell_ids[order], values[order]
+    bounds = np.flatnonzero(np.diff(cs)) + 1
+    starts = np.concatenate(([0], bounds))
+    ends = np.concatenate((bounds, [len(cs)]))
+    for s, e in zip(starts, ends):
+        c = cs[s]
+        cnt[c] = e - s
+        if e - s >= mincount:
+            out[c] = np.quantile(vs[s:e], q)
+    return out, cnt
+
+
+def _nearest_fill(grid: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    """Fill invalid cells with nearest valid value (cv2 distance transform, no scipy)."""
+    if valid.all() or not valid.any():
+        return grid
+    holes = (~valid).astype(np.uint8)
+    _, labels = cv2.distanceTransformWithLabels(
+        holes, cv2.DIST_L2, 3, labelType=cv2.DIST_LABEL_PIXEL)
+    lut = np.zeros(labels.max() + 1, grid.dtype)
+    lut[labels[valid]] = grid[valid]
+    return lut[labels]
+
+
+def _normalised_blur(field: np.ndarray, valid: np.ndarray, sigma: float) -> np.ndarray:
+    """Gaussian-smooth ``field`` using only ``valid`` cells (normalised convolution).
+
+    Unobserved cells contribute nothing and are not dragged toward the fill value, so
+    real ground never gets pulled up by the flat extrapolated background.
+    """
+    w = valid.astype(np.float32)
+    num = cv2.GaussianBlur(np.where(valid, field, 0).astype(np.float32), (0, 0), sigma)
+    den = cv2.GaussianBlur(w, (0, 0), sigma)
+    out = np.where(den > 1e-6, num / np.maximum(den, 1e-6), field)
+    return out.astype(np.float32)
+
+
+def build_dem(local_uv: np.ndarray, height: np.ndarray, R: np.ndarray, up: np.ndarray, *,
+              cell_size: float = 0.5, bounds_pct: float = 0.5,
+              seed_q: float = 0.08, refit_q: float = 0.25,
+              band_below: float = 0.25, band_above: float = 0.35,
+              iters: int = 4, smooth_sigma: float = 1.2, min_seed: int = 3,
+              log=print) -> GroundField:
+    """Robust lower-envelope ground DEM from gravity-aligned points.
+
+    ``local_uv`` is (N,2) horizontal coords in the gravity-aligned frame, ``height`` the
+    matching (N,) up-axis coord. Seeds with a low per-cell quantile then iteratively
+    refits inside an asymmetric band so the surface locks to the ground, not vegetation.
+    """
+    u, v = local_uv[:, 0], local_uv[:, 1]
+    lo_u, hi_u = np.percentile(u, [bounds_pct, 100 - bounds_pct])
+    lo_v, hi_v = np.percentile(v, [bounds_pct, 100 - bounds_pct])
+    cols = int(np.ceil((hi_u - lo_u) / cell_size)) + 1
+    rows = int(np.ceil((hi_v - lo_v) / cell_size)) + 1
+    spec = GridSpec(cell_size, float(lo_u), float(lo_v), cols, rows)
+    ncells = rows * cols
+    log(f"  grid {cols}x{rows} @ {cell_size} m "
+        f"({cols * cell_size:.0f}x{rows * cell_size:.0f} m), {len(height)} pts")
+
+    ix = np.clip(((u - lo_u) / cell_size).astype(np.int64), 0, cols - 1)
+    iy = np.clip(((v - lo_v) / cell_size).astype(np.int64), 0, rows - 1)
+    cid = iy * cols + ix
+
+    # Seed: low quantile per cell = lower envelope.
+    seed, cnt = _cell_quantile(cid, height, ncells, seed_q, min_seed)
+    valid = (cnt >= min_seed).reshape(rows, cols)
+    g = _normalised_blur(np.nan_to_num(seed).reshape(rows, cols).astype(np.float32),
+                         valid, smooth_sigma)
+    g = _nearest_fill(g, valid)     # continuous raster for sampling; trust = `coverage`
+
+    # Iterative asymmetric refit: pull the surface onto the ground cluster.
+    coverage = valid
+    for it in range(iters):
+        hag = height - g.reshape(-1)[cid]
+        inl = (hag > -band_below) & (hag < band_above)
+        refit, rc = _cell_quantile(cid[inl], height[inl], ncells, refit_q, 2)
+        cov = (rc >= 2).reshape(rows, cols)
+        gnew = _normalised_blur(np.nan_to_num(refit).reshape(rows, cols).astype(np.float32),
+                                cov, smooth_sigma)
+        gnew = _nearest_fill(gnew, cov)
+        delta = float(np.abs(gnew - g)[cov].mean()) if cov.any() else 0.0
+        g, coverage = gnew, cov
+        log(f"  iter{it}: inliers={inl.mean():.2f} meanΔ={delta:.3f} m "
+            f"coverage={cov.mean() * 100:.1f}%")
+
+    # Soften the extrapolated fill: nearest-fill leaves blocky Voronoi steps in
+    # unobserved cells (untrusted, but ugly and bad for gradients/hillshade). Blur only
+    # the holes; observed cells stay exact.
+    holes = ~coverage
+    if holes.any():
+        soft = cv2.GaussianBlur(g, (0, 0), max(2.0, 8.0 * 0.5 / cell_size))
+        g = np.where(coverage, g, soft).astype(np.float32)
+
+    return GroundField(spec, g.astype(np.float32), coverage, R, up)
+
+
+# ----- per-point classification ------------------------------------------------
+
+GROUND, VERTICAL, FLOATER = 0, 1, 2
+
+
+def classify_points(local_uv: np.ndarray, height: np.ndarray, gf: GroundField, *,
+                    band_below: float = 0.25, band_above: float = 0.35
+                    ) -> tuple[np.ndarray, np.ndarray]:
+    """Return (hag, label) where label in {GROUND, VERTICAL, FLOATER} by height-above-ground."""
+    hag = height - gf.height_at(local_uv)
+    label = np.full(len(hag), VERTICAL, np.uint8)
+    label[hag <= -band_below] = FLOATER
+    label[(hag > -band_below) & (hag < band_above)] = GROUND
+    return hag, label
+
+
+# ----- convenience: from a COLMAP reconstruction -------------------------------
+
+def from_reconstruction(recon, *, cell_size: float = 0.5, log=print, **dem_kw):
+    """One-call geometry: gravity-align a COLMAP recon, build the DEM, classify points.
+
+    Returns (gf, local_xyz, hag, label). ``local_xyz`` is every point in the gravity-
+    aligned frame (columns u, v, height).
+    """
+    xyz = np.array([p.xyz for p in recon.points3d.values()])
+    up = gravity_up(np.array([im.qvec for im in recon.images.values()]))
+    R = align_rotation(up)
+    local = (R @ xyz.T).T
+    axis = int(np.argmax(np.abs(up)))
+    tilt = np.degrees(np.arccos(min(abs(up[axis]), 1.0)))
+    log(f"gravity up = [{up[0]:+.4f} {up[1]:+.4f} {up[2]:+.4f}]  "
+        f"({tilt:.2f} deg off axis {axis})")
+    gf = build_dem(local[:, :2], local[:, 2], R, up, cell_size=cell_size, log=log, **dem_kw)
+    hag, label = classify_points(local[:, :2], local[:, 2], gf)
+    n = len(label)
+    log(f"  points: ground={np.mean(label == GROUND) * 100:.0f}% "
+        f"vertical={np.mean(label == VERTICAL) * 100:.0f}% "
+        f"floater={np.mean(label == FLOATER) * 100:.0f}%  (n={n})")
+    return gf, local, hag, label

--- a/script/semantic_bev/geometry_cli.py
+++ b/script/semantic_bev/geometry_cli.py
@@ -1,0 +1,152 @@
+"""CLI + diagnostic renders for the pure-geometry ground model (geometry.py).
+
+Run on a COLMAP text model; emits a DEM hillshade, structure-height map, ground/vertical
+density, camera-trajectory overlay, and vertical cross-sections so ground extraction
+quality can be judged by eye.
+
+    uv run python geometry_cli.py \
+        --model ../../output/maguro-park-after-itchy-refined/sparse/0 \
+        --out   ../../output/maguro-park-after-itchy-geom \
+        --cell-size 0.5
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from colmap_io import read_model
+import geometry as G
+
+
+def _colorize(field, valid, cmap=cv2.COLORMAP_TURBO, lo=None, hi=None):
+    v = field[valid]
+    if lo is None:
+        lo, hi = np.percentile(v, [2, 98]) if valid.any() else (0.0, 1.0)
+    n = np.clip((field - lo) / max(hi - lo, 1e-6), 0, 1)
+    img = cv2.applyColorMap((n * 255).astype(np.uint8), cmap)
+    img[~valid] = (35, 35, 35)
+    return img
+
+
+def _hillshade(dem, cell, az=315.0, alt=45.0):
+    gy, gx = np.gradient(dem, cell)
+    normal = np.dstack([-gx, -gy, np.ones_like(dem)])
+    normal /= np.linalg.norm(normal, axis=2, keepdims=True)
+    a, e = np.radians(az), np.radians(alt)
+    light = np.array([np.cos(e) * np.cos(a), np.cos(e) * np.sin(a), np.sin(e)])
+    return np.clip(normal @ light, 0, 1)
+
+
+def render(gf: G.GroundField, local, hag, label, cams_local, out: Path, log=print):
+    out.mkdir(parents=True, exist_ok=True)
+    s = gf.spec
+    rows, cols = s.rows, s.cols
+    cid = gf.cell_of(local[:, :2])
+    flip = np.flipud  # north-up: +v downward in array -> flip for display
+
+    # 1. DEM height, hill-shaded, masked to covered area (extrapolation dimmed).
+    shade = _hillshade(gf.dem, s.cell_size)
+    dem_rgb = _colorize(gf.dem, gf.coverage)
+    dem_rgb = (dem_rgb.astype(np.float32) * (0.35 + 0.65 * shade[..., None])).astype(np.uint8)
+    dem_rgb[~gf.coverage] = (dem_rgb[~gf.coverage] * 0.35).astype(np.uint8)
+    cv2.imwrite(str(out / "dem_hillshade.png"), flip(dem_rgb))
+
+    # 2. Structure height = 95th pct HAG of vertical points per cell.
+    vmask = label == G.VERTICAL
+    sh, _ = G._cell_quantile(cid[vmask], hag[vmask], rows * cols, 0.95, 1)
+    sh = np.nan_to_num(sh).reshape(rows, cols).clip(0, 8)
+    cv2.imwrite(str(out / "structure_height.png"),
+                flip(_colorize(sh, sh > 0, cv2.COLORMAP_MAGMA, 0, 6)))
+
+    # 3. Ground (green) vs vertical (red) point density.
+    gcnt = np.bincount(cid[label == G.GROUND], minlength=rows * cols).reshape(rows, cols)
+    vcnt = np.bincount(cid[vmask], minlength=rows * cols).reshape(rows, cols)
+    gv = np.zeros((rows, cols, 3), np.uint8)
+    gv[..., 1] = np.clip(gcnt * 40, 0, 255)
+    gv[..., 2] = np.clip(vcnt * 40, 0, 255)
+    cv2.imwrite(str(out / "ground_vs_vertical.png"), flip(gv))
+
+    # 4. Camera trajectory over the DEM (orientation / registration sanity).
+    traj = dem_rgb.copy()
+    px = np.clip(((cams_local[:, 0] - s.origin_u) / s.cell_size).astype(int), 0, cols - 1)
+    py = np.clip(((cams_local[:, 1] - s.origin_v) / s.cell_size).astype(int), 0, rows - 1)
+    for x, y in zip(px, py):
+        cv2.circle(traj, (x, y), 1, (0, 255, 255), -1)
+    cv2.imwrite(str(out / "camera_trajectory.png"), flip(traj))
+
+    # 5. Vertical cross-sections at 3 u-slices (the real ground-quality test).
+    #    Rendered with cv2 (no matplotlib dep): points coloured by class, DEM overlaid
+    #    solid where observed / faint where extrapolated.
+    u, v, h = local[:, 0], local[:, 1], local[:, 2]
+    panels = []
+    W, H, pad = 1200, 300, 40
+    for uc in np.percentile(u, [35, 50, 65]):
+        m = np.abs(u - uc) < 1.0
+        canvas = np.full((H, W, 3), 255, np.uint8)
+        vmin, vmax = np.percentile(v[m], [0, 100])
+        h0 = np.percentile(h[m], 1)
+        hmin, hmax = h0 - 1.0, h0 + 8.0
+
+        def to_px(vv, hh):
+            x = pad + (vv - vmin) / max(vmax - vmin, 1e-6) * (W - 2 * pad)
+            y = H - pad - (hh - hmin) / max(hmax - hmin, 1e-6) * (H - 2 * pad)
+            return x.astype(int), y.astype(int)
+
+        # gridlines every 1 m in height
+        for hh in np.arange(np.ceil(hmin), hmax, 1.0):
+            _, y = to_px(np.array([vmin]), np.array([hh]))
+            cv2.line(canvas, (pad, int(y[0])), (W - pad, int(y[0])), (235, 235, 235), 1)
+        for lb, col in [(G.GROUND, (34, 187, 34)), (G.VERTICAL, (34, 34, 204)),
+                        (G.FLOATER, (204, 136, 34))]:  # BGR
+            mm = m & (label == lb)
+            xs, ys = to_px(v[mm], h[mm])
+            ok = (ys >= 0) & (ys < H)
+            canvas[np.clip(ys[ok], 0, H - 1), np.clip(xs[ok], 0, W - 1)] = col
+        # DEM polyline for this slice
+        ii = int(np.clip((uc - s.origin_u) / s.cell_size, 0, cols - 1))
+        vs = s.origin_v + np.arange(rows) * s.cell_size
+        inside = (vs >= vmin) & (vs <= vmax)
+        xd, yd = to_px(vs, gf.dem[:, ii])
+        covc = gf.coverage[:, ii]
+        for j in range(rows - 1):
+            if not (inside[j] and inside[j + 1]):
+                continue
+            trusted = covc[j] and covc[j + 1]
+            cv2.line(canvas, (xd[j], yd[j]), (xd[j + 1], yd[j + 1]),
+                     (0, 0, 0) if trusted else (180, 180, 180), 2 if trusted else 1)
+        cv2.putText(canvas, f"u={uc:.1f}m (+/-1m)  black=observed DEM  grey=extrap",
+                    (pad, 24), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)
+        panels.append(canvas)
+    cv2.imwrite(str(out / "cross_sections.png"), np.vstack(panels))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="COLMAP text model dir")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--cell-size", type=float, default=0.5)
+    args = ap.parse_args()
+
+    print(f"reading {args.model} ...")
+    recon = read_model(args.model)
+    print(f"  images={len(recon.images)} points={recon.num_points}")
+    gf, local, hag, label = G.from_reconstruction(recon, cell_size=args.cell_size)
+
+    cams = np.array([-G._qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
+    cams_local = (gf.R @ cams.T).T
+
+    out = Path(args.out)
+    render(gf, local, hag, label, cams_local, out)
+    np.savez_compressed(out / "ground_field.npz", dem=gf.dem, coverage=gf.coverage,
+                        R=gf.R, up=gf.up,
+                        origin=np.array([gf.spec.origin_u, gf.spec.origin_v]),
+                        cell_size=gf.spec.cell_size)
+    print(f"wrote renders + ground_field.npz to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/semantic_bev/grid_transform.py
+++ b/script/semantic_bev/grid_transform.py
@@ -1,0 +1,51 @@
+"""Single source of truth for grid-cell <-> world-metre conversion.
+
+The raster's row axis is **gravity-canonical**: `row = v_sign * world[v_axis]` (set once in
+`ground_model.build_level`, so a Y-up and a Y-down source model rasterise the same way). Every
+converter that turns a `(col, row)` into world metres — or back — MUST go through here, so the
+sign lives in exactly one place. A forgotten sign silently mirrors the map (that is precisely
+the bug this module exists to make unrepresentable).
+
+Accepts either the `meta` dict (from `level0.meta.json`) or a `GridSpec` object.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _get(spec, key: str):
+    return spec[key] if isinstance(spec, dict) else getattr(spec, key)
+
+
+def _v_sign(spec) -> float:
+    try:
+        return float(_get(spec, "v_sign"))
+    except (KeyError, AttributeError):
+        return 1.0  # pre-canonical metas default to no flip
+
+
+def cell_to_world(col, row, spec):
+    """(col, row) grid indices -> (u, v) world metres along the two horizontal axes.
+
+    Scalars or numpy arrays. For a cell *centre* pass ``col + 0.5``, ``row + 0.5``.
+    """
+    cs = _get(spec, "cell_size")
+    u = _get(spec, "origin_u") + np.asarray(col, dtype=np.float64) * cs
+    v = _v_sign(spec) * (_get(spec, "origin_v") + np.asarray(row, dtype=np.float64) * cs)
+    return u, v
+
+
+def world_to_cell(u, v, spec):
+    """(u, v) world metres -> fractional (col, row) grid indices (inverse of cell_to_world)."""
+    cs = _get(spec, "cell_size")
+    col = (np.asarray(u, dtype=np.float64) - _get(spec, "origin_u")) / cs
+    row = (_v_sign(spec) * np.asarray(v, dtype=np.float64) - _get(spec, "origin_v")) / cs
+    return col, row
+
+
+def cells_to_world(colrow, spec):
+    """(N,2) array of (col,row) -> (N,2) array of (u,v) world metres."""
+    colrow = np.asarray(colrow, dtype=np.float64)
+    u, v = cell_to_world(colrow[:, 0], colrow[:, 1], spec)
+    return np.stack([u, v], axis=1)

--- a/script/semantic_bev/ground_model.py
+++ b/script/semantic_bev/ground_model.py
@@ -38,6 +38,8 @@ class GridSpec:
     origin_v: float           # world coord of row 0 (second horizontal axis)
     cols: int
     rows: int
+    v_sign: float = 1.0       # canonical row = v_sign * world[v_axis]; ties the overhead
+                              # orientation to gravity, not the model's Y-up/Y-down convention
 
     @property
     def horiz_axes(self) -> tuple[int, int]:
@@ -49,7 +51,8 @@ class Level:
     ordinal: int
     spec: GridSpec
     height: np.ndarray        # (rows, cols) float32, nan where unobserved
-    semantic: np.ndarray      # (rows, cols) uint8 Klass
+    semantic: np.ndarray      # (rows, cols) uint8 Klass -- the *ground* surface class
+    structure: np.ndarray     # (rows, cols) uint8 Klass -- dominant *vertical* class (UNKNOWN=none)
     occupancy: np.ndarray     # (rows, cols) uint8
     coverage: np.ndarray      # (rows, cols) bool
 
@@ -117,10 +120,10 @@ def _nearest_fill(grid: np.ndarray, valid: np.ndarray) -> np.ndarray:
 
 def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarray,
                 cell_size: float = 0.5, up_axis: int = 1, up_sign: float = 1.0,
-                ground_quantile: float = 0.2, obstacle_band: tuple[float, float] = (0.3, 2.2),
+                ground_quantile: float = 0.2,
                 bounds_pct: float = 0.02, ground_height_clip: tuple[float, float] = (0.01, 0.99),
-                min_obstacle_count: int = 3, obstacle_dominance: float = 1.0,
-                occupancy_morph: bool = True,
+                min_obstacle_count: int = 3, min_structure_count: int = 2,
+                solid_gap: float = 0.8, occupancy_morph: bool = True,
                 fill_holes: bool = True, ordinal: int = 0, log=print) -> Level:
     """Rasterise labelled points into a single ground Level."""
     roles = np.array([int(role_of(k)) for k in range(int(max(Klass)) + 1)])[labels]
@@ -128,8 +131,14 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     is_obstacle = roles == int(Role.OBSTACLE)
 
     u_axis, v_axis = (a for a in (0, 1, 2) if a != up_axis)
+    # Canonical overhead handedness: the raster's row axis follows gravity (via up_sign),
+    # not the source model's Y-up/Y-down convention. Without this, a model expressed with
+    # +Y-up (up_sign=+1) and the same scene refined to +Y-down (up_sign=-1) rasterise as
+    # vertical mirror images of each other, because the row axis was pinned to world-Z. The
+    # npz stays honest: world[v_axis] = v_sign * (origin_v + row*cell_size). Georef unaffected.
+    v_sign = -up_sign
     u = positions[:, u_axis]
-    v = positions[:, v_axis]
+    v = v_sign * positions[:, v_axis]
     height = up_sign * positions[:, up_axis]
 
     # Drop SfM floaters: keep ground candidates within a robust global height band. Real
@@ -152,7 +161,7 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     lo_v, hi_v = np.quantile(v[keep], [bounds_pct, 1 - bounds_pct])
     cols = int(np.ceil((hi_u - lo_u) / cell_size)) + 1
     rows = int(np.ceil((hi_v - lo_v) / cell_size)) + 1
-    spec = GridSpec(cell_size, up_axis, up_sign, float(lo_u), float(lo_v), cols, rows)
+    spec = GridSpec(cell_size, up_axis, up_sign, float(lo_u), float(lo_v), cols, rows, v_sign=v_sign)
     ncells = rows * cols
     log(f"  grid {cols}x{rows} @ {cell_size} m ({cols * cell_size:.0f}x{rows * cell_size:.0f} m)")
 
@@ -179,19 +188,32 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     else:
         height_out = height_raster
 
-    # Occupancy = walkability, not "is there anything above the ground". On narrow forest
-    # paths, foliage/branches overhang walkable ground and drop obstacle points into the band,
-    # so "any obstacle point -> blocked" false-blocks the paths the operator literally walked.
-    # Instead block only where obstacle points *dominate* ground points: a trunk/wall/bush has
-    # many obstacle points and little ground beneath it, whereas a path is ground-dominant with
-    # only overhang above. Then require a minimum count and drop isolated specks.
+    # ----- structure footprint + occupancy (solid-to-ground test) --------------
+    # Two independent questions per cell, kept in two rasters:
+    #   structure  -- *what* vertical thing is here: the dominant obstacle class, recorded
+    #                 wherever obstacle points land, walkable underneath or not.
+    #   occupancy  -- *can you walk here*: geometry, not mere presence. A barrier is BLOCKED
+    #                 only when its points reach down near the ground (building / wall / trunk /
+    #                 bush). Tree canopy overhanging a path leaves a clearance gap above the
+    #                 ground, so it stays FREE -- you walk under it (the operator did). This is
+    #                 why "any obstacle point -> blocked" over-blocks tree-lined paths.
     o_cells = cell_of(is_obstacle)
-    delta = height[is_obstacle] - height_out.reshape(-1)[o_cells]
-    lo_b, hi_b = obstacle_band
-    in_band = o_cells[(delta >= lo_b) & (delta <= hi_b)]
-    obs_count = np.bincount(in_band, minlength=ncells).reshape(rows, cols)
-    grd_count = g_count.reshape(rows, cols)
-    blocked = (obs_count >= min_obstacle_count) & (obs_count >= obstacle_dominance * grd_count)
+    obs_count = np.bincount(o_cells, minlength=ncells)
+
+    # Structure class: confidence-weighted obstacle majority where enough points landed.
+    structure_flat = _grouped_majority(o_cells, labels[is_obstacle], confidence[is_obstacle],
+                                       ncells, n_klass)
+    structure_flat[obs_count < min_structure_count] = int(Klass.UNKNOWN)
+    structure = structure_flat.reshape(rows, cols)
+
+    # Solidity: low quantile of the obstacle points' height-above-ground. Small -> the column
+    # reaches the ground (solid); large -> only high overhang (canopy) with walkable clearance.
+    # A low quantile (not the min) so one stray low point can't fake solidity under a canopy.
+    obs_hag = height[is_obstacle] - height_out.reshape(-1)[o_cells]
+    base_hag, _ = _grouped_reduce(o_cells, obs_hag, ncells, "quantile", q=0.1)
+    base_hag = base_hag.reshape(rows, cols)
+    obs_count2d = obs_count.reshape(rows, cols)
+    blocked = (obs_count2d >= min_obstacle_count) & np.isfinite(base_hag) & (base_hag <= solid_gap)
     raw_blocked = int(blocked.sum())
 
     if occupancy_morph and blocked.any():
@@ -207,9 +229,10 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     occ[blocked] = BLOCKED
     occupancy = occ
 
-    log(f"  ground cells {int(coverage.sum())}/{ncells} observed"
-        f" ({100 * coverage.mean():.1f}%); blocked {raw_blocked} -> {int(blocked.sum())} after cleanup")
-    return Level(ordinal, spec, height_out, semantic, occupancy, coverage)
+    n_struct = int((structure != int(Klass.UNKNOWN)).sum())
+    log(f"  ground cells {int(coverage.sum())}/{ncells} observed ({100 * coverage.mean():.1f}%); "
+        f"structure cells {n_struct}; blocked {raw_blocked} -> {int(blocked.sum())} after cleanup")
+    return Level(ordinal, spec, height_out, semantic, structure, occupancy, coverage)
 
 
 # ----- export ------------------------------------------------------------------
@@ -233,20 +256,20 @@ def save_level(level: Level, out_dir: str | Path, prefix: str = "level0") -> Non
 
     np.savez_compressed(
         d / f"{prefix}.npz",
-        height=level.height, semantic=level.semantic,
+        height=level.height, semantic=level.semantic, structure=level.structure,
         occupancy=level.occupancy, coverage=level.coverage,
     )
     with open(d / f"{prefix}.meta.json", "w") as f:
         json.dump({
             "ordinal": level.ordinal, "cell_size": s.cell_size,
-            "up_axis": s.up_axis, "up_sign": s.up_sign,
+            "up_axis": s.up_axis, "up_sign": s.up_sign, "v_sign": s.v_sign,
             "origin_u": s.origin_u, "origin_v": s.origin_v,
             "cols": s.cols, "rows": s.rows,
         }, f, indent=2)
 
-    # Orientation: col = +u (=+X), row = +v (=+Z). Shown as-is this is a NON-mirrored
-    # top-down (screen-right=+X, screen-up=-Z), verified against the ARKit trajectory
-    # (Kabsch det=+1, RMSE~0). Do NOT flipud -- that mirrors the map left/right.
+    # Orientation: col = +u (=+X), row = +v where v = -up_sign * world[v_axis]. The row axis
+    # is gravity-canonical (see build_level), so the overhead view renders the same regardless
+    # of whether the source model is Y-up or Y-down. Shown as-is (no flipud -- that mirrors L/R).
     def up(img):
         return img
 
@@ -256,6 +279,12 @@ def save_level(level: Level, out_dir: str | Path, prefix: str = "level0") -> Non
     sem_rgb = lut[level.semantic]
     sem_rgb[~level.coverage] = (30, 30, 30)
     cv2.imwrite(str(d / f"{prefix}_semantic.png"), up(cv2.cvtColor(sem_rgb, cv2.COLOR_RGB2BGR)))
+
+    # Structure footprints (vertical classes): building/wall/tree/... over dimmed ground.
+    struct_rgb = (0.30 * sem_rgb).astype(np.uint8)
+    has_struct = level.structure != int(Klass.UNKNOWN)
+    struct_rgb[has_struct] = lut[level.structure[has_struct]]
+    cv2.imwrite(str(d / f"{prefix}_structure.png"), up(cv2.cvtColor(struct_rgb, cv2.COLOR_RGB2BGR)))
 
     occ_rgb = np.zeros((*level.occupancy.shape, 3), np.uint8)
     occ_rgb[level.occupancy == FREE] = (60, 180, 60)

--- a/script/semantic_bev/ground_model.py
+++ b/script/semantic_bev/ground_model.py
@@ -123,7 +123,7 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
                 ground_quantile: float = 0.2,
                 bounds_pct: float = 0.02, ground_height_clip: tuple[float, float] = (0.01, 0.99),
                 min_obstacle_count: int = 3, min_structure_count: int = 2,
-                solid_gap: float = 0.8, occupancy_morph: bool = True,
+                clearance_band: tuple[float, float] = (0.4, 2.0), occupancy_morph: bool = True,
                 fill_holes: bool = True, ordinal: int = 0, log=print) -> Level:
     """Rasterise labelled points into a single ground Level."""
     roles = np.array([int(role_of(k)) for k in range(int(max(Klass)) + 1)])[labels]
@@ -192,11 +192,12 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     # Two independent questions per cell, kept in two rasters:
     #   structure  -- *what* vertical thing is here: the dominant obstacle class, recorded
     #                 wherever obstacle points land, walkable underneath or not.
-    #   occupancy  -- *can you walk here*: geometry, not mere presence. A barrier is BLOCKED
-    #                 only when its points reach down near the ground (building / wall / trunk /
-    #                 bush). Tree canopy overhanging a path leaves a clearance gap above the
-    #                 ground, so it stays FREE -- you walk under it (the operator did). This is
-    #                 why "any obstacle point -> blocked" over-blocks tree-lined paths.
+    #   occupancy  -- *can you walk here*: decided by what sits at **body height**, not mere
+    #                 presence overhead. A cell is BLOCKED only if obstacle points fall in the
+    #                 clearance band [lo, hi] m above the ground (a trunk / wall / building /
+    #                 bush at body height). Tree canopy overhanging a path is *above* the band,
+    #                 so the band is empty and the path stays FREE -- you walk under it. This is
+    #                 what "any obstacle point -> blocked" got wrong on tree-lined paths.
     o_cells = cell_of(is_obstacle)
     obs_count = np.bincount(o_cells, minlength=ncells)
 
@@ -206,23 +207,22 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     structure_flat[obs_count < min_structure_count] = int(Klass.UNKNOWN)
     structure = structure_flat.reshape(rows, cols)
 
-    # Solidity: low quantile of the obstacle points' height-above-ground. Small -> the column
-    # reaches the ground (solid); large -> only high overhang (canopy) with walkable clearance.
-    # A low quantile (not the min) so one stray low point can't fake solidity under a canopy.
+    # Occupancy: count obstacle points in the body-height clearance band above the ground.
     obs_hag = height[is_obstacle] - height_out.reshape(-1)[o_cells]
-    base_hag, _ = _grouped_reduce(o_cells, obs_hag, ncells, "quantile", q=0.1)
-    base_hag = base_hag.reshape(rows, cols)
-    obs_count2d = obs_count.reshape(rows, cols)
-    blocked = (obs_count2d >= min_obstacle_count) & np.isfinite(base_hag) & (base_hag <= solid_gap)
+    lo_c, hi_c = clearance_band
+    in_band = o_cells[(obs_hag >= lo_c) & (obs_hag <= hi_c)]
+    band_count = np.bincount(in_band, minlength=ncells).reshape(rows, cols)
+    blocked = band_count >= min_obstacle_count
     raw_blocked = int(blocked.sum())
 
     if occupancy_morph and blocked.any():
+        # Drop lone specks only. Deliberately NO morphological close: a walkable path is a thin
+        # free corridor through blocked forest, i.e. a "hole" in the blocked mask -- closing
+        # would fill it and erase the path.
         b = blocked.astype(np.float32)
         neighbours = cv2.filter2D(b, -1, np.ones((3, 3), np.float32),
                                   borderType=cv2.BORDER_CONSTANT) - b
-        b = np.where(blocked & (neighbours >= 1), np.uint8(1), np.uint8(0))  # drop lone specks
-        b = cv2.morphologyEx(b, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))   # fill pinholes
-        blocked = b.astype(bool)
+        blocked = (blocked & (neighbours >= 1))
 
     occ = np.full((rows, cols), UNKNOWN_OCC, dtype=np.uint8)
     occ[coverage] = FREE

--- a/script/semantic_bev/gsplat_source.py
+++ b/script/semantic_bev/gsplat_source.py
@@ -1,0 +1,89 @@
+"""Geometry source: a trained *semantic* 3DGS model -> (positions, labels, confidence).
+
+An alternative to the COLMAP sparse-point source (`colmap_io` + `labeling`). A semantic
+3DGS run (``script/gsplat/train.py --semantic``) bakes a taxonomy class into every
+Gaussian, so the BEV builder can consume the Gaussians directly:
+
+  - **denser** than COLMAP tracks (a whole optimised splat cloud, not just triangulated
+    keypoints), and
+  - **already labelled** — no segmentation/voting pass needed here; the labels were
+    distilled multi-view-consistently during Phase 2 of the gsplat trainer.
+
+Returns the same ``(positions, labels, confidence)`` triple as the COLMAP path, so
+``ground_model.build_level`` is unchanged. The gsplat model is in the *same world
+coordinates* as the COLMAP model it was trained from, so gravity/up detection (which needs
+camera orientations) still comes from that COLMAP model in ``pipeline.py``.
+
+Consumes the gsplat run's export dir:
+  point_cloud.ply            -- Gaussian means (+ opacity, used to prune floaters)
+  point_cloud_labels.npy     -- per-Gaussian Klass id  (row-aligned with the .ply)
+  point_cloud_confidence.npy -- per-Gaussian peak softmax prob (optional; 1.0 if absent)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def _read_float_ply(path: Path) -> dict[str, np.ndarray]:
+    """Read an all-float32 binary_little_endian PLY (the format script/gsplat writes).
+
+    Only 'property float <name>' vertex fields are supported -- which is exactly what the
+    gsplat exporter emits. Returns {field_name: (N,) float32}.
+    """
+    with open(path, "rb") as f:
+        if f.readline().strip() != b"ply":
+            raise ValueError(f"{path} is not a PLY file")
+        fmt = f.readline().strip()
+        if b"binary_little_endian" not in fmt:
+            raise ValueError(f"{path}: only binary_little_endian PLY is supported, got {fmt!r}")
+        count, names = None, []
+        while True:
+            line = f.readline().strip()
+            if line.startswith(b"element vertex"):
+                count = int(line.split()[-1])
+            elif line.startswith(b"property"):
+                parts = line.split()
+                if parts[1] != b"float":
+                    raise ValueError(f"{path}: non-float property {line!r} not supported")
+                names.append(parts[-1].decode())
+            elif line == b"end_header":
+                break
+        dtype = np.dtype([(n, "<f4") for n in names])
+        data = np.frombuffer(f.read(count * dtype.itemsize), dtype=dtype, count=count)
+    return {n: np.ascontiguousarray(data[n]) for n in names}
+
+
+def load_gsplat_points(gsplat_dir: str | Path, min_opacity: float = 0.1,
+                       log=print) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Load a semantic 3DGS export as ``(positions (N,3), labels (N,) uint8, conf (N,))``.
+
+    Gaussians with opacity below ``min_opacity`` are dropped: 3DGS leaves many faint
+    floaters that are visually minor but geometric noise for a ground/height model.
+    """
+    d = Path(gsplat_dir)
+    ply = _read_float_ply(d / "point_cloud.ply")
+    positions = np.stack([ply["x"], ply["y"], ply["z"]], axis=1).astype(np.float64)
+    # 'opacity' is stored as a logit (pre-sigmoid), matching the trainer's representation.
+    opacity = 1.0 / (1.0 + np.exp(-ply["opacity"])) if "opacity" in ply else np.ones(len(positions))
+
+    labels = np.load(d / "point_cloud_labels.npy").astype(np.uint8)
+    conf_path = d / "point_cloud_confidence.npy"
+    if conf_path.exists():
+        confidence = np.load(conf_path).astype(np.float32)
+    else:
+        confidence = np.ones(len(labels), dtype=np.float32)
+        log("  no _confidence.npy (older gsplat run); using uniform confidence 1.0")
+
+    if not (len(positions) == len(labels) == len(confidence)):
+        raise ValueError(
+            f"gsplat export row mismatch: {len(positions)} points, {len(labels)} labels, "
+            f"{len(confidence)} conf -- point_cloud.ply and the .npy files must be aligned"
+        )
+
+    keep = opacity >= min_opacity
+    log(f"  gsplat: {len(positions)} Gaussians, kept {int(keep.sum())} "
+        f"with opacity >= {min_opacity}")
+    return positions[keep], labels[keep], confidence[keep]

--- a/script/semantic_bev/imdf_export.py
+++ b/script/semantic_bev/imdf_export.py
@@ -30,6 +30,7 @@ from shapely.geometry.polygon import orient
 from shapely.ops import unary_union
 
 from colmap_io import qvec2rotmat, read_model
+from grid_transform import cells_to_world
 from taxonomy import CLASSES, Klass
 
 # --- allowed category enums (OGC IMDF 1.0.0 / docs.ogc.org/cs/20-094) ---------------
@@ -96,10 +97,7 @@ def fit_world_to_wgs84(recon, frames_path: str | Path, gps_path: str | Path):
 
 def _pix_to_world(pts_xy: np.ndarray, meta: dict) -> np.ndarray:
     """cv2 contour pixels (col=x, row=y) -> world (X,Z) metres."""
-    world = np.empty_like(pts_xy, dtype=np.float64)
-    world[:, 0] = meta["origin_u"] + pts_xy[:, 0] * meta["cell_size"]  # X
-    world[:, 1] = meta["origin_v"] + pts_xy[:, 1] * meta["cell_size"]  # Z
-    return world
+    return cells_to_world(pts_xy, meta)
 
 
 def mask_to_polygons(binary: np.ndarray, meta: dict, simplify_m: float = 0.5,
@@ -180,7 +178,8 @@ def _geom_wgs84(poly: Polygon, to_wgs84) -> dict:
 def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | Path,
                gps_path: str | Path, venue_name: str = "Maguro Park",
                venue_category: str = "themepark", locality: str = "Tokyo",
-               country: str = "JP", smooth: bool = True, log=print) -> dict:
+               country: str = "JP", smooth: bool = True, paths: str = "polygon",
+               log=print) -> dict:
     d = Path(level_dir)
     meta = json.load(open(d / "level0.meta.json"))
     npz = np.load(d / "level0.npz")
@@ -228,7 +227,7 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
                       "display_point": _display_point(venue_poly, to_wgs84),
                       "address_id": address["id"], "building_ids": None})
 
-    units = []
+    units, routing = [], []
     for category, klasses in cat_classes.items():
         if category not in UNIT_CATEGORIES:
             log(f"  skipping unit category '{category}' (not in IMDF enum)")
@@ -237,10 +236,23 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
         # consolidate before tracing: drop specks (open) then fill pinholes (close).
         k = np.ones((3, 3), np.uint8)
         mask = cv2.morphologyEx(cv2.morphologyEx(mask, cv2.MORPH_OPEN, k), cv2.MORPH_CLOSE, k)
-        polys = mask_to_polygons(mask, meta, simplify_m=0.6, min_area_m2=5.0)
+
+        if category == "walkway" and paths == "centerline":
+            # elegant paths: skeleton -> centerline graph -> constant-width polygons
+            from path_centerlines import centerlines_to_polygons, walkway_centerlines
+            cls = walkway_centerlines(mask, meta)
+            merged = centerlines_to_polygons(cls)
+            for c in cls:
+                ll = to_wgs84(c["line"])
+                if len(ll) >= 2:
+                    routing.append({"coords": [[float(x), float(y)] for x, y in ll.tolist()],
+                                    "width_m": round(c["width"], 2)})
+            log(f"  walkway: {len(cls)} centerline segments")
+        else:
+            polys = mask_to_polygons(mask, meta, simplify_m=0.6, min_area_m2=5.0)
+            merged = unary_union(polys) if polys else None
 
         # merge touching pieces, then cartographically smooth each region
-        merged = unary_union(polys) if polys else None
         parts = ([] if merged is None or merged.is_empty
                  else list(merged.geoms) if merged.geom_type == "MultiPolygon" else [merged])
         cat_polys = []
@@ -259,7 +271,7 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
         "manifest": {"version": "1.0.0", "created": datetime.now(timezone.utc).isoformat(),
                      "generated_by": "lar semantic_bev", "language": "en", "extensions": []},
         "address": [address], "venue": [venue], "level": [level], "unit": units,
-        "_geo": geo,
+        "_geo": geo, "_routing": routing,
     }
 
 
@@ -272,6 +284,15 @@ def write_archive(imdf: dict, out_dir: str | Path, log=print) -> None:
         (out / f"{ftype}.geojson").write_text(json.dumps(fc))
     log(f"wrote IMDF archive -> {out} "
         f"({len(imdf['unit'])} units, {len(imdf['level'])} level, {len(imdf['venue'])} venue)")
+
+    # bonus (not part of the IMDF spec): path centerline graph for LAR navigation
+    routing = imdf.get("_routing") or []
+    if routing:
+        fc = {"type": "FeatureCollection", "name": "routing", "features": [
+            {"type": "Feature", "geometry": {"type": "LineString", "coordinates": r["coords"]},
+             "properties": {"width_m": r["width_m"]}} for r in routing]}
+        (out / "routing.geojson").write_text(json.dumps(fc))
+        log(f"  + routing.geojson ({len(fc['features'])} path centerlines)")
 
 
 # ---- self-validation ----------------------------------------------------------------
@@ -335,11 +356,13 @@ def main() -> None:
     ap.add_argument("--venue-name", default="Maguro Park")
     ap.add_argument("--venue-category", default="themepark", choices=sorted(VENUE_CATEGORIES))
     ap.add_argument("--no-smooth", action="store_true", help="disable cartographic smoothing")
+    ap.add_argument("--paths", default="polygon", choices=["polygon", "centerline"],
+                    help="walkway units: traced polygons, or centerline-graph constant-width paths")
     args = ap.parse_args()
 
     imdf = build_imdf(args.level, args.model, args.frames, args.gps,
                       venue_name=args.venue_name, venue_category=args.venue_category,
-                      smooth=not args.no_smooth)
+                      smooth=not args.no_smooth, paths=args.paths)
     ok = validate(imdf)
     write_archive(imdf, args.out or (Path(args.level) / "imdf"))
     if not ok:

--- a/script/semantic_bev/imdf_export.py
+++ b/script/semantic_bev/imdf_export.py
@@ -128,6 +128,30 @@ def mask_to_polygons(binary: np.ndarray, meta: dict, simplify_m: float = 0.5,
     return polys
 
 
+def smooth_polygon(poly: Polygon, radius: float, simplify_m: float,
+                   min_hole_m2: float = 2.0) -> list[Polygon]:
+    """Cartographic smoothing: rounded morphological open+close (removes pixel-staircase and
+    thin protrusions/nicks), then simplify vertices and drop tiny holes. Returns 0+ polygons."""
+    p = (poly.buffer(-radius, join_style=1)      # open: erode+dilate -> drop protrusions
+         .buffer(2 * radius, join_style=1)        # ...then close: dilate+erode -> fill nicks
+         .buffer(-radius, join_style=1))          # (round joins => smooth curves)
+    if p.is_empty:
+        return []
+    out = []
+    for q in (p.geoms if p.geom_type == "MultiPolygon" else [p]):
+        q = q.simplify(simplify_m, preserve_topology=True)
+        if not q.is_valid:
+            q = q.buffer(0)
+        for r in (q.geoms if q.geom_type == "MultiPolygon" else [q]):
+            if r.geom_type != "Polygon" or r.is_empty:
+                continue
+            holes = [h for h in r.interiors if Polygon(h).area >= min_hole_m2]
+            r = Polygon(r.exterior, holes)
+            if r.is_valid and r.area > 0:
+                out.append(orient(r, sign=1.0))
+    return out
+
+
 # ---- IMDF assembly ------------------------------------------------------------------
 
 def _feature(feature_type: str, geometry, props: dict) -> dict:
@@ -156,7 +180,7 @@ def _geom_wgs84(poly: Polygon, to_wgs84) -> dict:
 def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | Path,
                gps_path: str | Path, venue_name: str = "Maguro Park",
                venue_category: str = "themepark", locality: str = "Tokyo",
-               country: str = "JP", log=print) -> dict:
+               country: str = "JP", smooth: bool = True, log=print) -> dict:
     d = Path(level_dir)
     meta = json.load(open(d / "level0.meta.json"))
     npz = np.load(d / "level0.npz")
@@ -178,13 +202,19 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
                         "province": locality, "country": country, "postal_code": None,
                         "postal_code_ext": None, "postal_code_vanity": None})
 
+    cs = meta["cell_size"]
+    smooth_r, simp_m = 1.4 * cs, 0.8 * cs             # smoothing radius / simplify tol in metres
+
     # venue / level boundary = outer boundary of observed coverage (gaps closed)
     cov = cv2.morphologyEx(coverage.astype(np.uint8), cv2.MORPH_CLOSE, np.ones((5, 5), np.uint8))
     boundary_polys = mask_to_polygons(cov, meta, simplify_m=1.0, min_area_m2=20.0)
     if not boundary_polys:
         raise ValueError("no coverage to form a venue boundary")
-    venue_poly = max(boundary_polys, key=lambda p: p.area)
-    venue_poly = Polygon(venue_poly.exterior)          # venue has no holes
+    venue_poly = Polygon(max(boundary_polys, key=lambda p: p.area).exterior)  # no holes
+    if smooth:
+        parts = smooth_polygon(venue_poly, smooth_r * 2, simp_m * 2)
+        if parts:
+            venue_poly = Polygon(max(parts, key=lambda p: p.area).exterior)
 
     venue = _feature("venue", _geom_wgs84(venue_poly, to_wgs84),
                      {"category": venue_category, "restriction": None, "name": _labels(venue_name),
@@ -204,17 +234,26 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
             log(f"  skipping unit category '{category}' (not in IMDF enum)")
             continue
         mask = (np.isin(semantic, klasses) & coverage).astype(np.uint8)
-        # consolidate before tracing: drop specks (open) then fill pinholes (close), so we get
-        # a few coherent units instead of hundreds of sliver polygons.
+        # consolidate before tracing: drop specks (open) then fill pinholes (close).
         k = np.ones((3, 3), np.uint8)
         mask = cv2.morphologyEx(cv2.morphologyEx(mask, cv2.MORPH_OPEN, k), cv2.MORPH_CLOSE, k)
         polys = mask_to_polygons(mask, meta, simplify_m=0.6, min_area_m2=5.0)
-        for poly in polys:
+
+        # merge touching pieces, then cartographically smooth each region
+        merged = unary_union(polys) if polys else None
+        parts = ([] if merged is None or merged.is_empty
+                 else list(merged.geoms) if merged.geom_type == "MultiPolygon" else [merged])
+        cat_polys = []
+        for part in parts:
+            cat_polys.extend(smooth_polygon(part, smooth_r, simp_m) if smooth else [part])
+        cat_polys = [p for p in cat_polys if p.area >= 5.0]
+
+        for poly in cat_polys:
             units.append(_feature("unit", _geom_wgs84(poly, to_wgs84),
                                   {"category": category, "restriction": None, "accessibility": None,
                                    "name": None, "alt_name": None, "display_point": None,
                                    "level_id": level["id"]}))
-        log(f"  {category}: {len(polys)} unit polygons")
+        log(f"  {category}: {len(cat_polys)} unit polygons")
 
     return {
         "manifest": {"version": "1.0.0", "created": datetime.now(timezone.utc).isoformat(),
@@ -295,10 +334,12 @@ def main() -> None:
     ap.add_argument("--out", default=None, help="archive dir (default <level>/imdf)")
     ap.add_argument("--venue-name", default="Maguro Park")
     ap.add_argument("--venue-category", default="themepark", choices=sorted(VENUE_CATEGORIES))
+    ap.add_argument("--no-smooth", action="store_true", help="disable cartographic smoothing")
     args = ap.parse_args()
 
     imdf = build_imdf(args.level, args.model, args.frames, args.gps,
-                      venue_name=args.venue_name, venue_category=args.venue_category)
+                      venue_name=args.venue_name, venue_category=args.venue_category,
+                      smooth=not args.no_smooth)
     ok = validate(imdf)
     write_archive(imdf, args.out or (Path(args.level) / "imdf"))
     if not ok:

--- a/script/semantic_bev/labeling.py
+++ b/script/semantic_bev/labeling.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from colmap_io import Reconstruction
+from colmap_io import Reconstruction, qvec2rotmat
 from segmentation import Segmenter, save_mask_png
 from taxonomy import Klass
 
@@ -69,19 +69,43 @@ def segment_and_cache(recon: Reconstruction, image_dir: str | Path,
     return done
 
 
-def accumulate_votes(recon: Reconstruction, store: MaskStore,
-                     image_ids: list[int]) -> tuple[np.ndarray, np.ndarray, dict[int, int]]:
+def accumulate_votes(recon: Reconstruction, store: MaskStore, image_ids: list[int],
+                     max_depth: float = 30.0, log=print) -> tuple[np.ndarray, np.ndarray, dict[int, int]]:
     """Stream masks and tally per-point class votes.
 
     Returns ``(point_ids, votes, index)`` where ``votes`` is (P, num_classes) uint16 and
     ``index`` maps a COLMAP point id to its row.
+
+    Uses the exact observed pixel from each image's 2D keypoints when available. For models
+    with no 2D observations (e.g. a BA export with empty POINTS2D and no point tracks), falls
+    back to reprojecting every point into every image (visibility via depth cap + majority).
     """
     point_ids = np.array(sorted(recon.points3d), dtype=np.int64)
     index = {int(pid): i for i, pid in enumerate(point_ids)}
     n_classes = int(max(Klass)) + 1
     votes = np.zeros((len(point_ids), n_classes), dtype=np.uint16)
 
-    id_set = set(image_ids)
+    if not any(len(recon.images[i].xys) for i in image_ids):
+        log("      model has no 2D observations -> reprojection labeling")
+        pos = np.array([recon.points3d[int(pid)].xyz for pid in point_ids])
+        for img_id in image_ids:
+            im = recon.images[img_id]
+            cam = pos @ qvec2rotmat(im.qvec).T + im.tvec
+            z = cam[:, 2]
+            near = (z > 0.1) & (z < max_depth)
+            if not near.any():
+                continue
+            fx, fy, cx, cy = recon.cameras[im.camera_id].params[:4]
+            px = fx * cam[:, 0] / z + cx
+            py = fy * cam[:, 1] / z + cy
+            mask = store.load(im.name)
+            H, W = mask.shape
+            inb = near & (px >= 0) & (px < W) & (py >= 0) & (py < H)
+            idx = np.nonzero(inb)[0]
+            if len(idx):
+                np.add.at(votes, (idx, mask[py[idx].astype(np.int64), px[idx].astype(np.int64)]), 1)
+        return point_ids, votes, index
+
     for img_id in image_ids:
         img = recon.images[img_id]
         mask = store.load(img.name)

--- a/script/semantic_bev/path_centerlines.py
+++ b/script/semantic_bev/path_centerlines.py
@@ -16,6 +16,8 @@ from shapely.geometry import LineString
 from shapely.ops import unary_union
 from skimage.morphology import skeletonize
 
+from grid_transform import cells_to_world
+
 _NB = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
 _STEP = {o: (2 ** 0.5 if o[0] and o[1] else 1.0) for o in _NB}
 
@@ -93,7 +95,8 @@ def walkway_centerlines(mask: np.ndarray, meta: dict, prune_m: float = 1.5,
         is_spur = deg[path[0]] == 1 or deg[path[-1]] == 1
         if (is_spur and length_m < prune_m) or length_m < min_len_m:
             continue
-        world = np.array([[meta["origin_u"] + x * cs, meta["origin_v"] + y * cs] for y, x in path])
+        rc = np.array(path, dtype=np.float64)  # (N,2) as (row, col)
+        world = cells_to_world(rc[:, ::-1], meta)  # -> (col, row) -> world (X, Z)
         world = _chaikin(world, smooth_iters)
         halfw = np.array([dist[y, x] for y, x in path]) * cs            # dist = half-width
         out.append({"line": world, "width": float(2 * np.median(halfw))})

--- a/script/semantic_bev/path_centerlines.py
+++ b/script/semantic_bev/path_centerlines.py
@@ -1,0 +1,111 @@
+"""Path centerlines: turn blob walkway regions into a smooth centerline graph + clean paths.
+
+A human draws a path as a centerline with a width, not a wiggly polygon. So we skeletonise the
+walkway mask, trace it into a graph (nodes = junctions/endpoints, edges = polylines), prune
+skeleton spurs, smooth each edge, and re-buffer by the measured width into clean constant-width
+paths. The graph doubles as a routing network.
+
+    walkway mask --skeletonize--> graph --prune+smooth--> centerlines (+width) --buffer--> paths
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from shapely.geometry import LineString
+from shapely.ops import unary_union
+from skimage.morphology import skeletonize
+
+_NB = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
+_STEP = {o: (2 ** 0.5 if o[0] and o[1] else 1.0) for o in _NB}
+
+
+def _trace(skel: np.ndarray):
+    """1px skeleton -> (edges, degree). Each edge is a pixel polyline between non-degree-2 nodes."""
+    pts = set(map(tuple, np.argwhere(skel)))
+
+    def nbrs(p):
+        y, x = p
+        return [(y + dy, x + dx) for dy, dx in _NB if (y + dy, x + dx) in pts]
+
+    deg = {p: len(nbrs(p)) for p in pts}
+    nodes = {p for p in pts if deg[p] != 2}
+    edges, seen = [], set()
+    for n in nodes:
+        for m in nbrs(n):
+            if (n, m) in seen:
+                continue
+            path, prev, cur = [n], n, m
+            while True:
+                path.append(cur)
+                seen.add((prev, cur))
+                seen.add((cur, prev))
+                if cur in nodes:
+                    break
+                nxt = [q for q in nbrs(cur) if q != prev]
+                if len(nxt) != 1:
+                    break
+                prev, cur = cur, nxt[0]
+            edges.append(path)
+    return edges, deg
+
+
+def _chaikin(pts: np.ndarray, iters: int) -> np.ndarray:
+    pts = np.asarray(pts, float)
+    for _ in range(iters):
+        if len(pts) < 3:
+            break
+        out = [pts[0]]
+        for a, b in zip(pts[:-1], pts[1:]):
+            out.append(0.75 * a + 0.25 * b)
+            out.append(0.25 * a + 0.75 * b)
+        out.append(pts[-1])
+        pts = np.array(out)
+    return pts
+
+
+def _pix_len(path) -> float:
+    return sum(_STEP[(b[0] - a[0], b[1] - a[1])] for a, b in zip(path[:-1], path[1:]))
+
+
+def walkway_centerlines(mask: np.ndarray, meta: dict, prune_m: float = 1.5,
+                        min_len_m: float = 1.0, smooth_iters: int = 2,
+                        min_component_m2: float = 10.0) -> list[dict]:
+    """Walkway mask -> centerline segments. Each: {'line': (N,2) world XZ, 'width': metres}."""
+    cs = meta["cell_size"]
+    m = mask.astype(np.uint8)
+    m = cv2.morphologyEx(m, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))  # heal gaps before skeleton
+
+    # drop disconnected speckle islands (only skeletonise real path components)
+    n, lbl, stats, _ = cv2.connectedComponentsWithStats(m, 8)
+    keep = np.zeros_like(m)
+    for i in range(1, n):
+        if stats[i, cv2.CC_STAT_AREA] * cs * cs >= min_component_m2:
+            keep[lbl == i] = 1
+    m = keep
+    skel = skeletonize(m.astype(bool))
+    dist = cv2.distanceTransform(m, cv2.DIST_L2, 5)                      # px to boundary
+    edges, deg = _trace(skel)
+
+    out = []
+    for path in edges:
+        length_m = _pix_len(path) * cs
+        is_spur = deg[path[0]] == 1 or deg[path[-1]] == 1
+        if (is_spur and length_m < prune_m) or length_m < min_len_m:
+            continue
+        world = np.array([[meta["origin_u"] + x * cs, meta["origin_v"] + y * cs] for y, x in path])
+        world = _chaikin(world, smooth_iters)
+        halfw = np.array([dist[y, x] for y, x in path]) * cs            # dist = half-width
+        out.append({"line": world, "width": float(2 * np.median(halfw))})
+    return out
+
+
+def centerlines_to_polygons(centerlines: list[dict], min_width_m: float = 0.6):
+    """Re-buffer each smooth centerline by half its width -> clean constant-width path polygons."""
+    polys = []
+    for c in centerlines:
+        if len(c["line"]) < 2:
+            continue
+        r = max(c["width"] / 2, min_width_m / 2)
+        polys.append(LineString(c["line"]).buffer(r, cap_style=1, join_style=1))
+    return unary_union(polys) if polys else None

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -49,6 +49,7 @@ def camera_centers(recon: Reconstruction) -> np.ndarray:
 
 def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
         source: str = "colmap", gsplat_dir: str | None = None, min_opacity: float = 0.1,
+        depth_dir: str | None = None, depth_stride: int = 4, depth_voxel: float = 0.05,
         segmenter_kind: str = "heuristic", cell_size: float = 0.5,
         up_axis: int | None = None, up_sign: float | None = None,
         limit: int | None = None, clip_threshold: float = 0.30,
@@ -58,7 +59,32 @@ def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
     store = None
     image_ids = None
 
-    if source == "gsplat":
+    if source == "depth":
+        # Back-project labelled pixels through per-view metric depth. Needs the same masks
+        # as the colmap source; only the geometry (points) comes from depth, not tracks.
+        mask_dir = out / "masks"
+        log(f"[1/4] reading COLMAP model: {model_dir}")
+        recon = read_model(model_dir)
+        image_ids = sorted(recon.images)
+        if limit is not None:
+            image_ids = image_ids[:limit]
+        log(f"[2/4] segmenting ({segmenter_kind}) -> {mask_dir}")
+        seg_kw = {"threshold": clip_threshold} if segmenter_kind == "clipseg" else {}
+        segmenter = make_segmenter(segmenter_kind, **seg_kw)
+        store = MaskStore(mask_dir)
+        segment_and_cache(recon, image_dir, segmenter, store, image_ids,
+                          overwrite=overwrite_masks, log=log)
+        log(f"[3/4] back-projecting depth: {depth_dir}")
+        from depth_backproject import backproject_labeled_points
+        positions, labels, conf = backproject_labeled_points(
+            recon, store, depth_dir, image_ids,
+            stride=depth_stride, voxel=depth_voxel, log=log)
+        labeled = int((labels != int(Klass.UNKNOWN)).sum())
+        log(f"      {labeled}/{len(labels)} points labelled "
+            f"({100 * labeled / max(len(labels), 1):.1f}%)")
+        _log_class_histogram(labels, log)
+        semantic_mode = "vote"  # dense-mask projection is COLMAP-only
+    elif source == "gsplat":
         log(f"[1/4] loading semantic 3DGS points: {gsplat_dir}")
         from gsplat_source import load_gsplat_points
         positions, labels, conf = load_gsplat_points(gsplat_dir, min_opacity=min_opacity, log=log)
@@ -143,13 +169,23 @@ def main() -> None:
     ap.add_argument("--session", default=None,
                     help="LAR session name: fills --model/--images/--gsplat-dir/--out from the "
                          "canonical layout (script/lar_session.py). Explicit flags override.")
-    ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat"],
-                    help="geometry source: 'colmap' sparse points + segmentation (default), or "
-                         "'gsplat' a trained semantic 3DGS export (denser, pre-labelled)")
+    ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat", "depth"],
+                    help="geometry source: 'colmap' sparse points + segmentation (default); "
+                         "'gsplat' a trained semantic 3DGS export; 'depth' back-projected "
+                         "per-view metric depth (MVS/2DGS/mono/3DGS bake-off)")
     ap.add_argument("--gsplat-dir", default=None,
                     help="semantic 3DGS export dir (script/gsplat --out); required for --source gsplat")
     ap.add_argument("--min-opacity", type=float, default=0.1,
                     help="drop Gaussians below this opacity when using --source gsplat")
+    ap.add_argument("--depth-backend", default=None,
+                    help="depth backend name (mvs/2dgs/mono/3dgs); with --session derives "
+                         "--depth-dir and the output tag")
+    ap.add_argument("--depth-dir", default=None,
+                    help="dir of per-view metric depth maps (<stem>.npy); required for --source depth")
+    ap.add_argument("--stride", type=int, default=4,
+                    help="pixel subsample stride for depth back-projection (--source depth)")
+    ap.add_argument("--voxel", type=float, default=0.05,
+                    help="voxel size in metres for depth-point dedup (--source depth)")
     ap.add_argument("--model", default=None,
                     help="COLMAP text model dir. Required for --source colmap; for --source gsplat "
                          "it supplies camera orientations for gravity (unless --up-axis/--up-sign given)")
@@ -170,23 +206,33 @@ def main() -> None:
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
         from lar_session import Session
         s = Session(args.session)
-        args.model = args.model or str(s.best_model())  # geometry (colmap) or gravity (gsplat)
-        args.out = args.out or str(s.sbev_out(args.source))
+        args.model = args.model or str(s.best_model())  # geometry (colmap) or gravity (gsplat/depth)
         if args.source == "gsplat":
             args.gsplat_dir = args.gsplat_dir or str(s.gsplat_out(semantic=True))
+            args.out = args.out or str(s.sbev_out("gsplat"))
+        elif args.source == "depth":
+            args.images = args.images or str(s.images)
+            if args.depth_backend:
+                args.depth_dir = args.depth_dir or str(s.depth_dir(args.depth_backend))
+                args.out = args.out or str(s.sbev_out("depth", tag=args.depth_backend))
         else:
             args.images = args.images or str(s.images)
+            args.out = args.out or str(s.sbev_out("colmap"))
         print(f"session '{args.session}': source={args.source} out={args.out}")
 
     if not args.out:
-        ap.error("need --session or --out")
+        ap.error("need --session (+ --depth-backend for depth) or --out")
     if args.source == "colmap" and (not args.model or not args.images):
         ap.error("--source colmap requires --model and --images (or --session)")
     if args.source == "gsplat" and not args.gsplat_dir:
         ap.error("--source gsplat requires --gsplat-dir (or --session)")
+    if args.source == "depth" and (not args.depth_dir or not args.model or not args.images):
+        ap.error("--source depth requires --depth-dir, --model, --images "
+                 "(or --session + --depth-backend)")
 
     run(args.model, args.images, args.out, source=args.source, gsplat_dir=args.gsplat_dir,
-        min_opacity=args.min_opacity, segmenter_kind=args.segmenter,
+        min_opacity=args.min_opacity, depth_dir=args.depth_dir, depth_stride=args.stride,
+        depth_voxel=args.voxel, segmenter_kind=args.segmenter,
         cell_size=args.cell_size, up_axis=args.up_axis, up_sign=args.up_sign,
         limit=args.limit, clip_threshold=args.clip_threshold,
         overwrite_masks=args.overwrite_masks, semantic_mode=args.semantic_mode)

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -140,6 +140,9 @@ def _log_class_histogram(labels: np.ndarray, log) -> None:
 def main() -> None:
     ap = argparse.ArgumentParser(description="Semantic BEV ground model from COLMAP points "
                                              "or a semantic 3DGS export")
+    ap.add_argument("--session", default=None,
+                    help="LAR session name: fills --model/--images/--gsplat-dir/--out from the "
+                         "canonical layout (script/lar_session.py). Explicit flags override.")
     ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat"],
                     help="geometry source: 'colmap' sparse points + segmentation (default), or "
                          "'gsplat' a trained semantic 3DGS export (denser, pre-labelled)")
@@ -151,7 +154,7 @@ def main() -> None:
                     help="COLMAP text model dir. Required for --source colmap; for --source gsplat "
                          "it supplies camera orientations for gravity (unless --up-axis/--up-sign given)")
     ap.add_argument("--images", default=None, help="directory of source images (--source colmap)")
-    ap.add_argument("--out", required=True, help="output directory")
+    ap.add_argument("--out", default=None, help="output directory (derived from --session if unset)")
     ap.add_argument("--segmenter", default="heuristic", choices=list(SEGMENTER_KINDS))
     ap.add_argument("--cell-size", type=float, default=0.5, help="metres per grid cell")
     ap.add_argument("--up-axis", type=int, default=None, choices=[0, 1, 2], help="0=x,1=y,2=z (auto if unset)")
@@ -162,10 +165,25 @@ def main() -> None:
     ap.add_argument("--semantic-mode", default="vote", choices=["vote", "project"],
                     help="vote: sparse point votes (fast); project: dense-mask projection (cleaner)")
     args = ap.parse_args()
+    if args.session:
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())  # geometry (colmap) or gravity (gsplat)
+        args.out = args.out or str(s.sbev_out(args.source))
+        if args.source == "gsplat":
+            args.gsplat_dir = args.gsplat_dir or str(s.gsplat_out(semantic=True))
+        else:
+            args.images = args.images or str(s.images)
+        print(f"session '{args.session}': source={args.source} out={args.out}")
+
+    if not args.out:
+        ap.error("need --session or --out")
     if args.source == "colmap" and (not args.model or not args.images):
-        ap.error("--source colmap requires --model and --images")
+        ap.error("--source colmap requires --model and --images (or --session)")
     if args.source == "gsplat" and not args.gsplat_dir:
-        ap.error("--source gsplat requires --gsplat-dir")
+        ap.error("--source gsplat requires --gsplat-dir (or --session)")
 
     run(args.model, args.images, args.out, source=args.source, gsplat_dir=args.gsplat_dir,
         min_opacity=args.min_opacity, segmenter_kind=args.segmenter,

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -47,37 +47,61 @@ def camera_centers(recon: Reconstruction) -> np.ndarray:
     return np.array([-_qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
 
 
-def run(model_dir: str, image_dir: str, out_dir: str, *,
+def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
+        source: str = "colmap", gsplat_dir: str | None = None, min_opacity: float = 0.1,
         segmenter_kind: str = "heuristic", cell_size: float = 0.5,
         up_axis: int | None = None, up_sign: float | None = None,
         limit: int | None = None, clip_threshold: float = 0.30,
         overwrite_masks: bool = False, semantic_mode: str = "vote", log=print) -> None:
     out = Path(out_dir)
-    mask_dir = out / "masks"
+    recon = None   # COLMAP model: geometry+labels in colmap mode; gravity only in gsplat mode
+    store = None
+    image_ids = None
 
-    log(f"[1/5] reading COLMAP model: {model_dir}")
-    recon = read_model(model_dir)
-    log(f"      {len(recon.images)} images, {recon.num_points} points")
+    if source == "gsplat":
+        log(f"[1/4] loading semantic 3DGS points: {gsplat_dir}")
+        from gsplat_source import load_gsplat_points
+        positions, labels, conf = load_gsplat_points(gsplat_dir, min_opacity=min_opacity, log=log)
+        labeled = int((labels != int(Klass.UNKNOWN)).sum())
+        log(f"      {labeled}/{len(labels)} points labelled "
+            f"({100 * labeled / max(len(labels), 1):.1f}%)")
+        _log_class_histogram(labels, log)
+        # Gravity/up needs camera orientations, which the Gaussians don't carry -- read the
+        # COLMAP model the gsplat run was trained from (same world coords).
+        if (up_axis is None or up_sign is None):
+            if not model_dir:
+                raise SystemExit("--source gsplat needs --model (for gravity) or explicit "
+                                 "--up-axis/--up-sign")
+            recon = read_model(model_dir)
+        if semantic_mode == "project":
+            log("      note: --semantic-mode project is COLMAP-only; using per-Gaussian labels")
+            semantic_mode = "vote"
+    else:
+        mask_dir = out / "masks"
+        log(f"[1/5] reading COLMAP model: {model_dir}")
+        recon = read_model(model_dir)
+        log(f"      {len(recon.images)} images, {recon.num_points} points")
 
-    image_ids = sorted(recon.images)
-    if limit is not None:
-        image_ids = image_ids[:limit]
-        log(f"      limiting to first {len(image_ids)} images")
+        image_ids = sorted(recon.images)
+        if limit is not None:
+            image_ids = image_ids[:limit]
+            log(f"      limiting to first {len(image_ids)} images")
 
-    log(f"[2/5] segmenting ({segmenter_kind}) -> {mask_dir}")
-    seg_kw = {"threshold": clip_threshold} if segmenter_kind == "clipseg" else {}
-    segmenter = make_segmenter(segmenter_kind, **seg_kw)
-    store = MaskStore(mask_dir)
-    segment_and_cache(recon, image_dir, segmenter, store, image_ids,
-                      overwrite=overwrite_masks, log=log)
+        log(f"[2/5] segmenting ({segmenter_kind}) -> {mask_dir}")
+        seg_kw = {"threshold": clip_threshold} if segmenter_kind == "clipseg" else {}
+        segmenter = make_segmenter(segmenter_kind, **seg_kw)
+        store = MaskStore(mask_dir)
+        segment_and_cache(recon, image_dir, segmenter, store, image_ids,
+                          overwrite=overwrite_masks, log=log)
 
-    log("[3/5] voting labels onto points")
-    point_ids, votes, _ = accumulate_votes(recon, store, image_ids)
-    labels, conf = resolve_labels(votes)
-    positions = np.array([recon.points3d[int(pid)].xyz for pid in point_ids])
-    labeled = int((labels != int(Klass.UNKNOWN)).sum())
-    log(f"      {labeled}/{len(labels)} points labelled ({100 * labeled / len(labels):.1f}%)")
-    _log_class_histogram(labels, log)
+        log("[3/5] voting labels onto points")
+        point_ids, votes, _ = accumulate_votes(recon, store, image_ids)
+        labels, conf = resolve_labels(votes)
+        positions = np.array([recon.points3d[int(pid)].xyz for pid in point_ids])
+        labeled = int((labels != int(Klass.UNKNOWN)).sum())
+        log(f"      {labeled}/{len(labels)} points labelled "
+            f"({100 * labeled / len(labels):.1f}%)")
+        _log_class_histogram(labels, log)
 
     if up_axis is None or up_sign is None:
         a, s, vec = detect_gravity_up(recon)
@@ -91,7 +115,7 @@ def run(model_dir: str, image_dir: str, out_dir: str, *,
         if above < 0:
             log("      WARNING: cameras sit BELOW ground along up-axis -- frame may be upside down!")
 
-    log("[4/5] building ground level")
+    log("[build] building ground level")
     level = build_level(positions, labels, conf, cell_size=cell_size,
                         up_axis=up_axis, up_sign=up_sign, log=log)
 
@@ -102,7 +126,7 @@ def run(model_dir: str, image_dir: str, out_dir: str, *,
         level.semantic = sem
         level.coverage = level.coverage | proj_cov  # projection reaches cells sparse points miss
 
-    log(f"[5/5] exporting -> {out}")
+    log(f"[export] -> {out}")
     save_level(level, out, prefix="level0")
     log("done.")
 
@@ -114,9 +138,19 @@ def _log_class_histogram(labels: np.ndarray, log) -> None:
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Semantic BEV ground model from COLMAP + segmentation")
-    ap.add_argument("--model", required=True, help="COLMAP text model dir (cameras/images/points3D.txt)")
-    ap.add_argument("--images", required=True, help="directory of source images")
+    ap = argparse.ArgumentParser(description="Semantic BEV ground model from COLMAP points "
+                                             "or a semantic 3DGS export")
+    ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat"],
+                    help="geometry source: 'colmap' sparse points + segmentation (default), or "
+                         "'gsplat' a trained semantic 3DGS export (denser, pre-labelled)")
+    ap.add_argument("--gsplat-dir", default=None,
+                    help="semantic 3DGS export dir (script/gsplat --out); required for --source gsplat")
+    ap.add_argument("--min-opacity", type=float, default=0.1,
+                    help="drop Gaussians below this opacity when using --source gsplat")
+    ap.add_argument("--model", default=None,
+                    help="COLMAP text model dir. Required for --source colmap; for --source gsplat "
+                         "it supplies camera orientations for gravity (unless --up-axis/--up-sign given)")
+    ap.add_argument("--images", default=None, help="directory of source images (--source colmap)")
     ap.add_argument("--out", required=True, help="output directory")
     ap.add_argument("--segmenter", default="heuristic", choices=list(SEGMENTER_KINDS))
     ap.add_argument("--cell-size", type=float, default=0.5, help="metres per grid cell")
@@ -128,8 +162,13 @@ def main() -> None:
     ap.add_argument("--semantic-mode", default="vote", choices=["vote", "project"],
                     help="vote: sparse point votes (fast); project: dense-mask projection (cleaner)")
     args = ap.parse_args()
+    if args.source == "colmap" and (not args.model or not args.images):
+        ap.error("--source colmap requires --model and --images")
+    if args.source == "gsplat" and not args.gsplat_dir:
+        ap.error("--source gsplat requires --gsplat-dir")
 
-    run(args.model, args.images, args.out, segmenter_kind=args.segmenter,
+    run(args.model, args.images, args.out, source=args.source, gsplat_dir=args.gsplat_dir,
+        min_opacity=args.min_opacity, segmenter_kind=args.segmenter,
         cell_size=args.cell_size, up_axis=args.up_axis, up_sign=args.up_sign,
         limit=args.limit, clip_threshold=args.clip_threshold,
         overwrite_masks=args.overwrite_masks, semantic_mode=args.semantic_mode)

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -63,8 +63,12 @@ def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
         # Back-project labelled pixels through per-view metric depth. Needs the same masks
         # as the colmap source; only the geometry (points) comes from depth, not tracks.
         mask_dir = out / "masks"
-        log(f"[1/4] reading COLMAP model: {model_dir}")
-        recon = read_model(model_dir)
+        # A backend may ship its own model (e.g. MVS's undistorted one) with matching
+        # intrinsics — prefer it over the passed --model.
+        colocated = Path(depth_dir) / "model"
+        depth_model = colocated if (colocated / "cameras.txt").exists() else Path(model_dir)
+        log(f"[1/4] reading COLMAP model: {depth_model}")
+        recon = read_model(depth_model)
         image_ids = sorted(recon.images)
         if limit is not None:
             image_ids = image_ids[:limit]

--- a/script/semantic_bev/segmentation.py
+++ b/script/semantic_bev/segmentation.py
@@ -181,6 +181,90 @@ class Mask2FormerSegmenter(Segmenter):
         return self.lut[seg.cpu().numpy().astype(np.int64)].astype(np.uint8)
 
 
+class LingBotSegmenter(Segmenter):
+    """Frozen LingBot-Vision ViT features -> optional AnyUp upsample -> trained
+    linear head -> dense taxonomy mask.
+
+    The head + normalization + config come from a checkpoint written by
+    ``script/backbone/probe.py linprobe --save-head`` (trained on OUR taxonomy via
+    Mask2Former pseudo-labels, so no ADE->Klass keyword remap). Requires the
+    ``lingbot_vision`` package importable; if the head was trained with AnyUp,
+    also the ``anyup`` repo (path stored in the ckpt, override with ``anyup_src``).
+    """
+
+    _MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)  # ImageNet, matches
+    _STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)   # lingbot load_image
+
+    def __init__(self, ckpt: str, device: str | None = None,
+                 anyup_src: str | None = None):
+        import sys
+        import torch  # lazy
+        from lingbot_vision import extract_patch_tokens, load_pretrained_backbone
+
+        self.torch = torch
+        self._extract = extract_patch_tokens
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.dtype = torch.bfloat16 if self.device == "cuda" else torch.float32
+
+        c = torch.load(ckpt, map_location="cpu", weights_only=False)
+        self.size = int(c["size"])
+        self.upsample = c["upsample"]
+        self.up_size = int(c["up_size"])
+        self.mu = torch.tensor(c["mu"], dtype=torch.float32, device=self.device)
+        self.sd = torch.tensor(c["sd"], dtype=torch.float32, device=self.device)
+
+        backbone, _ = load_pretrained_backbone(
+            variant=c["variant"], device=self.device, dtype=self.dtype)
+        self.backbone = backbone
+        self.patch_size = backbone.patch_size
+
+        head = torch.nn.Linear(int(c["embed_dim"]), int(c["n_klass"]))
+        head.load_state_dict(c["head"])
+        self.head = head.to(self.device).eval()
+
+        self.up = None
+        if self.upsample == "anyup":
+            src = anyup_src or c.get("anyup_src")
+            if src and src not in sys.path:
+                sys.path.insert(0, src)
+            from anyup.model import AnyUp
+            urls = {
+                "multi": "https://github.com/wimmerth/anyup/releases/download/checkpoint_v2/anyup_multi_backbone.pth",
+                "paper": "https://github.com/wimmerth/anyup/releases/download/checkpoint/anyup_paper.pth",
+            }
+            m = AnyUp().to(self.device).eval()
+            m.load_state_dict(torch.hub.load_state_dict_from_url(
+                urls[c["anyup_ckpt"]], map_location=self.device, progress=False))
+            self.up = m
+
+    def _preprocess(self, image_bgr: np.ndarray):
+        """BGR array -> [1,3,s,s] ImageNet-normalized tensor (lingbot square mode)."""
+        s = max(self.patch_size, (self.size // self.patch_size) * self.patch_size)
+        rgb = cv2.cvtColor(cv2.resize(image_bgr, (s, s), interpolation=cv2.INTER_LINEAR),
+                           cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0
+        rgb = (rgb - self._MEAN) / self._STD
+        return self.torch.from_numpy(rgb).permute(2, 0, 1).unsqueeze(0).contiguous()
+
+    def segment(self, image_bgr: np.ndarray) -> np.ndarray:
+        torch = self.torch
+        H, W = image_bgr.shape[:2]
+        img_norm = self._preprocess(image_bgr)
+        with torch.no_grad():
+            tokens, (h, w) = self._extract(self.backbone, img_norm, self.device, self.dtype)
+            if self.up is None:
+                feat = tokens[0].float()                       # [h*w, C]
+                gh, gw = h, w
+            else:
+                lr = tokens[0].float().reshape(1, h, w, -1).permute(0, 3, 1, 2).contiguous()
+                guide = img_norm.to(self.device).float()
+                hr = self.up(guide, lr, output_size=(self.up_size, self.up_size), q_chunk_size=256)
+                feat = hr[0].permute(1, 2, 0).reshape(-1, hr.shape[1])  # [up*up, C]
+                gh, gw = self.up_size, self.up_size
+            x = (feat - self.mu) / self.sd
+            pred = self.head(x).argmax(1).to(torch.uint8).cpu().numpy().reshape(gh, gw)
+        return cv2.resize(pred, (W, H), interpolation=cv2.INTER_NEAREST).astype(np.uint8)
+
+
 def save_mask_png(mask: np.ndarray, path: str | Path) -> None:
     """Write a class-id map as a colour PNG (viewable) alongside the raw ids in the R channel."""
     lut = np.array(color_lut(), dtype=np.uint8)
@@ -191,7 +275,7 @@ def save_mask_png(mask: np.ndarray, path: str | Path) -> None:
 
 # Single source of truth for valid backend names (CLI choices derive from this).
 SEGMENTER_KINDS = ("heuristic", "clipseg", "oneformer", "oneformer-large",
-                   "mask2former", "mask2former-large")
+                   "mask2former", "mask2former-large", "lingbot")
 
 
 def make_segmenter(kind: str, **kw) -> Segmenter:
@@ -207,5 +291,7 @@ def make_segmenter(kind: str, **kw) -> Segmenter:
         return Mask2FormerSegmenter(**kw)
     if kind == "mask2former-large":
         return Mask2FormerSegmenter(model_name="facebook/mask2former-swin-large-ade-semantic", **kw)
+    if kind == "lingbot":
+        return LingBotSegmenter(**kw)  # requires ckpt=<linprobe --save-head output>
     raise ValueError(f"unknown segmenter kind {kind!r} "
-                     f"(heuristic/clipseg/oneformer[-large]/mask2former[-large])")
+                     f"(heuristic/clipseg/oneformer[-large]/mask2former[-large]/lingbot)")

--- a/script/semantic_bev/taxonomy.py
+++ b/script/semantic_bev/taxonomy.py
@@ -126,14 +126,44 @@ def color_lut() -> "list[tuple[int, int, int]]":
 # Keyword -> Klass, for mapping *closed-set* model labels (e.g. ADE20K's 150 names) onto our
 # taxonomy. Checked in order; first substring hit wins, so put specific before generic.
 _KEYWORD_KLASS: list[tuple[str, Klass]] = [
+    # --- explicit disambiguations, must precede the generic keys below ---
+    # Word boundaries fix the accidental hits, but a few labels genuinely contain a keyword
+    # while meaning something else, and a few lost their (accidentally correct) mapping once
+    # the loose match was removed. Both are named here rather than left to chance.
+    ("pool table", Klass.UNKNOWN), ("billiard table", Klass.UNKNOWN),  # indoor, not WATER
+    ("skyscraper", Klass.BUILDING),                                    # a building, not SKY
+    ("playing field", Klass.GRASS), ("soccer field", Klass.GRASS),
+    ("seat", Klass.FURNITURE),
+    ("streetlight", Klass.FURNITURE), ("street lamp", Klass.FURNITURE),
+    ("vending machine", Klass.FURNITURE), ("kiosk", Klass.BUILDING),
+    ("bike rack", Klass.FURNITURE), ("picnic table", Klass.FURNITURE),
+    ("planter", Klass.FURNITURE), ("bollard", Klass.FURNITURE),
+    ("statue", Klass.FURNITURE), ("monument", Klass.FURNITURE),
+    # --- compounds that the OLD loose match happened to get right ---
+    # Anchoring alone is a net regression: "stairway"/"escalator" used to hit via "stair" in
+    # "staircase", "waterfall" via "water", "minibike" via "bike", "traffic light" via "sign"
+    # in "signal". Substring matching was accidentally correct about as often as it was wrong,
+    # so each compound has to be named rather than left to a lucky collision.
+    ("stairway", Klass.STAIRS), ("staircase", Klass.STAIRS), ("escalator", Klass.STAIRS),
+    ("waterfall", Klass.WATER),
+    ("minibike", Klass.VEHICLE), ("motorbike", Klass.VEHICLE), ("motorcycle", Klass.VEHICLE),
+    ("boat", Klass.VEHICLE), ("ship", Klass.VEHICLE), ("bus", Klass.VEHICLE),
+    ("airplane", Klass.VEHICLE), ("aeroplane", Klass.VEHICLE),
+    ("tower", Klass.BUILDING), ("grandstand", Klass.BUILDING),
+    ("traffic light", Klass.FURNITURE), ("traffic signal", Klass.FURNITURE),
+    ("stoplight", Klass.FURNITURE), ("light source", Klass.FURNITURE),
+    ("column", Klass.FURNITURE), ("pillar", Klass.FURNITURE), ("pedestal", Klass.FURNITURE),
+    ("flowerpot", Klass.FURNITURE), ("vase", Klass.FURNITURE),
+    ("bulletin board", Klass.FURNITURE), ("notice board", Klass.FURNITURE),
     ("sidewalk", Klass.PATH), ("pavement", Klass.PAVEMENT), ("runway", Klass.PATH),
     ("road", Klass.PATH), ("path", Klass.PATH),
     ("stair", Klass.STAIRS), ("step", Klass.STAIRS),
     ("grass", Klass.GRASS), ("lawn", Klass.GRASS), ("flower", Klass.GRASS),
+    ("field", Klass.GRASS),          # ADE "field" is a grass field, not bare ground
     ("palm", Klass.TREE), ("tree", Klass.TREE), ("plant", Klass.TREE),
     ("bush", Klass.TREE), ("shrub", Klass.TREE), ("hedge", Klass.TREE),
     ("earth", Klass.TERRAIN), ("ground", Klass.TERRAIN), ("soil", Klass.TERRAIN),
-    ("dirt", Klass.TERRAIN), ("land", Klass.TERRAIN), ("field", Klass.TERRAIN),
+    ("dirt", Klass.TERRAIN), ("land", Klass.TERRAIN),
     ("sand", Klass.TERRAIN), ("gravel", Klass.TERRAIN), ("hill", Klass.TERRAIN),
     ("mountain", Klass.TERRAIN), ("rock", Klass.TERRAIN),
     ("water", Klass.WATER), ("sea", Klass.WATER), ("river", Klass.WATER),
@@ -151,11 +181,39 @@ _KEYWORD_KLASS: list[tuple[str, Klass]] = [
 ]
 
 
+_KW_RE: "list[tuple[object, Klass]]" = []
+
+
 def keyword_klass(name: str) -> Klass:
-    """Map an arbitrary closed-set label name to our taxonomy by keyword; UNKNOWN if no hit."""
+    """Map an arbitrary closed-set label name to our taxonomy by keyword; UNKNOWN if no hit.
+
+    Matching is on WORD BOUNDARIES, not raw substrings. Plain ``kw in name`` silently produced
+    real mislabels, because our keywords are short and English is full of them:
+
+        "seat"           contained "sea"    -> WATER
+        "streetlight"    contained "tree"   -> TREE     (s-TREE-t)
+        "rug, carpet"    contained "car"    -> VEHICLE
+        "kitchen island" contained "land"   -> TERRAIN
+        "skyscraper"     started  "sky"     -> SKY
+
+    Ordering cannot fix this -- ``streetlight`` was already listed as FURNITURE, it just lost
+    the race to ``tree``. Only anchoring the match does. These were not hypothetical: the park
+    BEV carried 9 WATER cells (no water in the park) and misfiled street lamps as trees.
+
+    A name may be a comma-separated synonym list ("rug, carpet, carpeting"); boundary matching
+    spans it naturally, so callers should pass the whole string rather than splitting and
+    combining, which had no principled way to break ties.
+    """
+    global _KW_RE
+    if not _KW_RE:
+        import re
+        # ``s?`` because the keys are singular but label sets are not ("stair" must still
+        # catch "stairs, steps"). Anchoring without this silently drops every plural -- it sent
+        # STAIRS to UNKNOWN on the first attempt.
+        _KW_RE = [(re.compile(r"\b" + re.escape(kw) + r"s?\b"), k) for kw, k in _KEYWORD_KLASS]
     n = name.lower()
-    for kw, k in _KEYWORD_KLASS:
-        if kw in n:
+    for rx, k in _KW_RE:
+        if rx.search(n):
             return k
     return Klass.UNKNOWN
 

--- a/script/semantic_bev/verify_orientation.py
+++ b/script/semantic_bev/verify_orientation.py
@@ -18,6 +18,7 @@ import cv2
 import numpy as np
 
 from colmap_io import read_model
+from grid_transform import world_to_cell
 from pipeline import _qvec2rotmat
 from taxonomy import Klass, Role, role_of
 
@@ -39,9 +40,9 @@ def main() -> None:
     centers = np.array([-_qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
     u_axis, v_axis = (a for a in (0, 1, 2) if a != meta["up_axis"])
 
-    # same mapping the raster uses: col = (u-origin)/cell, row = (v-origin)/cell  (no flip)
-    col = ((centers[:, u_axis] - meta["origin_u"]) / meta["cell_size"]).astype(int)
-    row = ((centers[:, v_axis] - meta["origin_v"]) / meta["cell_size"]).astype(int)
+    # same mapping the raster uses (single source of truth in grid_transform)
+    col_f, row_f = world_to_cell(centers[:, u_axis], centers[:, v_axis], meta)
+    col, row = col_f.astype(int), row_f.astype(int)
     inb = (col >= 0) & (col < meta["cols"]) & (row >= 0) & (row < meta["rows"])
     col, row = col[inb], row[inb]
 

--- a/script/semantic_bev/view_imdf.py
+++ b/script/semantic_bev/view_imdf.py
@@ -28,7 +28,7 @@ HTML = """<!doctype html><html><head><meta charset="utf-8">
 .legend{{background:#fff;padding:8px 10px;border-radius:6px;font:13px sans-serif;line-height:1.6;box-shadow:0 1px 4px rgba(0,0,0,.3)}}
 .sw{{display:inline-block;width:12px;height:12px;margin-right:6px;border:1px solid #0003;vertical-align:middle}}</style>
 </head><body><div id="map"></div><script>
-const UNIT={units}, VENUE={venue}, LEVEL={level}, STYLE={style};
+const UNIT={units}, VENUE={venue}, LEVEL={level}, STYLE={style}, ROUTING={routing};
 const map=L.map('map');
 L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png',
   {{maxZoom:20,attribution:'&copy; OpenStreetMap'}}).addTo(map);
@@ -37,6 +37,8 @@ const units=L.geoJSON(UNIT,{{
   style:f=>STYLE[f.properties.category]||{{color:'#888',fillColor:'#bbb',fillOpacity:.5,weight:1}},
   onEachFeature:(f,l)=>l.bindPopup(`<b>${{f.feature_type}}</b><br>category: ${{f.properties.category}}<br>id: ${{f.id}}`)
 }}).addTo(map);
+if(ROUTING&&ROUTING.features&&ROUTING.features.length)
+  L.geoJSON(ROUTING,{{style:{{color:'#c0392b',weight:2,opacity:0.9,dashArray:'4 3'}}}}).addTo(map);
 const ven=L.geoJSON(VENUE,{{style:{venue_style}}}).addTo(map);
 map.fitBounds(ven.getBounds().pad(0.1));
 const lg=L.control({{position:'bottomright'}});
@@ -56,11 +58,14 @@ def main() -> None:
 
     venue = json.load(open(d / "venue.geojson"))
     title = venue["features"][0]["properties"]["name"].get("en", "IMDF Venue")
+    routing_path = d / "routing.geojson"
+    routing = json.load(open(routing_path)) if routing_path.exists() else {"features": []}
     html = HTML.format(
         title=title,
         units=json.dumps(json.load(open(d / "unit.geojson"))),
         venue=json.dumps(venue),
         level=json.dumps(json.load(open(d / "level.geojson"))),
+        routing=json.dumps(routing),
         style=json.dumps(STYLE),
         venue_style=json.dumps(VENUE_STYLE),
     )

--- a/uv.lock
+++ b/uv.lock
@@ -253,6 +253,19 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio"
+version = "2.37.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
 name = "jaxtyping"
 version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -293,6 +306,7 @@ gsplat = [
     { name = "tqdm" },
 ]
 imdf = [
+    { name = "scikit-image" },
     { name = "shapely" },
 ]
 segmentation = [
@@ -309,6 +323,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.5.0" },
     { name = "opencv-python", specifier = ">=4.13.0.92" },
     { name = "pillow", marker = "extra == 'segmentation'", specifier = ">=10.0.0" },
+    { name = "scikit-image", marker = "extra == 'imdf'", specifier = ">=0.22.0" },
     { name = "scipy", marker = "extra == 'gsplat'", specifier = ">=1.11.0" },
     { name = "scipy", marker = "extra == 'segmentation'", specifier = ">=1.11.0" },
     { name = "shapely", marker = "extra == 'imdf'", specifier = ">=2.0.0" },
@@ -319,6 +334,18 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'segmentation'", specifier = ">=4.44.0" },
 ]
 provides-extras = ["segmentation", "gsplat", "imdf"]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
+]
 
 [[package]]
 name = "markdown-it-py"
@@ -930,6 +957,64 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-image"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "imageio" },
+    { name = "lazy-loader" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "scipy" },
+    { name = "tifffile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/e8/e13757982264b33a1621628f86b587e9a73a13f5256dad49b19ba7dc9083/scikit_image-0.26.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d454b93a6fa770ac5ae2d33570f8e7a321bb80d29511ce4b6b78058ebe176e8c", size = 12376452, upload-time = "2025-12-20T17:10:52.796Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/be/f8dd17d0510f9911f9f17ba301f7455328bf13dae416560126d428de9568/scikit_image-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3409e89d66eff5734cd2b672d1c48d2759360057e714e1d92a11df82c87cba37", size = 12061567, upload-time = "2025-12-20T17:10:55.207Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/c70120a6880579fb42b91567ad79feb4772f7be72e8d52fec403a3dde0c6/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c717490cec9e276afb0438dd165b7c3072d6c416709cc0f9f5a4c1070d23a44", size = 13084214, upload-time = "2025-12-20T17:10:57.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466", size = 13561683, upload-time = "2025-12-20T17:10:59.49Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/48bdfd92794c5002d664e0910a349d0a1504671ef5ad358150f21643c79a/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cefd85033e66d4ea35b525bb0937d7f42d4cdcfed2d1888e1570d5ce450d3932", size = 14112147, upload-time = "2025-12-20T17:11:02.083Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/b5/ac71694da92f5def5953ca99f18a10fe98eac2dd0a34079389b70b4d0394/scikit_image-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3f5bf622d7c0435884e1e141ebbe4b2804e16b2dd23ae4c6183e2ea99233be70", size = 14661625, upload-time = "2025-12-20T17:11:04.528Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4d/a3cc1e96f080e253dad2251bfae7587cf2b7912bcd76fd43fd366ff35a87/scikit_image-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:abed017474593cd3056ae0fe948d07d0747b27a085e92df5474f4955dd65aec0", size = 11911059, upload-time = "2025-12-20T17:11:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/d1b8055f584acc937478abf4550d122936f420352422a1a625eef2c605d8/scikit_image-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:4d57e39ef67a95d26860c8caf9b14b8fb130f83b34c6656a77f191fa6d1d04d8", size = 11348740, upload-time = "2025-12-20T17:11:09.118Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/48/02357ffb2cca35640f33f2cfe054a4d6d5d7a229b88880a64f1e45c11f4e/scikit_image-0.26.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a2e852eccf41d2d322b8e60144e124802873a92b8d43a6f96331aa42888491c7", size = 12346329, upload-time = "2025-12-20T17:11:11.599Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b9/b792c577cea2c1e94cda83b135a656924fc57c428e8a6d302cd69aac1b60/scikit_image-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:98329aab3bc87db352b9887f64ce8cdb8e75f7c2daa19927f2e121b797b678d5", size = 12031726, upload-time = "2025-12-20T17:11:13.871Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/9564250dfd65cb20404a611016db52afc6268b2b371cd19c7538ea47580f/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:915bb3ba66455cf8adac00dc8fdf18a4cd29656aec7ddd38cb4dda90289a6f21", size = 13094910, upload-time = "2025-12-20T17:11:16.2Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/b8/0d8eeb5a9fd7d34ba84f8a55753a0a3e2b5b51b2a5a0ade648a8db4a62f7/scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b36ab5e778bf50af5ff386c3ac508027dc3aaeccf2161bdf96bde6848f44d21b", size = 13660939, upload-time = "2025-12-20T17:11:18.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d6/91d8973584d4793d4c1a847d388e34ef1218d835eeddecfc9108d735b467/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:09bad6a5d5949c7896c8347424c4cca899f1d11668030e5548813ab9c2865dcb", size = 14138938, upload-time = "2025-12-20T17:11:20.919Z" },
+    { url = "https://files.pythonhosted.org/packages/39/9a/7e15d8dc10d6bbf212195fb39bdeb7f226c46dd53f9c63c312e111e2e175/scikit_image-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:aeb14db1ed09ad4bee4ceb9e635547a8d5f3549be67fc6c768c7f923e027e6cd", size = 14752243, upload-time = "2025-12-20T17:11:23.347Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/58/2b11b933097bc427e42b4a8b15f7de8f24f2bac1fd2779d2aea1431b2c31/scikit_image-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac529eb9dbd5954f9aaa2e3fe9a3fd9661bfe24e134c688587d811a0233127f1", size = 11906770, upload-time = "2025-12-20T17:11:25.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ec/96941474a18a04b69b6f6562a5bd79bd68049fa3728d3b350976eccb8b93/scikit_image-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:a2d211bc355f59725efdcae699b93b30348a19416cc9e017f7b2fb599faf7219", size = 11342506, upload-time = "2025-12-20T17:11:27.399Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e5/c1a9962b0cf1952f42d32b4a2e48eed520320dbc4d2ff0b981c6fa508b6b/scikit_image-0.26.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:9eefb4adad066da408a7601c4c24b07af3b472d90e08c3e7483d4e9e829d8c49", size = 12663278, upload-time = "2025-12-20T17:11:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/97/c1a276a59ce8e4e24482d65c1a3940d69c6b3873279193b7ebd04e5ee56b/scikit_image-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6caec76e16c970c528d15d1c757363334d5cb3069f9cea93d2bead31820511f3", size = 12405142, upload-time = "2025-12-20T17:11:31.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4a/f1cbd1357caef6c7993f7efd514d6e53d8fd6f7fe01c4714d51614c53289/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a07200fe09b9d99fcdab959859fe0f7db8df6333d6204344425d476850ce3604", size = 12942086, upload-time = "2025-12-20T17:11:33.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/74d9fb87c5655bd64cf00b0c44dc3d6206d9002e5f6ba1c9aeb13236f6bf/scikit_image-0.26.0-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:92242351bccf391fc5df2d1529d15470019496d2498d615beb68da85fe7fdf37", size = 13265667, upload-time = "2025-12-20T17:11:36.11Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/73/faddc2413ae98d863f6fa2e3e14da4467dd38e788e1c23346cf1a2b06b97/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:52c496f75a7e45844d951557f13c08c81487c6a1da2e3c9c8a39fcde958e02cc", size = 14001966, upload-time = "2025-12-20T17:11:38.55Z" },
+    { url = "https://files.pythonhosted.org/packages/02/94/9f46966fa042b5d57c8cd641045372b4e0df0047dd400e77ea9952674110/scikit_image-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:20ef4a155e2e78b8ab973998e04d8a361d49d719e65412405f4dadd9155a61d9", size = 14359526, upload-time = "2025-12-20T17:11:41.087Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b4/2840fe38f10057f40b1c9f8fb98a187a370936bf144a4ac23452c5ef1baf/scikit_image-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c9087cf7d0e7f33ab5c46d2068d86d785e70b05400a891f73a13400f1e1faf6a", size = 12287629, upload-time = "2025-12-20T17:11:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ba/73b6ca70796e71f83ab222690e35a79612f0117e5aaf167151b7d46f5f2c/scikit_image-0.26.0-cp313-cp313t-win_arm64.whl", hash = "sha256:27d58bc8b2acd351f972c6508c1b557cfed80299826080a4d803dd29c51b707e", size = 11647755, upload-time = "2025-12-20T17:11:45.279Z" },
+    { url = "https://files.pythonhosted.org/packages/51/44/6b744f92b37ae2833fd423cce8f806d2368859ec325a699dc30389e090b9/scikit_image-0.26.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:63af3d3a26125f796f01052052f86806da5b5e54c6abef152edb752683075a9c", size = 12365810, upload-time = "2025-12-20T17:11:47.357Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f5/83590d9355191f86ac663420fec741b82cc547a4afe7c4c1d986bf46e4db/scikit_image-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ce00600cd70d4562ed59f80523e18cdcc1fae0e10676498a01f73c255774aefd", size = 12075717, upload-time = "2025-12-20T17:11:49.483Z" },
+    { url = "https://files.pythonhosted.org/packages/72/48/253e7cf5aee6190459fe136c614e2cbccc562deceb4af96e0863f1b8ee29/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6381edf972b32e4f54085449afde64365a57316637496c1325a736987083e2ab", size = 13161520, upload-time = "2025-12-20T17:11:51.58Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c3/cec6a3cbaadfdcc02bd6ff02f3abfe09eaa7f4d4e0a525a1e3a3f4bce49c/scikit_image-0.26.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6624a76c6085218248154cc7e1500e6b488edcd9499004dd0d35040607d7505", size = 13684340, upload-time = "2025-12-20T17:11:53.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0d/39a776f675d24164b3a267aa0db9f677a4cb20127660d8bf4fd7fef66817/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f775f0e420faac9c2aa6757135f4eb468fb7b70e0b67fa77a5e79be3c30ee331", size = 14203839, upload-time = "2025-12-20T17:11:55.89Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/25/2514df226bbcedfe9b2caafa1ba7bc87231a0c339066981b182b08340e06/scikit_image-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede4d6d255cc5da9faeb2f9ba7fedbc990abbc652db429f40a16b22e770bb578", size = 14770021, upload-time = "2025-12-20T17:11:58.014Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5b/0671dc91c0c79340c3fe202f0549c7d3681eb7640fe34ab68a5f090a7c7f/scikit_image-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:0660b83968c15293fd9135e8d860053ee19500d52bf55ca4fb09de595a1af650", size = 12023490, upload-time = "2025-12-20T17:12:00.013Z" },
+    { url = "https://files.pythonhosted.org/packages/65/08/7c4cb59f91721f3de07719085212a0b3962e3e3f2d1818cbac4eeb1ea53e/scikit_image-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:b8d14d3181c21c11170477a42542c1addc7072a90b986675a71266ad17abc37f", size = 11473782, upload-time = "2025-12-20T17:12:01.983Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/65c4258137acef3d73cb561ac55512eacd7b30bb4f4a11474cad526bc5db/scikit_image-0.26.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:cde0bbd57e6795eba83cb10f71a677f7239271121dc950bc060482834a668ad1", size = 12686060, upload-time = "2025-12-20T17:12:03.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/32/76971f8727b87f1420a962406388a50e26667c31756126444baf6668f559/scikit_image-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:163e9afb5b879562b9aeda0dd45208a35316f26cc7a3aed54fd601604e5cf46f", size = 12422628, upload-time = "2025-12-20T17:12:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/37/0d/996febd39f757c40ee7b01cdb861867327e5c8e5f595a634e8201462d958/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724f79fd9b6cb6f4a37864fe09f81f9f5d5b9646b6868109e1b100d1a7019e59", size = 12962369, upload-time = "2025-12-20T17:12:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b4/612d354f946c9600e7dea012723c11d47e8d455384e530f6daaaeb9bf62c/scikit_image-0.26.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3268f13310e6857508bd87202620df996199a016a1d281b309441d227c822394", size = 13272431, upload-time = "2025-12-20T17:12:10.255Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6e/26c00b466e06055a086de2c6e2145fe189ccdc9a1d11ccc7de020f2591ad/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fac96a1f9b06cd771cbbb3cd96c5332f36d4efd839b1d8b053f79e5887acde62", size = 14016362, upload-time = "2025-12-20T17:12:12.793Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/00a90402e1775634043c2a0af8a3c76ad450866d9fa444efcc43b553ba2d/scikit_image-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c1e7bd342f43e7a97e571b3f03ba4c1293ea1a35c3f13f41efdc8a81c1dc8f2", size = 14364151, upload-time = "2025-12-20T17:12:14.909Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ca/918d8d306bd43beacff3b835c6d96fac0ae64c0857092f068b88db531a7c/scikit_image-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b702c3bb115e1dcf4abf5297429b5c90f2189655888cbed14921f3d26f81d3a4", size = 12413484, upload-time = "2025-12-20T17:12:17.046Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cd/4da01329b5a8d47ff7ec3c99a2b02465a8017b186027590dc7425cee0b56/scikit_image-0.26.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0608aa4a9ec39e0843de10d60edb2785a30c1c47819b67866dd223ebd149acaf", size = 11769501, upload-time = "2025-12-20T17:12:19.339Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1059,6 +1144,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tifffile"
+version = "2026.7.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/2f/e5fe51c8f782241d86fdf7251594b195f0d6c2fcf9d389079de212599246/tifffile-2026.7.14.tar.gz", hash = "sha256:ce2703e5ef22c868f1528d5f5b4ef75eefb019cf628a1c9ec0d17e0afeca8ef5", size = 437660, upload-time = "2026-07-14T23:41:31.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/e8/d381de4a3cc4e3682cba0338f43250893508aad0b310af1d0635f7b04413/tifffile-2026.7.14-py3-none-any.whl", hash = "sha256:4eb20372e76edf2c9fed922b1e3a0a0567be3560bd2008336115763bb1f3c034", size = 270614, upload-time = "2026-07-14T23:41:30.078Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Prototype of the **footprint / free-space supervision generator** — training targets for a
Niantic-style ground/footprint head on the frozen LingBot backbone, with **no manual labels**.

## What it does
Renders the gravity-aligned global ground DEM (`semantic_bev/geometry.from_reconstruction`)
into each posed camera (z-buffered triangle mesh) to emit, per frame:
- `<stem>.png` — class map: non-ground / visible-ground / hidden-ground / footprint / object
- `<stem>_depth.npy` — metric depth to the DEM ground (incl. behind objects) — the regression target
- `<stem>_cover.npy` — DEM-observed vs extrapolated → per-pixel loss weight
- `<stem>_preview.png` + `meta.json`

The global DEM replaces Niantic's neighbour-frame reprojection trick (we already aggregate
every frame's ground). **Footprint reuses the validated solid-to-ground occupancy rule** from
`ground_model.build_level` (≥`min_count` obstacle points with low HAG-quantile ≤ `solid_gap`),
so canopy overhanging a path stays walkable ground instead of blocking it.

## Validation (`maguro-park-after-itchy`, 970 imgs / 429k pts)
Sampled across the capture: open leaf-litter → visible-ground, trunks/walls/planters →
footprint, distant ground behind the tree line → hidden-ground, canopy-over-sky → object;
ground depth sane (2–30 m). DEM build + render ≈ 15 s for the model + a handful of frames.

Known limitation: sparse COLMAP gives a speckly forest-floor footprint at 0.5 m cells. Next
steps in `script/backbone/README.md` — semantic class per footprint cell (Mask2Former votes),
and denser occluders for a stronger hidden-ground signal.

## Notes
- New files only: `script/backbone/footprint_labels.py`, `script/backbone/README.md`.
- Based on `arkit-covisibility-matching` (needs `geometry.py` / `lar_session.py` from it). The
  extra commits in this diff are that branch's unpushed local history; they drop out once it's pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)