### PR TITLE
semantic_bev: true-colour BEV orthophoto (--rgb-ortho)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,5 @@ gsplat = [
 # IMDF GeoJSON. shapely for robust polygonisation (validity, holes, winding, simplify).
 imdf = [
     "shapely>=2.0.0",
+    "scikit-image>=0.22.0",
 ]

--- a/script/colmap/export_mvs_depth.py
+++ b/script/colmap/export_mvs_depth.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""COLMAP dense MVS -> per-view metric depth for the semantic-BEV depth bake-off.
+
+Runs the standard COLMAP dense pipeline on a (refined) sparse model —
+``image_undistorter`` -> ``patch_match_stereo`` (geometric consistency) — and converts the
+resulting geometric depth maps into the bake-off contract: ``<out>/<image_stem>.npy``
+(float32 metric z-depth, 0 = invalid). Also writes the undistorted model as text to
+``<out>/model/`` so the back-projection harness uses matching intrinsics/poses.
+
+Launch inside the COLMAP env so both `colmap` and `uv` resolve, e.g.:
+  ~/bin/micromamba run -n colmap uv run python script/colmap/export_mvs_depth.py \
+      --session maguro-park-after-itchy --data-factor 2
+
+Notes: MVS is globally-consistent metric geometry, strong on textured/solid surfaces
+(vending machines, tables, plazas), weak on thin structures (poles, chair legs) and
+low-texture grass. On 8 GB keep --max-image-size modest and cache_size small.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def read_colmap_array(path: Path) -> np.ndarray:
+    """Read a COLMAP dense depth/normal map (.bin): '<W>&<H>&<C>&' header then float32."""
+    with open(path, "rb") as f:
+        w, h, c = np.genfromtxt(f, delimiter="&", max_rows=1, usecols=(0, 1, 2), dtype=int)
+        f.seek(0)
+        n = 0
+        while n < 3:
+            if f.read(1) == b"&":
+                n += 1
+        arr = np.fromfile(f, np.float32)
+    arr = arr.reshape((int(w), int(h), int(c)), order="F")
+    return np.transpose(arr, (1, 0, 2)).squeeze()
+
+
+def run(cmd, log):
+    log("$ " + " ".join(str(c) for c in cmd))
+    subprocess.run([str(c) for c in cmd], check=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None, help="fills --model/--images/--out from the layout")
+    ap.add_argument("--model", default=None, help="COLMAP sparse model dir (text or bin)")
+    ap.add_argument("--images", default=None, help="source images dir")
+    ap.add_argument("--out", default=None, help="depth output dir")
+    ap.add_argument("--data-factor", type=int, default=2, help="max_image_size = 1920 // this")
+    ap.add_argument("--max-image-size", type=int, default=None, help="override MVS image size")
+    ap.add_argument("--cache-size", type=int, default=8, help="patch-match GB cache (8 GB card)")
+    ap.add_argument("--colmap", default="colmap", help="colmap binary (on PATH inside the env)")
+    args = ap.parse_args()
+
+    if args.session:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.depth_dir("mvs"))
+    if not (args.model and args.images and args.out):
+        ap.error("need --session or explicit --model/--images/--out")
+
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    ws = out / "_mvs_workspace"
+    ws.mkdir(parents=True, exist_ok=True)
+    max_size = args.max_image_size or (1920 // args.data_factor)
+
+    run([args.colmap, "image_undistorter", "--image_path", args.images,
+         "--input_path", args.model, "--output_path", ws,
+         "--output_type", "COLMAP", "--max_image_size", max_size], print)
+    run([args.colmap, "patch_match_stereo", "--workspace_path", ws,
+         "--workspace_format", "COLMAP",
+         "--PatchMatchStereo.geom_consistency", "true",
+         "--PatchMatchStereo.cache_size", args.cache_size,
+         "--PatchMatchStereo.max_image_size", max_size], print)
+    # Undistorted model as text so the harness reads matching intrinsics/poses.
+    (out / "model").mkdir(exist_ok=True)
+    run([args.colmap, "model_converter", "--input_path", ws / "sparse",
+         "--output_path", out / "model", "--output_type", "TXT"], print)
+
+    depth_maps = sorted((ws / "stereo" / "depth_maps").glob("*.geometric.bin"))
+    if not depth_maps:
+        raise SystemExit("no geometric depth maps produced (patch_match_stereo failed?)")
+    print(f"converting {len(depth_maps)} depth maps -> {out}")
+    for i, dm in enumerate(depth_maps):
+        stem = dm.name[:-len("_image.jpeg.geometric.bin")] + "_image" \
+            if dm.name.endswith("_image.jpeg.geometric.bin") else dm.name.split(".")[0]
+        depth = read_colmap_array(dm).astype(np.float32)
+        depth[~np.isfinite(depth)] = 0.0
+        np.save(out / f"{stem}.npy", depth)
+        if (i + 1) % 100 == 0 or i + 1 == len(depth_maps):
+            print(f"  {i + 1}/{len(depth_maps)}")
+    print(f"done -> {out}   (pass --model {out}/model to the BEV harness, or --session handles it)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/depth/mono_depth.py
+++ b/script/depth/mono_depth.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Monocular metric depth (Depth Anything V2), scale-aligned to SfM -> bake-off contract.
+
+Per frame: run Depth Anything V2 (affine-invariant *disparity*), then fit it to the frame's
+sparse SfM depth so the result is **metric**. The fit is the standard MiDaS-style
+scale+shift in disparity space: for the SfM points observed in the frame we have metric
+depth ``z``; we solve ``1/z ≈ a·disp + b`` by least squares, then output
+``depth = 1/(a·disp + b)``. This gives dense depth — including thin structures (poles,
+chair legs) and low-texture regions MVS/GS miss — anchored to the SfM metric scale.
+
+  uv run --extra segmentation python script/depth/mono_depth.py \
+      --session maguro-park-after-itchy --data-factor 2
+
+Per-frame alignment means residual scale error between frames; the back-projection harness
+fuses many frames per voxel, which averages it down. Writes <out>/<stem>.npy (+ .conf.npy).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# SfM tracks (keypoint -> 3D point) come from the semantic_bev COLMAP reader.
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "semantic_bev"))
+from colmap_io import read_model  # noqa: E402
+
+
+def _qvec2rotmat(q):
+    w, x, y, z = q
+    return np.array([[1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                     [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                     [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)]])
+
+
+def sparse_samples(recon, img, scale):
+    """Observed SfM points -> (pixel_x, pixel_y at depth-res, metric z-depth)."""
+    R, t = _qvec2rotmat(img.qvec), img.tvec
+    pids, xys = img.point3d_ids, img.xys
+    keep = pids >= 0
+    if not keep.any():
+        return np.empty(0), np.empty(0), np.empty(0)
+    px, py, z = [], [], []
+    for pid, (u, v) in zip(pids[keep], xys[keep]):
+        p = recon.points3d.get(int(pid))
+        if p is None:
+            continue
+        zc = (R @ p.xyz + t)[2]
+        if zc > 0:
+            px.append(u * scale); py.append(v * scale); z.append(zc)
+    return np.array(px), np.array(py), np.array(z)
+
+
+def fit_metric(disp_at_pts, z, trim=0.1):
+    """Solve 1/z ≈ a·disp + b (least squares, one robust trim). Returns (a, b) or None."""
+    if len(z) < 20:
+        return None
+    inv = 1.0 / z
+    A = np.stack([disp_at_pts, np.ones_like(disp_at_pts)], axis=1)
+    ab, *_ = np.linalg.lstsq(A, inv, rcond=None)
+    resid = np.abs(A @ ab - inv)
+    keep = resid <= np.quantile(resid, 1 - trim)
+    ab, *_ = np.linalg.lstsq(A[keep], inv[keep], rcond=None)
+    return float(ab[0]), float(ab[1])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None)
+    ap.add_argument("--model", default=None, help="COLMAP text model (poses + tracks)")
+    ap.add_argument("--images", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--data-factor", type=int, default=2)
+    ap.add_argument("--model-name", default="depth-anything/Depth-Anything-V2-Large-hf")
+    args = ap.parse_args()
+
+    if args.session:
+        from lar_session import Session  # _ROOT (script/) already on path
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.depth_dir("mono"))
+    if not (args.model and args.images and args.out):
+        ap.error("need --session or explicit --model/--images/--out")
+
+    import torch
+    from transformers import pipeline
+    device = 0 if torch.cuda.is_available() else -1
+    pipe = pipeline("depth-estimation", model=args.model_name, device=device)
+
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    recon = read_model(args.model)
+    images_dir = Path(args.images)
+    f = args.data_factor
+    n_ok = n_skip = 0
+
+    for i, img in enumerate(sorted(recon.images.values(), key=lambda im: im.name)):
+        bgr = cv2.imread(str(images_dir / img.name), cv2.IMREAD_COLOR)
+        if bgr is None:
+            continue
+        H, W = bgr.shape[0] // f, bgr.shape[1] // f
+        rgb = cv2.cvtColor(cv2.resize(bgr, (W, H)), cv2.COLOR_BGR2RGB)
+        from PIL import Image as PILImage
+        pred = pipe(PILImage.fromarray(rgb))["predicted_depth"]  # disparity-like, higher=closer
+        disp = pred.squeeze().float().cpu().numpy()
+        if disp.shape != (H, W):
+            disp = cv2.resize(disp, (W, H), interpolation=cv2.INTER_LINEAR)
+
+        scale = W / recon.cameras[img.camera_id].width  # full-res keypoints -> depth res
+        px, py, z = sparse_samples(recon, img, scale)
+        ab = None
+        if len(z):
+            ix = np.clip(np.round(px).astype(int), 0, W - 1)
+            iy = np.clip(np.round(py).astype(int), 0, H - 1)
+            ab = fit_metric(disp[iy, ix], z)
+        if ab is None:
+            n_skip += 1
+            continue
+        a, b = ab
+        denom = a * disp + b
+        depth = np.where(denom > 1e-6, 1.0 / denom, 0.0).astype(np.float32)
+        depth[(depth <= 0) | ~np.isfinite(depth)] = 0.0
+        np.save(out / f"{Path(img.name).stem}.npy", depth)
+        n_ok += 1
+        if (i + 1) % 100 == 0 or i + 1 == len(recon.images):
+            print(f"  {i + 1}/{len(recon.images)} (aligned {n_ok}, skipped {n_skip})")
+    print(f"done -> {out}  (aligned {n_ok}, skipped {n_skip} frames with too few SfM points)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -27,6 +27,20 @@ pipelines. Output per Gaussian: an argmax class id (`_labels.npy`) + a taxonomy-
 `.ply`. That labelled point set is exactly the `(positions, labels, confidence)` geometry
 source `semantic_bev` is designed to consume, and a route into LAR localization.
 
+**Two-phase training (the reliable, canonical recipe).** Semantics is *not* trained jointly
+with geometry. Following LangSplat / Feature-3DGS / Gaussian Grouping:
+
+1. **Phase 1 (`--max-steps`)** — train RGB + geometry with MCMC densification. This is
+   identical to a plain RGB run; no semantic field exists yet.
+2. **Phase 2 (`--sem-steps`)** — attach a fresh semantic field to the *converged*
+   Gaussians and train only it, with the geometry **detached/frozen** (MCMC off). The 2D
+   masks are distilled onto fixed supports.
+
+Why: geometry from the dense photometric loss is far more reliable than the semantic CE,
+and freezing it means labelling becomes a clean multi-view fusion problem that **cannot
+move or degrade the reconstruction**. Phase 2 is cheap (a few thousand steps — no SSIM,
+no SH, no densification).
+
 ## Modules
 
 | file | role |

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -94,33 +94,30 @@ export TORCH_CUDA_ARCH_LIST=12.0     # Blackwell sm_120
 
 ## Run
 
-Smoke test (subset, few steps — proves the chain end to end):
+**Just pass `--session <name>`** and paths are filled from the canonical layout
+([`../lar_session.py`](../lar_session.py)): `--model` = the refined COLMAP model if it
+exists else the raw one, `--images` = `input/<name>`, `--out` = `output/<name>-gsplat[-sem]`.
+Any explicit flag overrides.
+
+Semantic park model (the usual command):
 
 ```sh
 cd script/gsplat
-uv run --extra gsplat python train.py \
-  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
-  --out   ../../output/maguro-gsplat-smoke \
-  --limit 40 --data-factor 4 --cap-max 80000 --max-steps 500 --preview-every 100
-```
-
-Coarse park model (RGB):
-
-```sh
-uv run --extra gsplat python train.py \
-  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
-  --out   ../../output/maguro-gsplat \
-  --data-factor 2 --cap-max 300000 --max-steps 30000
-```
-
-Semantic 3DGS (adds the distilled class head):
-
-```sh
 uv run --extra gsplat --extra segmentation python train.py \
-  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
-  --out   ../../output/maguro-gsplat-sem \
+  --session maguro-park-after-itchy \
   --data-factor 2 --cap-max 300000 --max-steps 30000 \
   --semantic --segmenter mask2former-large
+```
+
+RGB only — drop `--semantic` (writes to `output/<name>-gsplat`). Smoke test — add
+`--limit 40 --max-steps 500` (and `--out` if you don't want to overwrite the real run).
+
+Explicit paths still work instead of `--session`:
+
+```sh
+uv run --extra gsplat python train.py \
+  --model ../../input/maguro-park-after-itchy/colmap/poses_txt \
+  --out   ../../output/maguro-gsplat --data-factor 2 --cap-max 300000 --max-steps 30000
 ```
 
 `--segmenter` accepts any `semantic_bev` backend: `oneformer` / `oneformer-large` /

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -48,7 +48,43 @@ no SH, no densification).
 | `colmap_dataset.py` | read COLMAP **text** model (`poses_txt/`) → posed cameras + init points, RAM-cached at training resolution |
 | `model.py`          | Gaussian init from sparse points (k-NN scale seed); PLY + semantic-label export |
 | `semantic.py`       | cache per-image class masks via `semantic_bev` segmenters (shared taxonomy) |
-| `train.py`          | MCMC trainer (L1+SSIM RGB, optional semantic CE), CLI, exports |
+| `train.py`          | MCMC trainer (L1+SSIM RGB, optional semantic CE), 3DGS/2DGS modes, CLI, exports |
+| `export_depth.py`   | render per-view metric depth from a trained model (3DGS expected-depth / 2DGS median-depth) → depth bake-off contract |
+
+## 2DGS (surfel) mode — cleaner depth for the BEV
+
+`--mode 2dgs` swaps the volumetric 3D Gaussians for **2D Gaussian surfels** (flat disks
+that lie *on* surfaces) plus the 2DGS surface regularizers. The point is **geometry, not
+looks**: surfels give sharp, surface-aligned depth, which is what the `semantic_bev`
+depth back-projection needs for accurate ground height + object footprints. It keeps the
+exact same MCMC `--cap-max` VRAM budget and two-phase semantic recipe, and writes to a
+separate `output/<name>-gsplat2d[-sem]/` dir so it never clobbers a 3DGS model.
+
+```sh
+uv run --extra gsplat python train.py --session <name> --mode 2dgs          # RGB geometry
+uv run --extra gsplat --extra segmentation python train.py --session <name> --mode 2dgs --semantic
+```
+
+- `--normal-reg` (default **0.05**, the 2DGS paper value) — normal-consistency; this is
+  what flattens the surfels onto the surface. The safe, standard regularizer.
+- `--dist-reg` (default **0**) — distortion; sharpens depth further but, like the MCMC
+  regularizers, can misbehave on our un-normalized metric coordinates. Off by default;
+  turn up slowly and watch the depth previews.
+- `--reg-start` (default **500**) — delays both regularizers until the geometry has
+  roughly settled (fighting them too early stalls convergence).
+
+> **Implementation note.** gsplat 1.5.3's `rasterization_2dgs` has three sharp edges we
+> route around in `train.rasterize` (all verified on this build): its **packed** path
+> mis-gathers colours (`colors.shape[0] == nnz`), it only produces `surf_normals` under a
+> **depth render mode**, and with `sh_degree=None` it **omits the camera axis** on colours.
+> So 2DGS always renders unpacked, in `RGB+ED`, with non-SH colours shaped `(1, N, D)`.
+
+Render depth from any trained model for the bake-off:
+
+```sh
+uv run --extra gsplat python export_depth.py --session <name> --backend 2dgs   # 2dgs median depth
+uv run --extra gsplat python export_depth.py --session <name> --backend 3dgs   # 3dgs expected depth
+```
 
 ## Install
 

--- a/script/gsplat/README.md
+++ b/script/gsplat/README.md
@@ -86,6 +86,36 @@ uv run --extra gsplat python export_depth.py --session <name> --backend 2dgs   #
 uv run --extra gsplat python export_depth.py --session <name> --backend 3dgs   # 3dgs expected depth
 ```
 
+## Top-down BEV render (`render_bev.py`)
+
+Rasterise a trained model from a **virtual orthographic top-down camera** — a true
+photographic BEV where occlusion and above-ground structure are handled by the render
+itself, unlike the `semantic_bev` `--rgb-ortho` ground-drape (which smears anything off the
+ground plane). Uses gsplat's `rasterization(camera_model="ortho")` — real orthographic
+projection (`px = fx·Xc + cx`, no Z-divide), so `fx = fy = 1/cell_size` px-per-metre.
+
+```sh
+uv run --extra gsplat python render_bev.py \
+    --ply  ../../output/<run>/point_cloud.ply \
+    --meta ../../output/<run>-sbev/level0.meta.json \   # align to the DEM/semantic grid
+    --out  ../../output/<run>-sbev --cell-size 0.05
+```
+
+- `--meta level0.meta.json` lands the BEV on the **same grid** as the semantic/height/
+  occupancy rasters (same origin, gravity-canonical row axis) so all layers overlay
+  pixel-for-pixel. Without it, footprint + gravity come from `--model` (COLMAP cameras) and
+  the Gaussian extent.
+- `--cell-size` metres per output pixel (0.05 → high-res); `--min-opacity` (default 0.15)
+  culls floaters. Writes `level0_rgb_bev.png` + `_rgb_bev_masked.png` (alpha = coverage).
+
+> **OOD caveat.** The capture is all grazing ground-level views, so a top-down ortho is a
+> viewpoint with **no training supervision**. Under-trained or unregularised models show
+> needle artifacts (high-opacity Gaussians seen edge-on) and floaters from above. Mitigate
+> with a fully-trained model, `--opacity-reg`/`--scale-reg` during training, and
+> `--min-opacity` at render. 2DGS surfels would be cleaner top-down (flat disks on
+> surfaces), but gsplat 1.5.3's `rasterization_2dgs` has **no ortho** support — a
+> high-focal pinhole placed far above approximates it (follow-up).
+
 ## Install
 
 gsplat compiles CUDA kernels on **first import** (JIT via torch's `cpp_extension`, ~60 s,

--- a/script/gsplat/colmap_dataset.py
+++ b/script/gsplat/colmap_dataset.py
@@ -101,11 +101,25 @@ class CameraView:
 
 
 def read_images(path: Path, cameras: dict[int, CameraModel]) -> list[CameraView]:
-    """Header line carries the pose; the following keypoint line is skipped."""
+    """Two *physical* lines per image: a pose header, then a POINTS2D line.
+
+    The POINTS2D line can be **empty** (a refined image that kept its pose but has no
+    surviving 2D points — valid COLMAP). So we pair by physical line position rather than
+    filtering blanks first: a blank-skipping pass would drop those empty lines and desync
+    every subsequent pose. Comments only appear in the header block, never mid-record.
+    """
     views: list[CameraView] = []
-    it = _iter_data_lines(path)
-    for header in it:
-        next(it)  # discard the POINTS2D line -- unused for 3DGS
+    with open(path) as f:
+        lines = f.read().split("\n")
+
+    i, n = 0, len(lines)
+    while i < n:
+        header = lines[i].strip()
+        if not header or header.startswith("#"):
+            i += 1
+            continue
+        i += 2  # consume the header AND its POINTS2D line (which may be empty)
+
         h = header.split()
         image_id = int(h[0])
         qw, qx, qy, qz = (float(x) for x in h[1:5])

--- a/script/gsplat/export_depth.py
+++ b/script/gsplat/export_depth.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import numpy as np
 import torch
 
-from gsplat import rasterization
+from gsplat import rasterization, rasterization_2dgs
 from colmap_dataset import read_cameras, read_images
 
 
@@ -72,8 +72,10 @@ def main():
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
         from lar_session import Session
         s = Session(args.session)
+        # 2dgs backend reads the surfel model dir; 3dgs (or anything else) the volumetric one.
+        gs_mode = "2dgs" if args.backend == "2dgs" else "3dgs"
         args.model = args.model or str(s.best_model())
-        args.gs_dir = args.gs_dir or str(s.gsplat_out(semantic=True))
+        args.gs_dir = args.gs_dir or str(s.gsplat_out(semantic=True, mode=gs_mode))
         args.out = args.out or str(s.depth_dir(args.backend))
     if not (args.gs_dir and args.model and args.out):
         ap.error("need --session or explicit --gs-dir/--model/--out")
@@ -96,9 +98,18 @@ def main():
         K[1, :] *= H / v.height
         vm = torch.from_numpy(v.viewmat).float().to(device)[None]
         Kt = torch.from_numpy(K).float().to(device)[None]
-        render, _, _ = rasterization(means, quats, scales, opac, colors, vm, Kt, W, H,
-                                     sh_degree=None, packed=True, render_mode="RGB+ED")
-        depth = render[0, ..., 3].cpu().numpy().astype(np.float32)  # expected metric z-depth
+        if args.backend == "2dgs":
+            # Surfel rasterizer: median depth is the ray/surface intersection -- the
+            # sharpest, most surface-accurate depth a 2DGS model produces. gsplat 1.5.3's
+            # 2dgs path needs unpacked + a camera dim on non-SH colors (see train.rasterize).
+            _, _, _, _, _, median, _ = rasterization_2dgs(
+                means, quats, scales, opac, colors[None], vm, Kt, W, H,
+                sh_degree=None, packed=False, render_mode="RGB+ED")
+            depth = median[0, ..., 0].cpu().numpy().astype(np.float32)
+        else:
+            render, _, _ = rasterization(means, quats, scales, opac, colors, vm, Kt, W, H,
+                                         sh_degree=None, packed=True, render_mode="RGB+ED")
+            depth = render[0, ..., 3].cpu().numpy().astype(np.float32)  # expected metric z-depth
         np.save(out / f"{Path(v.name).stem}.npy", depth)
         if (i + 1) % 100 == 0 or i + 1 == len(views):
             print(f"  rendered depth {i + 1}/{len(views)}")

--- a/script/gsplat/export_depth.py
+++ b/script/gsplat/export_depth.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Render per-view metric depth from a trained 3DGS/2DGS model -> depth bake-off contract.
+
+Loads a trained ``point_cloud.ply`` (the geometry only — colors are irrelevant for depth)
+and renders each training view's **expected depth** (gsplat ``render_mode="RGB+ED"``, i.e.
+alpha-normalised metric z-depth). Writes ``<out>/<image_stem>.npy`` for the
+``semantic_bev`` depth back-projection harness. Serves the **3DGS** backend directly and
+the **2DGS** backend once a 2DGS model is trained (same .ply layout, surface-accurate depth).
+
+  uv run --extra gsplat python export_depth.py \
+      --session maguro-park-after-itchy --gs-dir ../../output/<name>-gsplat-sem \
+      --backend 3dgs --data-factor 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from gsplat import rasterization
+from colmap_dataset import read_cameras, read_images
+
+
+def _read_float_ply(path: Path) -> dict[str, np.ndarray]:
+    """Read an all-float32 binary_little_endian PLY (our exporter's format)."""
+    with open(path, "rb") as f:
+        if f.readline().strip() != b"ply":
+            raise ValueError(f"{path} is not a PLY")
+        if b"binary_little_endian" not in f.readline():
+            raise ValueError("only binary_little_endian PLY supported")
+        count, names = None, []
+        while True:
+            line = f.readline().strip()
+            if line.startswith(b"element vertex"):
+                count = int(line.split()[-1])
+            elif line.startswith(b"property"):
+                names.append(line.split()[-1].decode())
+            elif line == b"end_header":
+                break
+        dt = np.dtype([(n, "<f4") for n in names])
+        data = np.frombuffer(f.read(count * dt.itemsize), dtype=dt, count=count)
+    return {n: np.ascontiguousarray(data[n]) for n in names}
+
+
+def load_gaussians(ply_path: Path, device: str):
+    """Load geometry (means, quats, scales, opacities) from a 3DGS/2DGS .ply."""
+    p = _read_float_ply(ply_path)
+    means = np.stack([p["x"], p["y"], p["z"]], axis=1)
+    scales = np.stack([p[f"scale_{i}"] for i in range(3)], axis=1)  # log-space
+    quats = np.stack([p[f"rot_{i}"] for i in range(4)], axis=1)
+    opac = p["opacity"]                                             # logit
+    t = lambda a: torch.from_numpy(a).float().to(device)
+    return t(means), t(quats), torch.exp(t(scales)), torch.sigmoid(t(opac))
+
+
+@torch.no_grad()
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", default=None, help="fills --model/--gs-dir/--out from the layout")
+    ap.add_argument("--backend", default="3dgs", help="tag for the output dir (3dgs/2dgs)")
+    ap.add_argument("--gs-dir", default=None, help="trained gsplat run dir (has point_cloud.ply)")
+    ap.add_argument("--model", default=None, help="COLMAP text model (cameras/poses)")
+    ap.add_argument("--out", default=None, help="depth output dir (<stem>.npy)")
+    ap.add_argument("--data-factor", type=int, default=2)
+    args = ap.parse_args()
+
+    if args.session:
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.gs_dir = args.gs_dir or str(s.gsplat_out(semantic=True))
+        args.out = args.out or str(s.depth_dir(args.backend))
+    if not (args.gs_dir and args.model and args.out):
+        ap.error("need --session or explicit --gs-dir/--model/--out")
+
+    assert torch.cuda.is_available(), "depth render needs a CUDA GPU"
+    device = "cuda"
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+
+    means, quats, scales, opac = load_gaussians(Path(args.gs_dir) / "point_cloud.ply", device)
+    print(f"loaded {means.shape[0]} Gaussians from {args.gs_dir}")
+    colors = torch.zeros(means.shape[0], 3, device=device)  # unused; depth only
+
+    cams = read_cameras(Path(args.model) / "cameras.txt")
+    views = read_images(Path(args.model) / "images.txt", cams)
+    f = args.data_factor
+    for i, v in enumerate(views):
+        W, H = v.width // f, v.height // f
+        K = v.K.copy()
+        K[0, :] *= W / v.width
+        K[1, :] *= H / v.height
+        vm = torch.from_numpy(v.viewmat).float().to(device)[None]
+        Kt = torch.from_numpy(K).float().to(device)[None]
+        render, _, _ = rasterization(means, quats, scales, opac, colors, vm, Kt, W, H,
+                                     sh_degree=None, packed=True, render_mode="RGB+ED")
+        depth = render[0, ..., 3].cpu().numpy().astype(np.float32)  # expected metric z-depth
+        np.save(out / f"{Path(v.name).stem}.npy", depth)
+        if (i + 1) % 100 == 0 or i + 1 == len(views):
+            print(f"  rendered depth {i + 1}/{len(views)}")
+    print(f"done -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gsplat/model.py
+++ b/script/gsplat/model.py
@@ -149,9 +149,14 @@ def export_semantic(params: nn.ParameterDict, path_stem: str | Path, color_lut) 
     """
     path_stem = Path(path_stem)
     means = params["means"].detach().cpu().numpy()
-    labels = params["sem"].detach().argmax(dim=1).cpu().numpy().astype(np.uint8)
+    logits = params["sem"].detach()
+    labels = logits.argmax(dim=1).cpu().numpy().astype(np.uint8)
+    # Confidence = peak softmax prob. Poorly-observed Gaussians have near-flat logits
+    # (~1/num_classes), so this down-weights them when the BEV builder votes per cell.
+    conf = torch.softmax(logits, dim=1).max(dim=1).values.cpu().numpy().astype(np.float32)
 
     np.save(path_stem.with_name(path_stem.name + "_labels.npy"), labels)
+    np.save(path_stem.with_name(path_stem.name + "_confidence.npy"), conf)
 
     lut = np.asarray(color_lut, dtype=np.float32) / 255.0
     rgb = lut[labels]

--- a/script/gsplat/render_bev.py
+++ b/script/gsplat/render_bev.py
@@ -32,8 +32,10 @@ import cv2
 import numpy as np
 import torch
 
-from gsplat import rasterization
+from gsplat import rasterization, rasterization_2dgs
 from colmap_dataset import read_cameras, read_images, camera_center
+
+_SH_C0 = 0.28209479177387814  # SH band-0 constant; DC coeff -> base RGB
 
 
 # ----- load the exported Gaussians (INRIA PLY layout) --------------------------
@@ -61,6 +63,7 @@ def load_ply(path: Path, device: str) -> dict:
     shN = f_rest.reshape(n, 3, k_minus1).transpose(0, 2, 1)
     sh = np.concatenate([f_dc[:, None, :], shN], axis=1)
     sh_degree = int(round(sh.shape[1] ** 0.5)) - 1
+    rgb_dc = np.clip(f_dc * _SH_C0 + 0.5, 0.0, 1.0)  # view-independent base colour (for 2dgs path)
 
     opacities = torch.sigmoid(torch.from_numpy(data[:, [col["opacity"]]].copy()).squeeze(-1))
     scales = torch.exp(torch.from_numpy(
@@ -69,6 +72,7 @@ def load_ply(path: Path, device: str) -> dict:
     return dict(
         means_np=means, means=torch.from_numpy(means).to(device),
         colors=torch.from_numpy(sh.copy()).to(device),
+        rgb_dc=torch.from_numpy(rgb_dc.copy()).to(device),
         opacities=opacities.to(device), scales=scales.to(device), quats=quats.to(device),
         sh_degree=sh_degree, n=n,
     )
@@ -95,6 +99,14 @@ def main() -> None:
                    help="COLMAP model dir for gravity (needed when --meta is absent)")
     p.add_argument("--out", default=None, help="output dir (default: alongside the ply)")
     p.add_argument("--prefix", default="level0")
+    p.add_argument("--mode", choices=["3dgs", "2dgs"], default="3dgs",
+                   help="3dgs: true orthographic rasterisation. 2dgs: surfels via a high-focal "
+                        "pinhole placed far above (pseudo-ortho) — gsplat's rasterization_2dgs "
+                        "has no ortho camera. Surfels lie flat on surfaces, so the ground renders "
+                        "clean from above and vertical stuff shrinks to lines (ideal for a BEV)")
+    p.add_argument("--ortho-distance", type=float, default=2000.0,
+                   help="(2dgs) virtual camera height in m; larger = closer to true ortho "
+                        "(less perspective across the footprint)")
     p.add_argument("--cell-size", type=float, default=0.05, help="metres per output pixel")
     p.add_argument("--pad", type=float, default=2.0, help="footprint padding (m) when auto (no --meta)")
     p.add_argument("--bounds-pct", type=float, default=0.01,
@@ -120,7 +132,7 @@ def main() -> None:
     if args.min_opacity > 0:
         keep = g["opacities"] >= args.min_opacity
         nk = int(keep.sum())
-        for k in ("means", "colors", "opacities", "scales", "quats"):
+        for k in ("means", "colors", "rgb_dc", "opacities", "scales", "quats"):
             g[k] = g[k][keep]
         g["means_np"] = g["means_np"][keep.cpu().numpy()]
         print(f"  kept {nk}/{g['n']} Gaussians with opacity >= {args.min_opacity}")
@@ -165,6 +177,21 @@ def main() -> None:
     if W * H > args.max_pixels:
         raise SystemExit(f"grid {W}x{H} = {W * H} px exceeds --max-pixels {args.max_pixels}; "
                          f"raise --cell-size")
+
+    # Cull Gaussians outside the footprint column (+margin). An under-trained model can have
+    # floaters millions of metres away; without this they never show in the BEV but WOULD push
+    # the virtual-camera height (below) to infinity, collapsing the whole scene to sub-pixel.
+    m = 5.0
+    uu, vv = means[:, u_axis], means[:, v_axis]
+    inside = ((uu >= u_lo - m) & (uu <= u_hi + m) &
+              (vv >= v_lo_w - m) & (vv <= v_hi_w + m))
+    if inside.sum() < g["n"]:
+        for k in ("means", "colors", "rgb_dc", "opacities", "scales", "quats"):
+            g[k] = g[k][torch.from_numpy(inside).to(g[k].device)]
+        means = means[inside]
+        print(f"  culled {g['n'] - int(inside.sum())} out-of-footprint floaters -> "
+              f"{int(inside.sum())} Gaussians")
+        g["n"] = int(inside.sum())
     print(f"BEV grid {W}x{H} @ {cs} m  (footprint {u_hi - u_lo:.1f} x {v_hi_w - v_lo_w:.1f} m, "
           f"up=axis{up_axis}{up_sign:+.0f}, v_sign={v_sign:+.0f})")
 
@@ -175,30 +202,42 @@ def main() -> None:
     down = np.cross(forward, right)            # right-handed OpenCV cam frame (X right, Y down, Z fwd)
     R_wc = np.stack([right, down, forward], axis=0)  # world->camera rotation (rows are cam axes)
 
-    # Camera centre: over the footprint centre, above the highest Gaussian.
-    up_hi = up_sign * float(means[:, up_axis].max())      # highest height in the scene
+    # Camera centre: over the footprint centre. 3dgs ortho ignores distance (no Z-divide), so
+    # sit just above the top. 2dgs pseudo-ortho needs the camera far away with a matching focal
+    # length (f = distance/cs) so perspective across the footprint is negligible.
+    up_hi = up_sign * float(np.quantile(means[:, up_axis], 0.999))  # robust top (ignore floaters)
+    dist = 5.0 if args.mode == "3dgs" else args.ortho_distance
+    focal = (1.0 / cs) if args.mode == "3dgs" else (dist / cs)
     C = np.zeros(3)
     C[u_axis] = 0.5 * (u_lo + u_hi)
     C[v_axis] = 0.5 * (v_lo_w + v_hi_w)
-    C[up_axis] = up_sign * (up_hi + 5.0)                  # 5 m above the top
+    C[up_axis] = up_sign * (up_hi + dist)
     tvec = -R_wc @ C
     viewmat = np.eye(4)
     viewmat[:3, :3] = R_wc
     viewmat[:3, 3] = tvec
-
-    # Intrinsics: 1/cs px per metre; principal point centres the footprint (camera is at centre).
-    K = np.array([[1.0 / cs, 0, W / 2.0], [0, 1.0 / cs, H / 2.0], [0, 0, 1.0]])
+    K = np.array([[focal, 0, W / 2.0], [0, focal, H / 2.0], [0, 0, 1.0]])
 
     vt = torch.from_numpy(viewmat).float().to(device)[None]
     Kt = torch.from_numpy(K).float().to(device)[None]
     with torch.no_grad():
-        renders, alphas, _ = rasterization(
-            means=g["means"], quats=g["quats"], scales=g["scales"],
-            opacities=g["opacities"], colors=g["colors"],
-            viewmats=vt, Ks=Kt, width=W, height=H,
-            sh_degree=g["sh_degree"], packed=True, render_mode="RGB",
-            camera_model="ortho",
-        )
+        if args.mode == "3dgs":
+            renders, alphas, _ = rasterization(
+                means=g["means"], quats=g["quats"], scales=g["scales"],
+                opacities=g["opacities"], colors=g["colors"],
+                viewmats=vt, Ks=Kt, width=W, height=H,
+                sh_degree=g["sh_degree"], packed=True, render_mode="RGB",
+                camera_model="ortho",
+            )
+        else:
+            # rasterization_2dgs: unpacked, RGB+ED, non-SH colours (see train.rasterize notes).
+            r2d = rasterization_2dgs(
+                means=g["means"], quats=g["quats"], scales=g["scales"],
+                opacities=g["opacities"], colors=g["rgb_dc"][None],
+                viewmats=vt, Ks=Kt, width=W, height=H,
+                sh_degree=None, packed=False, render_mode="RGB+ED",
+            )
+            renders, alphas = r2d[0][..., :3], r2d[1]
     # renders are alpha-composited over black; place them over the --bg grey via the alpha.
     rgb = renders[0].clamp(0, 1).cpu().numpy()
     alpha = alphas[0, ..., 0].cpu().numpy()

--- a/script/gsplat/render_bev.py
+++ b/script/gsplat/render_bev.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Top-down orthographic BEV render from a trained 3DGS point_cloud.ply.
+
+The `--rgb-ortho` drape in `script/semantic_bev` paints the source RGB onto a single-surface
+ground DEM. That smears anything above the ground (benches, walls, trees) and ghosts under the
+grazing capture views. Gaussian splatting sidesteps both: rasterise the trained model from a
+**virtual orthographic top-down camera** and occlusion/height fall out of the render itself —
+a true photographic BEV, not a ground drape.
+
+gsplat's `rasterization(camera_model="ortho")` gives real orthographic projection
+(`px = fx*Xc + cx`, no Z-divide), so `fx = fy = 1/cell_size` px-per-metre and the whole
+footprint maps in with the camera centred over it, looking straight down gravity.
+
+Alignment: pass `--meta <level0.meta.json>` and the BEV lands on the **same grid** as the
+semantic/height/occupancy rasters (same origin, cell size, gravity-canonical row axis), so the
+layers overlay pixel-for-pixel. Without `--meta`, the footprint + gravity are inferred from the
+COLMAP cameras (`--model`) and the Gaussian extent.
+
+  uv run --extra gsplat python render_bev.py \
+      --ply   ../../output/<run>/point_cloud.ply \
+      --meta  ../../output/<run>-sbev/level0.meta.json \
+      --out   ../../output/<run>-sbev --cell-size 0.05
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+import torch
+
+from gsplat import rasterization
+from colmap_dataset import read_cameras, read_images, camera_center
+
+
+# ----- load the exported Gaussians (INRIA PLY layout) --------------------------
+def load_ply(path: Path, device: str) -> dict:
+    with open(path, "rb") as f:
+        assert f.readline().strip() == b"ply"
+        fields, n = [], 0
+        while True:
+            line = f.readline().decode("ascii").strip()
+            if line == "end_header":
+                break
+            if line.startswith("element vertex"):
+                n = int(line.split()[-1])
+            elif line.startswith("property float"):
+                fields.append(line.split()[-1])
+        data = np.fromfile(f, dtype="<f4", count=n * len(fields)).reshape(n, len(fields))
+
+    col = {name: i for i, name in enumerate(fields)}
+    means = data[:, [col["x"], col["y"], col["z"]]].copy()
+    f_dc = data[:, [col["f_dc_0"], col["f_dc_1"], col["f_dc_2"]]]
+    rest_names = sorted((k for k in col if k.startswith("f_rest_")),
+                        key=lambda s: int(s.split("_")[-1]))
+    f_rest = data[:, [col[k] for k in rest_names]]
+    k_minus1 = f_rest.shape[1] // 3
+    shN = f_rest.reshape(n, 3, k_minus1).transpose(0, 2, 1)
+    sh = np.concatenate([f_dc[:, None, :], shN], axis=1)
+    sh_degree = int(round(sh.shape[1] ** 0.5)) - 1
+
+    opacities = torch.sigmoid(torch.from_numpy(data[:, [col["opacity"]]].copy()).squeeze(-1))
+    scales = torch.exp(torch.from_numpy(
+        data[:, [col["scale_0"], col["scale_1"], col["scale_2"]]].copy()))
+    quats = torch.from_numpy(data[:, [col["rot_0"], col["rot_1"], col["rot_2"], col["rot_3"]]].copy())
+    return dict(
+        means_np=means, means=torch.from_numpy(means).to(device),
+        colors=torch.from_numpy(sh.copy()).to(device),
+        opacities=opacities.to(device), scales=scales.to(device), quats=quats.to(device),
+        sh_degree=sh_degree, n=n,
+    )
+
+
+# ----- gravity from the COLMAP cameras (same rule as semantic_bev.pipeline) -----
+def detect_gravity(model_dir: Path) -> tuple[int, float]:
+    cams = read_cameras(model_dir / "cameras.txt")
+    views = read_images(model_dir / "images.txt", cams)
+    # image-up in world = -R[1,:] (COLMAP: +Y_cam points down); phones held upright -> true up.
+    ups = np.array([-v.viewmat[:3, :3][1, :] for v in views])
+    m = ups.mean(0)
+    m /= np.linalg.norm(m) + 1e-12
+    axis = int(np.argmax(np.abs(m)))
+    return axis, float(np.sign(m[axis]))
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Orthographic top-down BEV render of a 3DGS model")
+    p.add_argument("--ply", required=True)
+    p.add_argument("--meta", default=None,
+                   help="level0.meta.json to align the BEV to the semantic/DEM raster grid")
+    p.add_argument("--model", default=None,
+                   help="COLMAP model dir for gravity (needed when --meta is absent)")
+    p.add_argument("--out", default=None, help="output dir (default: alongside the ply)")
+    p.add_argument("--prefix", default="level0")
+    p.add_argument("--cell-size", type=float, default=0.05, help="metres per output pixel")
+    p.add_argument("--pad", type=float, default=2.0, help="footprint padding (m) when auto (no --meta)")
+    p.add_argument("--bounds-pct", type=float, default=0.01,
+                   help="robust Gaussian-extent quantile for auto footprint")
+    p.add_argument("--up-axis", type=int, default=None, choices=[0, 1, 2])
+    p.add_argument("--up-sign", type=float, default=None, choices=[1.0, -1.0])
+    p.add_argument("--bg", type=float, default=0.0, help="background grey level [0,1]")
+    p.add_argument("--min-opacity", type=float, default=0.15,
+                   help="drop Gaussians below this opacity before rendering. A top-down view is "
+                        "out-of-distribution for a ground-captured model, so low-opacity floaters "
+                        "show as needle artifacts; culling them cleans the BEV. 0 = keep all")
+    p.add_argument("--max-pixels", type=int, default=80_000_000,
+                   help="guard: refuse a grid larger than this (W*H)")
+    args = p.parse_args()
+
+    device = "cuda"
+    ply = Path(args.ply)
+    out = Path(args.out) if args.out else ply.parent
+    out.mkdir(parents=True, exist_ok=True)
+    g = load_ply(ply, device)
+    print(f"loaded {g['n']} Gaussians (sh_degree={g['sh_degree']}) from {ply}")
+
+    if args.min_opacity > 0:
+        keep = g["opacities"] >= args.min_opacity
+        nk = int(keep.sum())
+        for k in ("means", "colors", "opacities", "scales", "quats"):
+            g[k] = g[k][keep]
+        g["means_np"] = g["means_np"][keep.cpu().numpy()]
+        print(f"  kept {nk}/{g['n']} Gaussians with opacity >= {args.min_opacity}")
+        g["n"] = nk
+
+    cs = args.cell_size
+    meta = json.loads(Path(args.meta).read_text()) if args.meta else None
+
+    # --- gravity + canonical row sign ---
+    if args.up_axis is not None and args.up_sign is not None:
+        up_axis, up_sign = args.up_axis, args.up_sign
+    elif meta is not None:
+        up_axis, up_sign = int(meta["up_axis"]), float(meta["up_sign"])
+    elif args.model:
+        up_axis, up_sign = detect_gravity(Path(args.model))
+    else:
+        raise SystemExit("need --meta, --model, or explicit --up-axis/--up-sign for gravity")
+    u_axis, v_axis = (a for a in (0, 1, 2) if a != up_axis)
+    v_sign = float(meta["v_sign"]) if meta else -up_sign  # matches ground_model.build_level
+
+    means = g["means_np"]
+
+    # --- footprint (u,v world extent) + output resolution ---
+    if meta is not None:
+        cols, rows = int(meta["cols"]), int(meta["rows"])
+        origin_u, origin_v, dem_cs = meta["origin_u"], meta["origin_v"], meta["cell_size"]
+        # Align to the DEM grid exactly, but render at the finer --cell-size.
+        u_lo, u_hi = origin_u, origin_u + cols * dem_cs
+        # canonical v span -> world[v_axis] span (v = v_sign * world[v_axis]).
+        cv_lo, cv_hi = origin_v, origin_v + rows * dem_cs
+        v_lo_w, v_hi_w = sorted((cv_lo * v_sign, cv_hi * v_sign))
+    else:
+        u = means[:, u_axis]
+        w = means[:, v_axis]
+        u_lo, u_hi = np.quantile(u, [args.bounds_pct, 1 - args.bounds_pct])
+        v_lo_w, v_hi_w = np.quantile(w, [args.bounds_pct, 1 - args.bounds_pct])
+        u_lo, u_hi = u_lo - args.pad, u_hi + args.pad
+        v_lo_w, v_hi_w = v_lo_w - args.pad, v_hi_w + args.pad
+
+    W = int(np.ceil((u_hi - u_lo) / cs))
+    H = int(np.ceil((v_hi_w - v_lo_w) / cs))
+    if W * H > args.max_pixels:
+        raise SystemExit(f"grid {W}x{H} = {W * H} px exceeds --max-pixels {args.max_pixels}; "
+                         f"raise --cell-size")
+    print(f"BEV grid {W}x{H} @ {cs} m  (footprint {u_hi - u_lo:.1f} x {v_hi_w - v_lo_w:.1f} m, "
+          f"up=axis{up_axis}{up_sign:+.0f}, v_sign={v_sign:+.0f})")
+
+    # --- virtual ortho camera: right=+u_axis, look straight down gravity ---
+    e = np.eye(3)
+    right = e[u_axis].copy()
+    forward = -up_sign * e[up_axis]            # look down: Z_cam along -up
+    down = np.cross(forward, right)            # right-handed OpenCV cam frame (X right, Y down, Z fwd)
+    R_wc = np.stack([right, down, forward], axis=0)  # world->camera rotation (rows are cam axes)
+
+    # Camera centre: over the footprint centre, above the highest Gaussian.
+    up_hi = up_sign * float(means[:, up_axis].max())      # highest height in the scene
+    C = np.zeros(3)
+    C[u_axis] = 0.5 * (u_lo + u_hi)
+    C[v_axis] = 0.5 * (v_lo_w + v_hi_w)
+    C[up_axis] = up_sign * (up_hi + 5.0)                  # 5 m above the top
+    tvec = -R_wc @ C
+    viewmat = np.eye(4)
+    viewmat[:3, :3] = R_wc
+    viewmat[:3, 3] = tvec
+
+    # Intrinsics: 1/cs px per metre; principal point centres the footprint (camera is at centre).
+    K = np.array([[1.0 / cs, 0, W / 2.0], [0, 1.0 / cs, H / 2.0], [0, 0, 1.0]])
+
+    vt = torch.from_numpy(viewmat).float().to(device)[None]
+    Kt = torch.from_numpy(K).float().to(device)[None]
+    with torch.no_grad():
+        renders, alphas, _ = rasterization(
+            means=g["means"], quats=g["quats"], scales=g["scales"],
+            opacities=g["opacities"], colors=g["colors"],
+            viewmats=vt, Ks=Kt, width=W, height=H,
+            sh_degree=g["sh_degree"], packed=True, render_mode="RGB",
+            camera_model="ortho",
+        )
+    # renders are alpha-composited over black; place them over the --bg grey via the alpha.
+    rgb = renders[0].clamp(0, 1).cpu().numpy()
+    alpha = alphas[0, ..., 0].cpu().numpy()
+    rgb = (rgb + (1.0 - alpha)[..., None] * args.bg).clip(0, 1)
+
+    # Orient to the gravity-canonical raster: render row axis is `down`; raster row axis is
+    # v_sign*e[v_axis]. Flip vertically iff they oppose so the BEV overlays the other layers.
+    raster_row = v_sign * e[v_axis]
+    if np.dot(down, raster_row) < 0:
+        rgb = rgb[::-1].copy()
+        alpha = alpha[::-1].copy()
+
+    img = (rgb * 255).clip(0, 255).astype(np.uint8)
+    bgr = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+    cv2.imwrite(str(out / f"{args.prefix}_rgb_bev.png"), bgr)
+    bgra = cv2.cvtColor(bgr, cv2.COLOR_BGR2BGRA)
+    bgra[..., 3] = (alpha.clip(0, 1) * 255).astype(np.uint8)
+    cv2.imwrite(str(out / f"{args.prefix}_rgb_bev_masked.png"), bgra)
+    print(f"done -> {out}/{args.prefix}_rgb_bev.png  ({W}x{H}, "
+          f"mean alpha {alpha.mean():.2f})")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/gsplat/train.py
+++ b/script/gsplat/train.py
@@ -15,6 +15,13 @@ size, trading detail for a coarse-but-complete model that fits an 8 GB laptop GP
   uv run --extra gsplat --extra segmentation python train.py ... \
       --semantic --segmenter mask2former-large
 
+  # 2DGS (surfel) mode: cleaner surface-aligned depth for the BEV back-projection.
+  uv run --extra gsplat python train.py --session <name> --mode 2dgs
+
+``--mode 2dgs`` swaps the volumetric rasterizer for the surfel (2D Gaussian) one and adds
+the normal-consistency / distortion surface regularizers, keeping the same MCMC ``--cap-max``
+VRAM budget. It writes to a separate ``-gsplat2d`` dir so it never clobbers a 3DGS model.
+
 Semantic training is two-phase (the reliable, canonical recipe):
   Phase 1 (--max-steps) trains RGB + geometry with MCMC densification -- identical to a
     plain RGB run, no semantic field involved.
@@ -39,11 +46,43 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 
-from gsplat import rasterization
+from gsplat import rasterization, rasterization_2dgs
 from gsplat.strategy import MCMCStrategy
 
 import model as gmodel
 from colmap_dataset import ColmapDataset
+
+
+def rasterize(mode, *, colors, sh_degree, packed=True, render_mode="RGB", **kw):
+    """Dispatch to the 3DGS or 2DGS rasterizer, returning a uniform 4-tuple.
+
+    Both paths return ``(colors, alphas, info, aux)``. For 2DGS ``aux`` carries the
+    surfel extras used by the surface regularizers -- rendered normals, the normals
+    implied by the depth map, and the per-pixel distortion. For 3DGS ``aux`` is ``None``.
+    MCMC's densification never reads ``info``, so the two rasterizers' differing meta
+    dicts are interchangeable here.
+
+    gsplat 1.5.3's ``rasterization_2dgs`` has three sharp edges that this wrapper hides so
+    the trainer never has to think about them (all verified empirically on this build):
+      * **packed is buggy** -- the packed path mis-gathers colors to the intersection count
+        (``colors.shape[0] == nnz`` assert) and fails on most inputs. Force ``packed=False``.
+      * **needs a depth render mode** -- ``surf_normals`` (normal-from-depth, required by the
+        normal-consistency reg) is only produced when depth is rendered, and the internal
+        colors/depth ``cat`` only lines up then. Force ``RGB+ED`` and slice the depth back off.
+      * **non-SH colors need a camera dim** -- with ``sh_degree=None`` gsplat forgets to add
+        the ``C`` axis, so ``(N, D)`` collides with depth ``(1, N, 1)``. Pass ``(1, N, D)``.
+    """
+    if mode == "2dgs":
+        c_in = colors if sh_degree is not None else colors[None]      # (N,D) -> (1,N,D)
+        colors_out, alphas, normals, surf_normals, distort, median, info = rasterization_2dgs(
+            colors=c_in, sh_degree=sh_degree, packed=False, render_mode="RGB+ED", **kw)
+        n_ch = 3 if sh_degree is not None else colors.shape[-1]       # strip appended depth
+        aux = {"normals": normals, "surf_normals": surf_normals,
+               "distort": distort, "median": median}
+        return colors_out[..., :n_ch], alphas, info, aux
+    colors, alphas, info = rasterization(
+        colors=colors, sh_degree=sh_degree, packed=packed, render_mode=render_mode, **kw)
+    return colors, alphas, info, None
 
 
 # --------------------------------------------------------------------------- metrics
@@ -106,7 +145,7 @@ def train(args):
     out.mkdir(parents=True, exist_ok=True)
     image_dir = Path(args.images) if args.images else Path(args.model).parent
 
-    print(f"gsplat 3DGS training -> {out}")
+    print(f"gsplat {args.mode.upper()} training -> {out}")
     ds = ColmapDataset(args.model, image_dir, data_factor=args.data_factor, limit=args.limit)
 
     # Optionally subsample the init cloud. MCMC's --cap-max only bounds *growth*, so if
@@ -185,7 +224,8 @@ def train(args):
         H, W = v.height, v.width
 
         colors = torch.cat([params["sh0"], params["shN"]], dim=1)  # (N, K, 3)
-        renders, alphas, info = rasterization(
+        renders, alphas, info, aux = rasterize(
+            args.mode,
             means=params["means"],
             quats=params["quats"],
             scales=torch.exp(params["scales"]),
@@ -198,11 +238,36 @@ def train(args):
             packed=True,
             render_mode="RGB",
         )
-        rgb = renders[0].clamp(0.0, 1.0)  # (H, W, 3)
+        # Random-background compositing: add bkgd*(1-alpha) to the render only (GT is the
+        # raw image). Where real content exists this forces alpha->1; the leftover sky
+        # fill is randomized so floaters can't settle on one convenient background colour.
+        raw_rgb = renders[0].clamp(0.0, 1.0)  # clean render, for preview/PSNR logging
+        rgb = renders[0]
+        if args.random_bkgd:
+            bkgd = torch.rand(3, device=device)
+            rgb = rgb + bkgd * (1.0 - alphas[0])
+        rgb = rgb.clamp(0.0, 1.0)  # (H, W, 3), background-composited -> loss
 
         l1 = F.l1_loss(rgb, gt)
         ssim_val = ssim(rgb.permute(2, 0, 1)[None], gt.permute(2, 0, 1)[None])
         loss = (1.0 - lam) * l1 + lam * (1.0 - ssim_val)
+        # MCMC regularizers on the raw (positive) opacity/scale values.
+        if args.opacity_reg:
+            loss = loss + args.opacity_reg * torch.sigmoid(params["opacities"]).mean()
+        if args.scale_reg:
+            loss = loss + args.scale_reg * torch.exp(params["scales"]).mean()
+        # 2DGS surface regularizers (paper §3.3), warmed up so they only bite once the
+        # geometry has roughly settled: normal consistency snaps the disks flush to the
+        # surface (this is what makes 2DGS depth cleaner than 3DGS); distortion pulls the
+        # ray's mass onto a single depth. Both default OFF-ish -- see the arg help.
+        nloss = dloss = None
+        if aux is not None and step >= args.reg_start:
+            if args.normal_reg:
+                nloss = (1.0 - (aux["normals"] * aux["surf_normals"]).sum(dim=-1)).mean()
+                loss = loss + args.normal_reg * nloss
+            if args.dist_reg:
+                dloss = aux["distort"].mean()
+                loss = loss + args.dist_reg * dloss
 
         strategy.step_pre_backward(params, optimizers, strategy_state, step, info)
         loss.backward()
@@ -218,10 +283,15 @@ def train(args):
         if step % args.log_every == 0 or step == args.max_steps - 1:
             n = params["means"].shape[0]
             rate = (step + 1) / (time.time() - t0)
+            extra = ""
+            if nloss is not None:
+                extra += f" nrm={nloss.item():.3f}"
+            if dloss is not None:
+                extra += f" dist={dloss.item():.4f}"
             print(f"[P1 {step:6d}/{args.max_steps}] loss={loss.item():.4f} "
-                  f"psnr={psnr(rgb, gt):.2f} gaussians={n} {rate:.1f} it/s")
+                  f"psnr={psnr(raw_rgb, gt):.2f} gaussians={n}{extra} {rate:.1f} it/s")
         if args.preview_every and (step % args.preview_every == 0 or step == args.max_steps - 1):
-            _save_preview(rgb, out / f"preview_{step:06d}.png")
+            _save_preview(raw_rgb, out / f"preview_{step:06d}.png")
         # Periodic geometry checkpoint so a long RGB phase survives a late crash/OOM.
         if args.save_every and step > 0 and step % args.save_every == 0:
             gmodel.export_gaussian_ply(params, out / "point_cloud.ply")
@@ -254,7 +324,8 @@ def train(args):
                 order = np.random.permutation(n_views)
             v = ds.views[idx]
 
-            sem_render, _, _ = rasterization(
+            sem_render, _, _, _ = rasterize(
+                args.mode,
                 means=geo["means"], quats=geo["quats"], scales=geo["scales"],
                 opacities=geo["opacities"], colors=params["sem"],
                 viewmats=viewmats[idx][None], Ks=Ks[idx][None],
@@ -312,6 +383,11 @@ def main():
     p.add_argument("--limit", type=int, default=None,
                    help="use only the first N images (smoke tests)")
 
+    p.add_argument("--mode", choices=["3dgs", "2dgs"], default="3dgs",
+                   help="Gaussian primitive: 3dgs (volumetric ellipsoids) or 2dgs "
+                        "(surfels/flat disks). 2dgs gives cleaner surface-aligned depth for "
+                        "the BEV back-projection, at some RGB fidelity. Same MCMC/--cap-max "
+                        "VRAM budget either way; writes to a separate -gsplat2d output dir.")
     p.add_argument("--max-steps", type=int, default=30000)
     p.add_argument("--cap-max", type=int, default=1_000_000,
                    help="hard cap on Gaussian count (MCMC). Lower = coarser + less VRAM.")
@@ -324,6 +400,34 @@ def main():
     p.add_argument("--ssim-weight", type=float, default=0.2)
     p.add_argument("--refine-start", type=int, default=500)
     p.add_argument("--refine-every", type=int, default=100)
+    # MCMC regularizers (the official recipe treats these as mandatory): opacity-reg
+    # pushes surplus Gaussians toward zero opacity so pruning removes the near-camera
+    # floater veil; scale-reg penalizes large scales so Gaussians stop growing into the
+    # view-ray needles/spikes. Omitting them is what wrecks an otherwise-correct scene.
+    # NOTE (2026-07-06): these three all DEGRADED the metric park scene and are OFF by
+    # default. gsplat's 0.01 reg defaults assume a scene normalized to ~unit scale; on our
+    # un-normalized metric coords they collapse opacity (median 1.0->0.015) and explode
+    # anisotropy. Random-bkgd just produced hazy fog on view-inconsistent foliage. Prefer
+    # post-hoc prune_gaussians.py for the veil/spike artifacts. See gsplat-pipeline memory.
+    p.add_argument("--opacity-reg", type=float, default=0.0,
+                   help="MCMC opacity regulariser (0 = off; >0 collapsed opacity on this scene)")
+    p.add_argument("--scale-reg", type=float, default=0.0,
+                   help="MCMC scale regulariser (0 = off; >0 exploded anisotropy on this scene)")
+    p.add_argument("--random-bkgd", action=argparse.BooleanOptionalAction, default=False,
+                   help="composite a random background onto the render each step (default off; "
+                        "on produced hazy fog here)")
+
+    # 2DGS surface regularizers (ignored when --mode 3dgs). normal-reg is the safe,
+    # standard one (0.05, the 2DGS paper value) and is what actually flattens the surfels
+    # onto the surface for clean depth. dist-reg (distortion) sharpens depth further but,
+    # like the MCMC regs above, can misbehave on our un-normalized metric coords, so it's
+    # OFF by default -- turn it on cautiously and watch the depth previews.
+    p.add_argument("--normal-reg", type=float, default=0.05,
+                   help="2DGS normal-consistency weight (0 = off; 0.05 = paper default)")
+    p.add_argument("--dist-reg", type=float, default=0.0,
+                   help="2DGS distortion weight (0 = off; risky on metric coords, tune up slowly)")
+    p.add_argument("--reg-start", type=int, default=500,
+                   help="delay the 2DGS surface regularizers until this step (let geometry settle first)")
 
     p.add_argument("--semantic", action="store_true",
                    help="train a per-Gaussian semantic head distilled from a 2D segmenter")
@@ -359,7 +463,7 @@ def _resolve_session(args, parser):
         s = Session(args.session)
         args.model = args.model or str(s.best_model())
         args.images = args.images or str(s.images)
-        args.out = args.out or str(s.gsplat_out(semantic=args.semantic))
+        args.out = args.out or str(s.gsplat_out(semantic=args.semantic, mode=args.mode))
         print(f"session '{args.session}':\n  model  = {args.model}\n"
               f"  images = {args.images}\n  out    = {args.out}")
     missing = [m for m in ("model", "out") if not getattr(args, m)]

--- a/script/gsplat/train.py
+++ b/script/gsplat/train.py
@@ -11,9 +11,16 @@ size, trading detail for a coarse-but-complete model that fits an 8 GB laptop GP
       --out    ../../output/<session>-gsplat \
       --data-factor 2 --cap-max 300000 --max-steps 30000
 
-  # Semantic 3DGS: also distil a segmenter into per-Gaussian class logits
+  # Semantic 3DGS: distil a segmenter into per-Gaussian class logits
   uv run --extra gsplat --extra segmentation python train.py ... \
       --semantic --segmenter mask2former-large
+
+Semantic training is two-phase (the reliable, canonical recipe):
+  Phase 1 (--max-steps) trains RGB + geometry with MCMC densification -- identical to a
+    plain RGB run, no semantic field involved.
+  Phase 2 (--sem-steps) attaches a fresh semantic field to the CONVERGED Gaussians and
+    trains only it, with geometry detached (MCMC off). Cross-entropy distils the 2D masks
+    onto fixed supports, so semantics can never move or degrade the reconstruction.
 
 See README.md. Requires a CUDA toolchain (nvcc) matching the installed torch, because
 gsplat compiles kernels on first import.
@@ -112,14 +119,17 @@ def train(args):
         points_xyz, points_rgb = points_xyz[sel], points_rgb[sel]
         print(f"subsampled init cloud {len(ds.points_xyz)} -> {init_max} points (<= cap_max)")
 
-    # Semantic head: cache masks + per-view targets up front.
+    # Semantic supervision (Phase 2): cache masks up front so a misconfigured segmenter
+    # fails fast, not after a multi-hour RGB phase.
     masks = None
     num_classes = None
     color_lut = None
+    ignore_index = 0
     if args.semantic:
         import semantic as sem_mod
         num_classes = sem_mod.NUM_CLASSES
         color_lut = sem_mod.SEMANTIC_COLOR_LUT
+        ignore_index = sem_mod.IGNORE_INDEX
         # Namespace the cache by segmenter so switching backends (oneformer ->
         # mask2former-large) against the same --out never silently reuses stale masks.
         store = sem_mod.build_mask_cache(
@@ -130,16 +140,16 @@ def train(args):
             torch.from_numpy(sem_mod.load_mask(store, v.name, v.width, v.height).astype(np.int64))
             for v in ds.views
         ]
-        ignore_index = sem_mod.IGNORE_INDEX
-        print(f"semantic head enabled: {num_classes} classes, segmenter={args.segmenter}")
+        print(f"semantic enabled: {num_classes} classes, segmenter={args.segmenter}")
 
+    # Phase 1 Gaussians carry no semantic field -- this phase is identical to a plain,
+    # well-tested RGB run. The semantic field is attached afterwards (Phase 2).
     params = gmodel.init_gaussians(
-        points_xyz, points_rgb, sh_degree=args.sh_degree,
-        num_classes=num_classes, device=device,
+        points_xyz, points_rgb, sh_degree=args.sh_degree, num_classes=None, device=device,
     )
     print(f"initialised {params['means'].shape[0]} Gaussians (sh_degree={args.sh_degree})")
 
-    optimizers, lrs = build_optimizers(params, ds.scene_scale, args.semantic)
+    optimizers, lrs = build_optimizers(params, ds.scene_scale, sem=False)
     # Exponential decay of the means lr (positions settle as training progresses).
     means_gamma = (0.01) ** (1.0 / args.max_steps)
 
@@ -160,9 +170,11 @@ def train(args):
 
     lam = args.ssim_weight
     n_views = len(ds.views)
-    order = np.random.permutation(n_views)
     t0 = time.time()
 
+    # ===================== Phase 1: RGB + geometry (MCMC densification) =====================
+    print(f"\nPhase 1 — RGB/geometry, {args.max_steps} steps")
+    order = np.random.permutation(n_views)
     for step in range(args.max_steps):
         idx = int(order[step % n_views])
         if step % n_views == 0 and step > 0:
@@ -192,59 +204,74 @@ def train(args):
         ssim_val = ssim(rgb.permute(2, 0, 1)[None], gt.permute(2, 0, 1)[None])
         loss = (1.0 - lam) * l1 + lam * (1.0 - ssim_val)
 
-        sem_loss = torch.tensor(0.0, device=device)
-        if args.semantic and step >= args.sem_start:
-            sem_render, _, _ = rasterization(
-                means=params["means"],
-                quats=params["quats"],
-                scales=torch.exp(params["scales"]),
-                opacities=torch.sigmoid(params["opacities"]),
-                colors=params["sem"],
-                viewmats=viewmats[idx][None],
-                Ks=Ks[idx][None],
-                width=W, height=H,
-                sh_degree=None,
-                packed=True,
-                render_mode="RGB",
-            )
-            logits = sem_render.permute(0, 3, 1, 2)              # (1, C, H, W)
-            target = masks[idx].to(device)[None]                 # (1, H, W)
-            sem_loss = F.cross_entropy(logits, target, ignore_index=ignore_index)
-            loss = loss + args.sem_weight * sem_loss
-
         strategy.step_pre_backward(params, optimizers, strategy_state, step, info)
         loss.backward()
-
         for opt in optimizers.values():
             opt.step()
             opt.zero_grad(set_to_none=True)
 
-        # Decay means lr.
         cur_means_lr = lrs["means"] * (means_gamma ** step)
         for g in optimizers["means"].param_groups:
             g["lr"] = cur_means_lr
-
-        strategy.step_post_backward(
-            params, optimizers, strategy_state, step, info, lr=cur_means_lr
-        )
+        strategy.step_post_backward(params, optimizers, strategy_state, step, info, lr=cur_means_lr)
 
         if step % args.log_every == 0 or step == args.max_steps - 1:
             n = params["means"].shape[0]
             rate = (step + 1) / (time.time() - t0)
-            msg = (f"[{step:6d}/{args.max_steps}] loss={loss.item():.4f} "
-                   f"psnr={psnr(rgb, gt):.2f} gaussians={n} {rate:.1f} it/s")
-            if args.semantic and step >= args.sem_start:
-                msg += f" sem_ce={sem_loss.item():.4f}"
-            print(msg)
-
+            print(f"[P1 {step:6d}/{args.max_steps}] loss={loss.item():.4f} "
+                  f"psnr={psnr(rgb, gt):.2f} gaussians={n} {rate:.1f} it/s")
         if args.preview_every and (step % args.preview_every == 0 or step == args.max_steps - 1):
             _save_preview(rgb, out / f"preview_{step:06d}.png")
-
-        # Periodic checkpoint so a long train survives a late crash/OOM (don't wait
-        # until the very end to write anything to disk).
+        # Periodic geometry checkpoint so a long RGB phase survives a late crash/OOM.
         if args.save_every and step > 0 and step % args.save_every == 0:
-            save_outputs(params, out, args.semantic, color_lut, num_classes,
-                         label=f"checkpoint @ step {step}")
+            gmodel.export_gaussian_ply(params, out / "point_cloud.ply")
+
+    gmodel.export_gaussian_ply(params, out / "point_cloud.ply")
+    print(f"Phase 1 done in {time.time() - t0:.1f}s")
+
+    # ============= Phase 2: semantic field on FROZEN geometry (canonical recipe) =============
+    # Attach a fresh semantic field to the final Gaussians and train only it, with the
+    # geometry inputs detached: cross-entropy can label the supports but can never move
+    # or degrade them, and MCMC is off. This is the reliable LangSplat/Feature-3DGS recipe.
+    if args.semantic:
+        n = params["means"].shape[0]
+        params["sem"] = torch.nn.Parameter(torch.zeros(n, num_classes, device=device))
+        sem_opt = torch.optim.Adam([params["sem"]], lr=args.sem_lr, eps=1e-15)
+
+        geo = dict(  # frozen snapshot of the converged geometry
+            means=params["means"].detach(),
+            quats=params["quats"].detach(),
+            scales=torch.exp(params["scales"]).detach(),
+            opacities=torch.sigmoid(params["opacities"]).detach(),
+        )
+
+        print(f"\nPhase 2 — semantic ({args.segmenter}), {args.sem_steps} steps, geometry frozen")
+        t1 = time.time()
+        order = np.random.permutation(n_views)
+        for step in range(args.sem_steps):
+            idx = int(order[step % n_views])
+            if step % n_views == 0 and step > 0:
+                order = np.random.permutation(n_views)
+            v = ds.views[idx]
+
+            sem_render, _, _ = rasterization(
+                means=geo["means"], quats=geo["quats"], scales=geo["scales"],
+                opacities=geo["opacities"], colors=params["sem"],
+                viewmats=viewmats[idx][None], Ks=Ks[idx][None],
+                width=v.width, height=v.height, sh_degree=None, packed=True, render_mode="RGB",
+            )
+            logits = sem_render.permute(0, 3, 1, 2)          # (1, C, H, W)
+            target = masks[idx].to(device)[None]             # (1, H, W)
+            ce = F.cross_entropy(logits, target, ignore_index=ignore_index)
+            ce.backward()
+            sem_opt.step()
+            sem_opt.zero_grad(set_to_none=True)
+
+            if step % args.log_every == 0 or step == args.sem_steps - 1:
+                rate = (step + 1) / (time.time() - t1)
+                print(f"[P2 {step:6d}/{args.sem_steps}] sem_ce={ce.item():.4f} {rate:.1f} it/s")
+            if args.save_every and step > 0 and step % args.save_every == 0:
+                gmodel.export_semantic(params, out / "point_cloud", color_lut)
 
     save_outputs(params, out, args.semantic, color_lut, num_classes, label="final")
     (out / "config.json").write_text(json.dumps(vars(args), indent=2, default=str))
@@ -300,9 +327,9 @@ def main():
     p.add_argument("--segmenter", default="mask2former-large",
                    help="semantic_bev segmenter kind (default: mask2former-large; also "
                         "oneformer[-large]/mask2former/clipseg)")
-    p.add_argument("--sem-weight", type=float, default=1.0, help="semantic CE loss weight")
-    p.add_argument("--sem-start", type=int, default=0,
-                   help="step to start semantic supervision (let geometry form first)")
+    p.add_argument("--sem-steps", type=int, default=7000,
+                   help="Phase 2 steps: train the semantic field on the frozen geometry")
+    p.add_argument("--sem-lr", type=float, default=1e-2, help="learning rate for semantic logits")
     p.add_argument("--overwrite-masks", action="store_true",
                    help="re-run the segmenter even if masks are cached")
 

--- a/script/gsplat/train.py
+++ b/script/gsplat/train.py
@@ -299,11 +299,14 @@ def _save_preview(rgb: torch.Tensor, path: Path) -> None:
 def main():
     p = argparse.ArgumentParser(description=__doc__,
                                 formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("--model", required=True,
-                   help="COLMAP text model dir (…/colmap/poses_txt)")
+    p.add_argument("--session", default=None,
+                   help="LAR session name: fills --model/--images/--out from the canonical "
+                        "layout (script/lar_session.py). Explicit flags override.")
+    p.add_argument("--model", default=None,
+                   help="COLMAP text model dir (…/colmap/sparse/0 or …/poses_txt)")
     p.add_argument("--images", default=None,
-                   help="image dir (default: parent of --model, i.e. …/colmap)")
-    p.add_argument("--out", required=True, help="output dir for plys/previews/config")
+                   help="image dir (default: session images, else parent of --model)")
+    p.add_argument("--out", default=None, help="output dir for plys/previews/config")
     p.add_argument("--data-factor", type=int, default=2,
                    help="downscale images by this integer factor (default: 2; use >=2 at park scale)")
     p.add_argument("--limit", type=int, default=None,
@@ -341,9 +344,27 @@ def main():
                         "survives a late crash (default 5000; 0 = only at the end)")
 
     args = p.parse_args()
+    _resolve_session(args, p)
     if args.preview_every == 0:
         args.preview_every = args.max_steps  # still dump one at the end
     train(args)
+
+
+def _resolve_session(args, parser):
+    """Fill --model/--images/--out from --session (canonical layout); explicit flags win."""
+    if args.session:
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())
+        args.images = args.images or str(s.images)
+        args.out = args.out or str(s.gsplat_out(semantic=args.semantic))
+        print(f"session '{args.session}':\n  model  = {args.model}\n"
+              f"  images = {args.images}\n  out    = {args.out}")
+    missing = [m for m in ("model", "out") if not getattr(args, m)]
+    if missing:
+        parser.error("need --session or explicit " + " ".join(f"--{m}" for m in missing))
 
 
 if __name__ == "__main__":

--- a/script/lar_session.py
+++ b/script/lar_session.py
@@ -62,5 +62,10 @@ class Session:
     def gsplat_out(self, semantic: bool = False) -> Path:
         return self.root / "output" / f"{self.name}-gsplat{'-sem' if semantic else ''}"
 
-    def sbev_out(self, source: str = "colmap") -> Path:
-        return self.root / "output" / f"{self.name}-sbev{'-gsplat' if source == 'gsplat' else ''}"
+    def sbev_out(self, source: str = "colmap", tag: str | None = None) -> Path:
+        suffix = f"-{tag}" if tag else ("-gsplat" if source == "gsplat" else "")
+        return self.root / "output" / f"{self.name}-sbev{suffix}"
+
+    def depth_dir(self, backend: str) -> Path:
+        """Per-backend per-view depth maps for the depth bake-off (mvs/2dgs/mono/3dgs)."""
+        return self.root / "output" / f"{self.name}-depth-{backend}"

--- a/script/lar_session.py
+++ b/script/lar_session.py
@@ -1,0 +1,66 @@
+"""Canonical directory layout for a LAR capture session — one source of truth.
+
+Every phase of the pipeline reads/writes paths derived from a single **session name**
+(e.g. ``maguro-park-after-itchy``). Encoding the convention here means each tool can accept
+just ``--session <name>`` instead of re-specifying ``--model``/``--images``/``--out`` every
+time. Explicit flags still override whatever the session resolves.
+
+Layout (relative to the repo root that contains ``input/`` and ``output/``):
+
+    input/<name>/                         raw capture (images, frames.json, gps.json, map.json)
+    input/<name>/colmap/poses_txt/        COLMAP text model from script/colmap/colmap.py
+    output/<name>-refined/                lar_refine_colmap output
+    output/<name>-refined/colmap/sparse/0/  refined COLMAP text model (bundle-adjusted)
+    output/<name>-gsplat[-sem]/           script/gsplat/train.py output
+    output/<name>-sbev[-gsplat]/          script/semantic_bev/pipeline.py output
+
+``best_model()`` prefers the refined (bundle-adjusted) model when present, else the raw
+COLMAP model — that's the sensible default input for the gsplat/BEV phases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# script/lar_session.py -> repo root is two levels up (root/script/lar_session.py).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class Session:
+    def __init__(self, name: str, root: Path | str = REPO_ROOT):
+        self.name = name
+        self.root = Path(root)
+
+    # ---- inputs -------------------------------------------------------------
+    @property
+    def input_dir(self) -> Path:
+        return self.root / "input" / self.name
+
+    @property
+    def images(self) -> Path:
+        return self.input_dir
+
+    @property
+    def colmap_model(self) -> Path:
+        """Raw COLMAP text model from the reconstruction phase."""
+        return self.input_dir / "colmap" / "poses_txt"
+
+    @property
+    def refined_dir(self) -> Path:
+        return self.root / "output" / f"{self.name}-refined"
+
+    @property
+    def refined_model(self) -> Path:
+        """Bundle-adjusted COLMAP text model from lar_refine_colmap (the richer one)."""
+        return self.refined_dir / "colmap" / "sparse" / "0"
+
+    def best_model(self) -> Path:
+        """Refined model if it exists, else the raw COLMAP model."""
+        return self.refined_model if (self.refined_model / "images.txt").exists() else self.colmap_model
+
+    # ---- outputs ------------------------------------------------------------
+    def gsplat_out(self, semantic: bool = False) -> Path:
+        return self.root / "output" / f"{self.name}-gsplat{'-sem' if semantic else ''}"
+
+    def sbev_out(self, source: str = "colmap") -> Path:
+        return self.root / "output" / f"{self.name}-sbev{'-gsplat' if source == 'gsplat' else ''}"

--- a/script/lar_session.py
+++ b/script/lar_session.py
@@ -59,8 +59,10 @@ class Session:
         return self.refined_model if (self.refined_model / "images.txt").exists() else self.colmap_model
 
     # ---- outputs ------------------------------------------------------------
-    def gsplat_out(self, semantic: bool = False) -> Path:
-        return self.root / "output" / f"{self.name}-gsplat{'-sem' if semantic else ''}"
+    def gsplat_out(self, semantic: bool = False, mode: str = "3dgs") -> Path:
+        # 2DGS (surfel) models live in a sibling dir so a 2dgs run never clobbers the 3dgs one.
+        kind = "gsplat2d" if mode == "2dgs" else "gsplat"
+        return self.root / "output" / f"{self.name}-{kind}{'-sem' if semantic else ''}"
 
     def sbev_out(self, source: str = "colmap", tag: str | None = None) -> Path:
         suffix = f"-{tag}" if tag else ("-gsplat" if source == "gsplat" else "")

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -94,6 +94,16 @@ class, so this skips segmentation/voting entirely and feeds a much denser, pre-l
 cloud straight into the *same* `build_level`. `--model` is still used (cameras only) to
 detect gravity/up, unless you pass `--up-axis`/`--up-sign`.
 
+**Just pass `--session <name>`** (canonical layout, [`../lar_session.py`](../lar_session.py)):
+it fills `--gsplat-dir` = `output/<name>-gsplat-sem`, `--model` = the refined model (for
+gravity), and `--out` = `output/<name>-sbev-gsplat`. Explicit flags override.
+
+```sh
+uv run python pipeline.py --session maguro-park-after-itchy --source gsplat --cell-size 0.5
+```
+
+Equivalent explicit form:
+
 ```sh
 uv run python pipeline.py --source gsplat \
   --gsplat-dir ../../output/<session>-gsplat-sem \

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -26,6 +26,8 @@ export — and the semantic labels are intended to feed back into localization.
 
 | file | role |
 |------|------|
+| `geometry.py`    | **pure-geometry front-end**: gravity-align + robust ground DEM + ground/vertical split (no semantics) |
+| `geometry_cli.py`| run `geometry.py` on a COLMAP model → DEM hillshade, structure-height, ground/vertical, trajectory, cross-sections |
 | `colmap_io.py`   | read COLMAP text model; tracks give exact observed pixel per point |
 | `taxonomy.py`    | **the semantic contract**: prompts → internal class → IMDF category |
 | `segmentation.py`| `Segmenter` interface + `Heuristic`/`ClipSeg`/`OneFormer` backends |
@@ -36,6 +38,41 @@ export — and the semantic labels are intended to feed back into localization.
 | `pipeline.py`    | end-to-end driver + CLI (auto up-axis/sign detection) |
 | `compare_segmenters.py` | run backends side-by-side on sample images → comparison grid |
 | `verify_orientation.py` | overlay camera trajectory on the BEV (orientation sanity) |
+
+## Geometry front-end (`geometry.py` / `geometry_cli.py`)
+
+"Master the geometry first" — a semantics-free ground model, so the DEM / ground mask /
+obstacle mask are correct *before* any labels are projected onto them. Three products:
+
+1. **Gravity-aligned frame** — up is measured from camera image-up averaged over all
+   frames (not axis-snapped). On `maguro-park-after-itchy-refined` gravity is only 0.92°
+   off −Y, but that's ~1.5 m of false slope across the 90 m park, so we rotate by the full
+   vector and keep the horizontal axes level.
+2. **Ground DEM** — robust *lower envelope*: a low per-cell quantile seeds the surface,
+   then an iterative refit inside an asymmetric band (tight below, looser above) locks it
+   to the ground cluster without climbing into the bush/canopy layer. Smoothing is
+   normalised-convolution (blur observed ÷ blur mask) so unobserved cells never drag real
+   ground up. Sharp to ~15–20 cm where cameras walked; the rest is marked extrapolated.
+3. **Ground / vertical / floater split** — per-point height-above-ground: within the band
+   = ground, above = vertical structure, below = floater/outlier.
+
+```sh
+uv run python geometry_cli.py \
+  --model ../../output/maguro-park-after-itchy-refined/sparse/0 \
+  --out   ../../output/maguro-park-after-itchy-geom --cell-size 0.5
+```
+
+Emits `ground_field.npz` (dem, coverage, R, up, origin, cell_size) + previews:
+`dem_hillshade`, `structure_height`, `ground_vs_vertical`, `camera_trajectory`,
+`cross_sections` (the real ground-quality test — DEM vs. class-coloured points). No
+matplotlib dependency (renders via cv2).
+
+> **Note — the refined LAR model has no tracks.** `…-refined/sparse/0` stores poses +
+> point *positions* only: `points3D.txt` has no track, colour, or reproj-error (all
+> RGB=180,180,180, error=1.0) and `images.txt` has empty POINTS2D. So track-pixel
+> semantic voting (`labeling.py`) **cannot run on the refined model** — semantics there
+> must come from dense-mask projection (poses + intrinsics), which needs no tracks. The
+> geometry front-end uses only positions + camera orientations, so it works fine.
 
 ## Semantic raster modes (`--semantic-mode`)
 

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -82,6 +82,23 @@ matplotlib dependency (renders via cv2).
   cleaner + higher coverage, CPU-only. This is the fallback for when semantic 3DGS is too heavy
   (low-VRAM / on-device). Height + occupancy still come from the point path.
 
+## True-colour BEV orthophoto (`--rgb-ortho`)
+
+Drapes the source RGB onto the DEM, top-down, into `level0_rgb.png` — a photographic overhead
+map instead of a class raster. It's the same reprojection as `--semantic-mode project`, but it
+reads the source **image** at each cell instead of the mask, and at a **finer grid**:
+
+- `--rgb-sub N` — render at `N`× the DEM resolution (fine cell = `cell_size / N`). Height varies
+  slowly, so a coarse DEM (e.g. 0.5 m) upsamples cleanly and colour gets the resolution
+  (e.g. `--cell-size 0.5 --rgb-sub 10` → a 0.05 m orthophoto).
+- Occlusion-robust: when masks exist (colmap/depth sources), a view's colour is kept only where
+  its pixel is a **ground class**, so canopy/wall colours are dropped and a clear ground view wins.
+- `--rgb-best-view` — colour each cell from its single closest view (crisper, but exposure seams)
+  instead of the default inverse-depth weighted mean (smoother, but slight parallax ghosting).
+
+Outputs `level0_rgb.png` (opaque, gaps nearest-filled) and `level0_rgb_masked.png` (alpha = only
+directly-observed cells). Needs a COLMAP model (poses + gravity) and `--images`.
+
 ## Segmentation backends (all commercial-license friendly)
 
 | backend | model | license | speed | notes |
@@ -159,6 +176,7 @@ at the cost of first training a semantic splat model.
   (free/blocked/unknown), `coverage` (observed vs interpolated)
 - `level0.meta.json` — grid spec (cell size, origin, up-axis/sign, dims)
 - `level0_{height,semantic,occupancy}.png` — previews (north-up)
+- `level0_rgb.png`, `level0_rgb_masked.png` — true-colour orthophoto (only with `--rgb-ortho`)
 - `masks/` — cached per-image class-id PNGs (+ colour previews); segmentation runs once
 
 ## Status / next

--- a/script/semantic_bev/README.md
+++ b/script/semantic_bev/README.md
@@ -85,6 +85,27 @@ uv run python pipeline.py ... --segmenter clipseg --clip-threshold 0.3
 
 Add `--limit N` to process only the first N images while iterating.
 
+### Geometry source: COLMAP points (default) or semantic 3DGS
+
+`--source` selects where `(positions, labels, confidence)` come from. The default
+`colmap` path is above. `--source gsplat` instead consumes a trained **semantic 3DGS**
+export ([`../gsplat`](../gsplat/) `train.py --semantic`): every Gaussian already carries a
+class, so this skips segmentation/voting entirely and feeds a much denser, pre-labelled
+cloud straight into the *same* `build_level`. `--model` is still used (cameras only) to
+detect gravity/up, unless you pass `--up-axis`/`--up-sign`.
+
+```sh
+uv run python pipeline.py --source gsplat \
+  --gsplat-dir ../../output/<session>-gsplat-sem \
+  --model      ../../output/<session>-refined/colmap/sparse/0 \
+  --out        ../../output/<session>-sbev-gsplat \
+  --cell-size 0.5 --min-opacity 0.1
+```
+
+`--min-opacity` drops faint Gaussians (3DGS floaters) before rasterising. This is the
+optional "3DGS geometry source" tier: denser height/occupancy than sparse COLMAP tracks,
+at the cost of first training a semantic splat model.
+
 ## Output (`<out>/`)
 
 - `level0.npz` — `height` (m, nan=unobserved), `semantic` (Klass id), `occupancy`

--- a/script/semantic_bev/colmap_io.py
+++ b/script/semantic_bev/colmap_io.py
@@ -87,11 +87,25 @@ def read_cameras_text(path: Path) -> dict[int, Camera]:
 
 
 def read_images_text(path: Path) -> dict[int, Image]:
-    """Two lines per image: pose line, then a flat (X, Y, POINT3D_ID) triple list."""
+    """Two *physical* lines per image: a pose header, then a (X, Y, POINT3D_ID) list.
+
+    The POINTS2D line can be **empty** (a refined image with a pose but no surviving 2D
+    points -- valid COLMAP). Pair by physical line position, not by filtering blanks first,
+    or those empty lines desync every subsequent pose.
+    """
     images: dict[int, Image] = {}
-    it = _read_lines(path)
-    for header in it:
-        pts_line = next(it)
+    with open(path) as f:
+        lines = f.read().split("\n")
+
+    i, n = 0, len(lines)
+    while i < n:
+        header = lines[i].strip()
+        if not header or header.startswith("#"):
+            i += 1
+            continue
+        pts_line = lines[i + 1] if i + 1 < n else ""
+        i += 2
+
         h = header.split()
         img_id = int(h[0])
         qvec = np.array(h[1:5], dtype=np.float64)
@@ -99,15 +113,15 @@ def read_images_text(path: Path) -> dict[int, Image]:
         camera_id = int(h[8])
         name = h[9]
 
-        vals = np.array(pts_line.split(), dtype=np.float64).reshape(-1, 3)
+        toks = pts_line.split()
+        if toks:
+            vals = np.array(toks, dtype=np.float64).reshape(-1, 3)
+            xys, pids = vals[:, :2].copy(), vals[:, 2].astype(np.int64)
+        else:
+            xys, pids = np.empty((0, 2)), np.empty((0,), dtype=np.int64)
         images[img_id] = Image(
-            id=img_id,
-            qvec=qvec,
-            tvec=tvec,
-            camera_id=camera_id,
-            name=name,
-            xys=vals[:, :2].copy(),
-            point3d_ids=vals[:, 2].astype(np.int64),
+            id=img_id, qvec=qvec, tvec=tvec, camera_id=camera_id, name=name,
+            xys=xys, point3d_ids=pids,
         )
     return images
 

--- a/script/semantic_bev/dense_projection.py
+++ b/script/semantic_bev/dense_projection.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import numpy as np
 
 from colmap_io import Reconstruction, qvec2rotmat
+from grid_transform import cell_to_world
 from ground_model import Level
 from labeling import MaskStore
 from taxonomy import Klass, Role, role_of
@@ -35,8 +36,9 @@ def project_dense_semantics(recon: Reconstruction, store: MaskStore, level: Leve
     # World-space centre of every cell (height from the Level's field).
     jj, ii = np.meshgrid(np.arange(cols), np.arange(rows))  # jj=col(=u), ii=row(=v)
     P = np.zeros((rows * cols, 3))
-    P[:, u_axis] = (spec.origin_u + (jj.ravel() + 0.5) * spec.cell_size)
-    P[:, v_axis] = (spec.origin_v + (ii.ravel() + 0.5) * spec.cell_size)
+    u_world, v_world = cell_to_world(jj.ravel() + 0.5, ii.ravel() + 0.5, spec)  # cell centres
+    P[:, u_axis] = u_world
+    P[:, v_axis] = v_world
     P[:, spec.up_axis] = level.height.ravel() * spec.up_sign  # world up-coord = height*sign
 
     ncells = rows * cols

--- a/script/semantic_bev/depth_backproject.py
+++ b/script/semantic_bev/depth_backproject.py
@@ -1,0 +1,132 @@
+"""Depth back-projection geometry source — the shared harness for the depth bake-off.
+
+Every "real geometry" approach (COLMAP MVS, 2DGS, mono-depth, 3DGS) reduces to the same
+thing: **per-view metric depth**. This module is the common back-end. It back-projects
+every labelled pixel to its *true* 3D position using that depth — instead of assuming the
+pixel lies on the ground, which is what makes `dense_projection` smear above-ground
+objects. Output is the standard ``(positions, labels, confidence)`` triple, so
+``ground_model.build_level`` is unchanged and every backend is compared apples-to-apples.
+
+Depth-map contract (one directory per backend, produced by that backend's exporter):
+
+    <depth_dir>/<image_stem>.npy        float32 (H, W) metric z-depth in metres; <=0 / NaN = invalid
+    <depth_dir>/<image_stem>.conf.npy   optional float32 (H, W) confidence in [0, 1]
+
+Depth resolution may differ from the source image; the pinhole intrinsics are scaled to
+the depth resolution. Points are accumulated across all frames and voxel-deduped (mean
+position, confidence-weighted majority label per voxel) so memory stays bounded.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from colmap_io import Reconstruction
+from labeling import MaskStore
+from taxonomy import Klass
+
+
+def _qvec2rotmat(q: np.ndarray) -> np.ndarray:
+    w, x, y, z = q
+    return np.array([[1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                     [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                     [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)]])
+
+
+def _pinhole_params(cam) -> tuple[float, float, float, float]:
+    """(fx, fy, cx, cy) from a PINHOLE / SIMPLE_PINHOLE camera."""
+    p = cam.params
+    if cam.model == "PINHOLE":
+        return float(p[0]), float(p[1]), float(p[2]), float(p[3])
+    if cam.model == "SIMPLE_PINHOLE":
+        return float(p[0]), float(p[0]), float(p[1]), float(p[2])
+    raise ValueError(f"camera model {cam.model!r} not supported for back-projection")
+
+
+def _load_depth(depth_dir: Path, stem: str):
+    dp = depth_dir / f"{stem}.npy"
+    if not dp.exists():
+        return None, None
+    depth = np.load(dp).astype(np.float32)
+    cp = depth_dir / f"{stem}.conf.npy"
+    conf = np.load(cp).astype(np.float32) if cp.exists() else None
+    return depth, conf
+
+
+def backproject_labeled_points(
+    recon: Reconstruction, store: MaskStore, depth_dir: str | Path, image_ids: list[int],
+    *, stride: int = 4, voxel: float = 0.05, min_conf: float = 0.0, log=print,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Back-project labelled pixels via per-view depth -> voxel-deduped labelled cloud."""
+    depth_dir = Path(depth_dir)
+    n_klass = int(max(Klass)) + 1
+    all_pos, all_lab, all_conf = [], [], []
+    n_frames = raw = 0
+
+    for img_id in image_ids:
+        im = recon.images[img_id]
+        depth, conf = _load_depth(depth_dir, Path(im.name).stem)
+        if depth is None:
+            continue
+        H, W = depth.shape
+        cam = recon.cameras[im.camera_id]
+        fx, fy, cx, cy = _pinhole_params(cam)
+        sx, sy = W / cam.width, H / cam.height           # scale intrinsics to depth res
+        fx, fy, cx, cy = fx * sx, fy * sy, cx * sx, cy * sy
+
+        mask = store.load(im.name)
+        if mask.shape != (H, W):
+            mask = cv2.resize(mask, (W, H), interpolation=cv2.INTER_NEAREST)
+
+        ys = np.arange(0, H, stride)
+        xs = np.arange(0, W, stride)
+        gx, gy = np.meshgrid(xs, ys)
+        gx, gy = gx.ravel(), gy.ravel()
+        d = depth[gy, gx]
+        lab = mask[gy, gx]
+        valid = (d > 0) & np.isfinite(d) & (lab != int(Klass.UNKNOWN))
+        if conf is not None:
+            cvals = conf[gy, gx]
+            valid &= cvals >= min_conf
+        if not valid.any():
+            continue
+
+        u, v, dd, ll = gx[valid].astype(np.float32), gy[valid].astype(np.float32), d[valid], lab[valid]
+        cw = conf[gy, gx][valid].astype(np.float32) if conf is not None else np.ones(len(dd), np.float32)
+        # pixel + metric z-depth -> camera coords -> world coords.
+        cam_pts = np.stack([(u - cx) / fx * dd, (v - cy) / fy * dd, dd], axis=1)
+        R = _qvec2rotmat(im.qvec)
+        C = -R.T @ im.tvec
+        world = cam_pts @ R + C                          # world_i = R^T @ cam_i + C
+
+        all_pos.append(world.astype(np.float32))
+        all_lab.append(ll.astype(np.int64))
+        all_conf.append(cw)
+        n_frames += 1
+        raw += len(world)
+
+    if not all_pos:
+        raise ValueError(f"no depth maps found in {depth_dir} for the requested images")
+
+    pos = np.concatenate(all_pos)
+    lab = np.concatenate(all_lab)
+    cw = np.concatenate(all_conf)
+    log(f"  back-projected {raw} points from {n_frames} depth maps (stride {stride})")
+
+    # Voxel dedup: mean position + confidence-weighted majority label per voxel.
+    vox = np.floor(pos / voxel).astype(np.int64)
+    uniq, inv = np.unique(vox, axis=0, return_inverse=True)
+    counts = np.bincount(inv)
+    sums = np.zeros((len(uniq), 3), np.float64)
+    np.add.at(sums, inv, pos)
+    positions = (sums / counts[:, None]).astype(np.float32)
+
+    flat = inv * n_klass + lab
+    votes = np.bincount(flat, weights=cw, minlength=len(uniq) * n_klass).reshape(len(uniq), n_klass)
+    labels = votes.argmax(1).astype(np.uint8)
+    confidence = (votes.max(1) / votes.sum(1)).astype(np.float32)
+    log(f"  voxel-deduped to {len(positions)} points @ {voxel} m")
+    return positions, labels, confidence

--- a/script/semantic_bev/eval_depth_bev.py
+++ b/script/semantic_bev/eval_depth_bev.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Score the depth bake-off: compare BEV levels from each geometry backend side by side.
+
+Loads each backend's ``level0.npz`` (from ``pipeline.py`` with the corresponding source)
+and reports, per backend:
+
+  - coverage %       -- fraction of grid cells with observed ground geometry
+  - ground cells     -- absolute observed count (denser depth -> more)
+  - blocked cells    -- occupancy footprints (obstacles/objects)
+  - height roughness -- median |∇height| over observed cells (proxy for surface noise;
+                        lower = smoother, so MVS/2DGS should beat mono/3DGS if cleaner)
+  - class mix        -- semantic distribution over observed ground
+
+and renders a combined semantic+height comparison image. Footprint IoU vs. hand-marked
+objects is a later addition (needs instance segmentation), flagged as TODO.
+
+  uv run python eval_depth_bev.py --session maguro-park-after-itchy \
+      --backends colmap,mvs,mono,3dgs,2dgs --out ../../output/<name>-bakeoff
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from taxonomy import Klass, color_lut
+
+BLOCKED = 1
+
+
+def _sbev_dir(session, backend):
+    if backend in ("colmap", "gsplat"):
+        return session.sbev_out(backend)
+    return session.sbev_out("depth", tag=backend)
+
+
+def load_level(d: Path):
+    npz = np.load(d / "level0.npz")
+    meta = json.loads((d / "level0.meta.json").read_text())
+    return dict(height=npz["height"], semantic=npz["semantic"],
+                occupancy=npz["occupancy"], coverage=npz["coverage"], meta=meta)
+
+
+def metrics(lv) -> dict:
+    cov = lv["coverage"]
+    h = lv["height"].astype(np.float32)
+    obs = cov & np.isfinite(h)
+    gy, gx = np.gradient(np.nan_to_num(h))
+    grad = np.sqrt(gy ** 2 + gx ** 2)
+    rough = float(np.median(grad[obs])) if obs.any() else float("nan")
+    classes = np.bincount(lv["semantic"][cov], minlength=int(max(Klass)) + 1)
+    top = sorted(((c, int(n)) for c, n in enumerate(classes) if n), key=lambda x: -x[1])[:4]
+    return {
+        "cells": int(cov.size),
+        "coverage_%": round(100 * cov.mean(), 1),
+        "ground_cells": int(cov.sum()),
+        "blocked_cells": int((lv["occupancy"] == BLOCKED).sum()),
+        "height_roughness_m": round(rough, 3),
+        "top_classes": ", ".join(f"{Klass(c).name}:{n}" for c, n in top),
+    }
+
+
+def render_comparison(levels: dict, out: Path):
+    lut = np.array(color_lut(), np.uint8)
+    tiles = []
+    for name, lv in levels.items():
+        sem = lut[lv["semantic"]]
+        sem[~lv["coverage"]] = (30, 30, 30)
+        sem = cv2.cvtColor(sem, cv2.COLOR_RGB2BGR)
+        sem = cv2.copyMakeBorder(sem, 24, 4, 4, 4, cv2.BORDER_CONSTANT, value=(0, 0, 0))
+        cv2.putText(sem, name, (6, 17), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 1)
+        tiles.append(sem)
+    h = max(t.shape[0] for t in tiles)
+    tiles = [cv2.copyMakeBorder(t, 0, h - t.shape[0], 0, 0, cv2.BORDER_CONSTANT, value=(0, 0, 0)) for t in tiles]
+    cv2.imwrite(str(out / "bakeoff_semantic.png"), np.hstack(tiles))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--session", required=True)
+    ap.add_argument("--backends", default="colmap,mvs,mono,3dgs,2dgs",
+                    help="comma list; each resolves to its sbev output dir")
+    ap.add_argument("--out", default=None, help="scorecard dir (default: <name>-bakeoff)")
+    args = ap.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from lar_session import Session
+    s = Session(args.session)
+    out = Path(args.out) if args.out else s.root / "output" / f"{s.name}-bakeoff"
+    out.mkdir(parents=True, exist_ok=True)
+
+    levels, rows = {}, []
+    for b in [x.strip() for x in args.backends.split(",") if x.strip()]:
+        d = _sbev_dir(s, b)
+        if not (d / "level0.npz").exists():
+            print(f"skip {b}: no level0.npz at {d}")
+            continue
+        lv = load_level(d)
+        levels[b] = lv
+        m = metrics(lv)
+        rows.append((b, m))
+        print(f"\n[{b}]  {d.name}")
+        for k, v in m.items():
+            print(f"    {k:20} {v}")
+
+    if not levels:
+        raise SystemExit("no backend outputs found — run pipeline.py per backend first")
+
+    # Markdown scorecard.
+    cols = ["coverage_%", "ground_cells", "blocked_cells", "height_roughness_m", "top_classes"]
+    md = ["| backend | " + " | ".join(cols) + " |", "|" + "---|" * (len(cols) + 1)]
+    for b, m in rows:
+        md.append(f"| {b} | " + " | ".join(str(m[c]) for c in cols) + " |")
+    (out / "scorecard.md").write_text("\n".join(md) + "\n")
+    render_comparison(levels, out)
+    print(f"\nscorecard -> {out}/scorecard.md + bakeoff_semantic.png")
+    print("TODO: footprint IoU vs hand-marked objects (needs instance segmentation)")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/semantic_bev/geometry.py
+++ b/script/semantic_bev/geometry.py
@@ -1,0 +1,252 @@
+"""Pure-geometry ground model: gravity-aligned DEM + ground/vertical split.
+
+This is the *geometry front-end* for the semantic-BEV pipeline, deliberately kept
+independent of semantics. Given a point cloud (COLMAP sparse points today, MVS/2DGS
+surfels later) it produces three things the rest of the pipeline consumes:
+
+  1. a **gravity-aligned frame** (full rotation, not axis-snapping) so "up" is true
+     gravity and the two horizontal axes are level;
+  2. a robust **ground height field** (DEM) -- the lower envelope of the cloud, pinned
+     to the ground and smoothed only across *observed* cells;
+  3. a per-point **height-above-ground (HAG)** and a ground / vertical / floater split.
+
+Why geometry-first (vs. the semantics-defines-ground design in ground_model.py):
+On the refined LAR model the point tracks/colours/errors are stripped, so track-pixel
+semantic voting cannot run -- but the geometry is still excellent (ground sharp to
+~15-20 cm where cameras walked). Nailing the DEM + HAG first gives every later stage a
+clean scaffold: height for the BEV, a ground mask for semantic projection, and a
+vertical/obstacle mask for occupancy. Semantics then colours this surface via dense-mask
+projection (poses + intrinsics), which needs no tracks.
+
+Design notes that matter:
+- **Gravity is measured, not guessed.** ``gravity_up`` averages camera image-up over all
+  frames (phones held upright). A 1 deg residual tilt is ~1.5 m of false slope across a
+  90 m park, so we rotate by the *full* vector and keep the horizontal axes level.
+- **DEM = robust lower envelope.** Ground points form a razor-sharp bottom cluster;
+  vegetation stacks above it. A low per-cell quantile seeds the surface; an iterative
+  refit inside an *asymmetric* band (tight below, looser above) locks it to the ground
+  without climbing into the bush/canopy layer.
+- **Smooth only within coverage.** Most cells (a walked park is mostly unvisited) have no
+  ground points; naive blurring bleeds the flat extrapolated fill up into real ground.
+  We use normalised convolution (blur observed / blur mask) so unobserved cells never
+  drag the surface, then nearest-fill the remainder purely for a continuous raster.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+# ----- gravity alignment -------------------------------------------------------
+
+def _qvec2rotmat(q: np.ndarray) -> np.ndarray:
+    w, x, y, z = q
+    return np.array([[1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+                     [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+                     [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)]])
+
+
+def gravity_up(qvecs: np.ndarray) -> np.ndarray:
+    """World-space up unit vector, averaged over camera orientations.
+
+    COLMAP cameras look +Z_cam with +Y_cam pointing *down* in the image, so world-up for
+    an upright phone is ``-R[1, :]``. Averaging over frames cancels per-frame tilt.
+    ``qvecs`` is (N, 4) COLMAP quaternions [qw, qx, qy, qz].
+    """
+    ups = np.array([-_qvec2rotmat(q)[1, :] for q in qvecs])
+    m = ups.mean(0)
+    return m / (np.linalg.norm(m) + 1e-12)
+
+
+def align_rotation(up: np.ndarray) -> np.ndarray:
+    """3x3 rotation mapping world -> local so gravity-up becomes +Z, horizontals level.
+
+    Rows are the local axes in world coords; ``local = R @ world``.
+    """
+    up = up / np.linalg.norm(up)
+    a = np.array([1.0, 0, 0]) if abs(up[0]) < 0.9 else np.array([0, 1.0, 0])
+    x = a - up * (a @ up)
+    x /= np.linalg.norm(x)
+    y = np.cross(up, x)
+    return np.stack([x, y, up])
+
+
+# ----- grid / DEM --------------------------------------------------------------
+
+@dataclass
+class GridSpec:
+    cell_size: float
+    origin_u: float           # world (local-frame) coord of column 0
+    origin_v: float           # world (local-frame) coord of row 0
+    cols: int
+    rows: int
+
+
+@dataclass
+class GroundField:
+    spec: GridSpec
+    dem: np.ndarray           # (rows, cols) float32 ground height (metres, +up)
+    coverage: np.ndarray      # (rows, cols) bool: cell had ground points (DEM trusted)
+    R: np.ndarray             # (3,3) world->local gravity-aligned rotation
+    up: np.ndarray            # (3,) world-space gravity-up unit vector
+
+    def cell_of(self, uv: np.ndarray) -> np.ndarray:
+        """Map local-frame (N,2) horizontal coords -> flat cell ids (clipped)."""
+        ix = np.clip(((uv[:, 0] - self.spec.origin_u) / self.spec.cell_size).astype(np.int64),
+                     0, self.spec.cols - 1)
+        iy = np.clip(((uv[:, 1] - self.spec.origin_v) / self.spec.cell_size).astype(np.int64),
+                     0, self.spec.rows - 1)
+        return iy * self.spec.cols + ix
+
+    def height_at(self, uv: np.ndarray) -> np.ndarray:
+        """Ground height sampled at local-frame (N,2) horizontal coords."""
+        return self.dem.reshape(-1)[self.cell_of(uv)]
+
+
+def _cell_quantile(cell_ids: np.ndarray, values: np.ndarray, ncells: int,
+                   q: float, mincount: int) -> tuple[np.ndarray, np.ndarray]:
+    """Per-cell quantile + count (vectorised group-by via sort)."""
+    out = np.full(ncells, np.nan, np.float32)
+    cnt = np.zeros(ncells, np.int32)
+    if len(cell_ids) == 0:
+        return out, cnt
+    order = np.argsort(cell_ids, kind="stable")
+    cs, vs = cell_ids[order], values[order]
+    bounds = np.flatnonzero(np.diff(cs)) + 1
+    starts = np.concatenate(([0], bounds))
+    ends = np.concatenate((bounds, [len(cs)]))
+    for s, e in zip(starts, ends):
+        c = cs[s]
+        cnt[c] = e - s
+        if e - s >= mincount:
+            out[c] = np.quantile(vs[s:e], q)
+    return out, cnt
+
+
+def _nearest_fill(grid: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    """Fill invalid cells with nearest valid value (cv2 distance transform, no scipy)."""
+    if valid.all() or not valid.any():
+        return grid
+    holes = (~valid).astype(np.uint8)
+    _, labels = cv2.distanceTransformWithLabels(
+        holes, cv2.DIST_L2, 3, labelType=cv2.DIST_LABEL_PIXEL)
+    lut = np.zeros(labels.max() + 1, grid.dtype)
+    lut[labels[valid]] = grid[valid]
+    return lut[labels]
+
+
+def _normalised_blur(field: np.ndarray, valid: np.ndarray, sigma: float) -> np.ndarray:
+    """Gaussian-smooth ``field`` using only ``valid`` cells (normalised convolution).
+
+    Unobserved cells contribute nothing and are not dragged toward the fill value, so
+    real ground never gets pulled up by the flat extrapolated background.
+    """
+    w = valid.astype(np.float32)
+    num = cv2.GaussianBlur(np.where(valid, field, 0).astype(np.float32), (0, 0), sigma)
+    den = cv2.GaussianBlur(w, (0, 0), sigma)
+    out = np.where(den > 1e-6, num / np.maximum(den, 1e-6), field)
+    return out.astype(np.float32)
+
+
+def build_dem(local_uv: np.ndarray, height: np.ndarray, R: np.ndarray, up: np.ndarray, *,
+              cell_size: float = 0.5, bounds_pct: float = 0.5,
+              seed_q: float = 0.08, refit_q: float = 0.25,
+              band_below: float = 0.25, band_above: float = 0.35,
+              iters: int = 4, smooth_sigma: float = 1.2, min_seed: int = 3,
+              log=print) -> GroundField:
+    """Robust lower-envelope ground DEM from gravity-aligned points.
+
+    ``local_uv`` is (N,2) horizontal coords in the gravity-aligned frame, ``height`` the
+    matching (N,) up-axis coord. Seeds with a low per-cell quantile then iteratively
+    refits inside an asymmetric band so the surface locks to the ground, not vegetation.
+    """
+    u, v = local_uv[:, 0], local_uv[:, 1]
+    lo_u, hi_u = np.percentile(u, [bounds_pct, 100 - bounds_pct])
+    lo_v, hi_v = np.percentile(v, [bounds_pct, 100 - bounds_pct])
+    cols = int(np.ceil((hi_u - lo_u) / cell_size)) + 1
+    rows = int(np.ceil((hi_v - lo_v) / cell_size)) + 1
+    spec = GridSpec(cell_size, float(lo_u), float(lo_v), cols, rows)
+    ncells = rows * cols
+    log(f"  grid {cols}x{rows} @ {cell_size} m "
+        f"({cols * cell_size:.0f}x{rows * cell_size:.0f} m), {len(height)} pts")
+
+    ix = np.clip(((u - lo_u) / cell_size).astype(np.int64), 0, cols - 1)
+    iy = np.clip(((v - lo_v) / cell_size).astype(np.int64), 0, rows - 1)
+    cid = iy * cols + ix
+
+    # Seed: low quantile per cell = lower envelope.
+    seed, cnt = _cell_quantile(cid, height, ncells, seed_q, min_seed)
+    valid = (cnt >= min_seed).reshape(rows, cols)
+    g = _normalised_blur(np.nan_to_num(seed).reshape(rows, cols).astype(np.float32),
+                         valid, smooth_sigma)
+    g = _nearest_fill(g, valid)     # continuous raster for sampling; trust = `coverage`
+
+    # Iterative asymmetric refit: pull the surface onto the ground cluster.
+    coverage = valid
+    for it in range(iters):
+        hag = height - g.reshape(-1)[cid]
+        inl = (hag > -band_below) & (hag < band_above)
+        refit, rc = _cell_quantile(cid[inl], height[inl], ncells, refit_q, 2)
+        cov = (rc >= 2).reshape(rows, cols)
+        gnew = _normalised_blur(np.nan_to_num(refit).reshape(rows, cols).astype(np.float32),
+                                cov, smooth_sigma)
+        gnew = _nearest_fill(gnew, cov)
+        delta = float(np.abs(gnew - g)[cov].mean()) if cov.any() else 0.0
+        g, coverage = gnew, cov
+        log(f"  iter{it}: inliers={inl.mean():.2f} meanΔ={delta:.3f} m "
+            f"coverage={cov.mean() * 100:.1f}%")
+
+    # Soften the extrapolated fill: nearest-fill leaves blocky Voronoi steps in
+    # unobserved cells (untrusted, but ugly and bad for gradients/hillshade). Blur only
+    # the holes; observed cells stay exact.
+    holes = ~coverage
+    if holes.any():
+        soft = cv2.GaussianBlur(g, (0, 0), max(2.0, 8.0 * 0.5 / cell_size))
+        g = np.where(coverage, g, soft).astype(np.float32)
+
+    return GroundField(spec, g.astype(np.float32), coverage, R, up)
+
+
+# ----- per-point classification ------------------------------------------------
+
+GROUND, VERTICAL, FLOATER = 0, 1, 2
+
+
+def classify_points(local_uv: np.ndarray, height: np.ndarray, gf: GroundField, *,
+                    band_below: float = 0.25, band_above: float = 0.35
+                    ) -> tuple[np.ndarray, np.ndarray]:
+    """Return (hag, label) where label in {GROUND, VERTICAL, FLOATER} by height-above-ground."""
+    hag = height - gf.height_at(local_uv)
+    label = np.full(len(hag), VERTICAL, np.uint8)
+    label[hag <= -band_below] = FLOATER
+    label[(hag > -band_below) & (hag < band_above)] = GROUND
+    return hag, label
+
+
+# ----- convenience: from a COLMAP reconstruction -------------------------------
+
+def from_reconstruction(recon, *, cell_size: float = 0.5, log=print, **dem_kw):
+    """One-call geometry: gravity-align a COLMAP recon, build the DEM, classify points.
+
+    Returns (gf, local_xyz, hag, label). ``local_xyz`` is every point in the gravity-
+    aligned frame (columns u, v, height).
+    """
+    xyz = np.array([p.xyz for p in recon.points3d.values()])
+    up = gravity_up(np.array([im.qvec for im in recon.images.values()]))
+    R = align_rotation(up)
+    local = (R @ xyz.T).T
+    axis = int(np.argmax(np.abs(up)))
+    tilt = np.degrees(np.arccos(min(abs(up[axis]), 1.0)))
+    log(f"gravity up = [{up[0]:+.4f} {up[1]:+.4f} {up[2]:+.4f}]  "
+        f"({tilt:.2f} deg off axis {axis})")
+    gf = build_dem(local[:, :2], local[:, 2], R, up, cell_size=cell_size, log=log, **dem_kw)
+    hag, label = classify_points(local[:, :2], local[:, 2], gf)
+    n = len(label)
+    log(f"  points: ground={np.mean(label == GROUND) * 100:.0f}% "
+        f"vertical={np.mean(label == VERTICAL) * 100:.0f}% "
+        f"floater={np.mean(label == FLOATER) * 100:.0f}%  (n={n})")
+    return gf, local, hag, label

--- a/script/semantic_bev/geometry_cli.py
+++ b/script/semantic_bev/geometry_cli.py
@@ -1,0 +1,152 @@
+"""CLI + diagnostic renders for the pure-geometry ground model (geometry.py).
+
+Run on a COLMAP text model; emits a DEM hillshade, structure-height map, ground/vertical
+density, camera-trajectory overlay, and vertical cross-sections so ground extraction
+quality can be judged by eye.
+
+    uv run python geometry_cli.py \
+        --model ../../output/maguro-park-after-itchy-refined/sparse/0 \
+        --out   ../../output/maguro-park-after-itchy-geom \
+        --cell-size 0.5
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from colmap_io import read_model
+import geometry as G
+
+
+def _colorize(field, valid, cmap=cv2.COLORMAP_TURBO, lo=None, hi=None):
+    v = field[valid]
+    if lo is None:
+        lo, hi = np.percentile(v, [2, 98]) if valid.any() else (0.0, 1.0)
+    n = np.clip((field - lo) / max(hi - lo, 1e-6), 0, 1)
+    img = cv2.applyColorMap((n * 255).astype(np.uint8), cmap)
+    img[~valid] = (35, 35, 35)
+    return img
+
+
+def _hillshade(dem, cell, az=315.0, alt=45.0):
+    gy, gx = np.gradient(dem, cell)
+    normal = np.dstack([-gx, -gy, np.ones_like(dem)])
+    normal /= np.linalg.norm(normal, axis=2, keepdims=True)
+    a, e = np.radians(az), np.radians(alt)
+    light = np.array([np.cos(e) * np.cos(a), np.cos(e) * np.sin(a), np.sin(e)])
+    return np.clip(normal @ light, 0, 1)
+
+
+def render(gf: G.GroundField, local, hag, label, cams_local, out: Path, log=print):
+    out.mkdir(parents=True, exist_ok=True)
+    s = gf.spec
+    rows, cols = s.rows, s.cols
+    cid = gf.cell_of(local[:, :2])
+    flip = np.flipud  # north-up: +v downward in array -> flip for display
+
+    # 1. DEM height, hill-shaded, masked to covered area (extrapolation dimmed).
+    shade = _hillshade(gf.dem, s.cell_size)
+    dem_rgb = _colorize(gf.dem, gf.coverage)
+    dem_rgb = (dem_rgb.astype(np.float32) * (0.35 + 0.65 * shade[..., None])).astype(np.uint8)
+    dem_rgb[~gf.coverage] = (dem_rgb[~gf.coverage] * 0.35).astype(np.uint8)
+    cv2.imwrite(str(out / "dem_hillshade.png"), flip(dem_rgb))
+
+    # 2. Structure height = 95th pct HAG of vertical points per cell.
+    vmask = label == G.VERTICAL
+    sh, _ = G._cell_quantile(cid[vmask], hag[vmask], rows * cols, 0.95, 1)
+    sh = np.nan_to_num(sh).reshape(rows, cols).clip(0, 8)
+    cv2.imwrite(str(out / "structure_height.png"),
+                flip(_colorize(sh, sh > 0, cv2.COLORMAP_MAGMA, 0, 6)))
+
+    # 3. Ground (green) vs vertical (red) point density.
+    gcnt = np.bincount(cid[label == G.GROUND], minlength=rows * cols).reshape(rows, cols)
+    vcnt = np.bincount(cid[vmask], minlength=rows * cols).reshape(rows, cols)
+    gv = np.zeros((rows, cols, 3), np.uint8)
+    gv[..., 1] = np.clip(gcnt * 40, 0, 255)
+    gv[..., 2] = np.clip(vcnt * 40, 0, 255)
+    cv2.imwrite(str(out / "ground_vs_vertical.png"), flip(gv))
+
+    # 4. Camera trajectory over the DEM (orientation / registration sanity).
+    traj = dem_rgb.copy()
+    px = np.clip(((cams_local[:, 0] - s.origin_u) / s.cell_size).astype(int), 0, cols - 1)
+    py = np.clip(((cams_local[:, 1] - s.origin_v) / s.cell_size).astype(int), 0, rows - 1)
+    for x, y in zip(px, py):
+        cv2.circle(traj, (x, y), 1, (0, 255, 255), -1)
+    cv2.imwrite(str(out / "camera_trajectory.png"), flip(traj))
+
+    # 5. Vertical cross-sections at 3 u-slices (the real ground-quality test).
+    #    Rendered with cv2 (no matplotlib dep): points coloured by class, DEM overlaid
+    #    solid where observed / faint where extrapolated.
+    u, v, h = local[:, 0], local[:, 1], local[:, 2]
+    panels = []
+    W, H, pad = 1200, 300, 40
+    for uc in np.percentile(u, [35, 50, 65]):
+        m = np.abs(u - uc) < 1.0
+        canvas = np.full((H, W, 3), 255, np.uint8)
+        vmin, vmax = np.percentile(v[m], [0, 100])
+        h0 = np.percentile(h[m], 1)
+        hmin, hmax = h0 - 1.0, h0 + 8.0
+
+        def to_px(vv, hh):
+            x = pad + (vv - vmin) / max(vmax - vmin, 1e-6) * (W - 2 * pad)
+            y = H - pad - (hh - hmin) / max(hmax - hmin, 1e-6) * (H - 2 * pad)
+            return x.astype(int), y.astype(int)
+
+        # gridlines every 1 m in height
+        for hh in np.arange(np.ceil(hmin), hmax, 1.0):
+            _, y = to_px(np.array([vmin]), np.array([hh]))
+            cv2.line(canvas, (pad, int(y[0])), (W - pad, int(y[0])), (235, 235, 235), 1)
+        for lb, col in [(G.GROUND, (34, 187, 34)), (G.VERTICAL, (34, 34, 204)),
+                        (G.FLOATER, (204, 136, 34))]:  # BGR
+            mm = m & (label == lb)
+            xs, ys = to_px(v[mm], h[mm])
+            ok = (ys >= 0) & (ys < H)
+            canvas[np.clip(ys[ok], 0, H - 1), np.clip(xs[ok], 0, W - 1)] = col
+        # DEM polyline for this slice
+        ii = int(np.clip((uc - s.origin_u) / s.cell_size, 0, cols - 1))
+        vs = s.origin_v + np.arange(rows) * s.cell_size
+        inside = (vs >= vmin) & (vs <= vmax)
+        xd, yd = to_px(vs, gf.dem[:, ii])
+        covc = gf.coverage[:, ii]
+        for j in range(rows - 1):
+            if not (inside[j] and inside[j + 1]):
+                continue
+            trusted = covc[j] and covc[j + 1]
+            cv2.line(canvas, (xd[j], yd[j]), (xd[j + 1], yd[j + 1]),
+                     (0, 0, 0) if trusted else (180, 180, 180), 2 if trusted else 1)
+        cv2.putText(canvas, f"u={uc:.1f}m (+/-1m)  black=observed DEM  grey=extrap",
+                    (pad, 24), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (0, 0, 0), 1)
+        panels.append(canvas)
+    cv2.imwrite(str(out / "cross_sections.png"), np.vstack(panels))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", required=True, help="COLMAP text model dir")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--cell-size", type=float, default=0.5)
+    args = ap.parse_args()
+
+    print(f"reading {args.model} ...")
+    recon = read_model(args.model)
+    print(f"  images={len(recon.images)} points={recon.num_points}")
+    gf, local, hag, label = G.from_reconstruction(recon, cell_size=args.cell_size)
+
+    cams = np.array([-G._qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
+    cams_local = (gf.R @ cams.T).T
+
+    out = Path(args.out)
+    render(gf, local, hag, label, cams_local, out)
+    np.savez_compressed(out / "ground_field.npz", dem=gf.dem, coverage=gf.coverage,
+                        R=gf.R, up=gf.up,
+                        origin=np.array([gf.spec.origin_u, gf.spec.origin_v]),
+                        cell_size=gf.spec.cell_size)
+    print(f"wrote renders + ground_field.npz to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/semantic_bev/grid_transform.py
+++ b/script/semantic_bev/grid_transform.py
@@ -1,0 +1,51 @@
+"""Single source of truth for grid-cell <-> world-metre conversion.
+
+The raster's row axis is **gravity-canonical**: `row = v_sign * world[v_axis]` (set once in
+`ground_model.build_level`, so a Y-up and a Y-down source model rasterise the same way). Every
+converter that turns a `(col, row)` into world metres — or back — MUST go through here, so the
+sign lives in exactly one place. A forgotten sign silently mirrors the map (that is precisely
+the bug this module exists to make unrepresentable).
+
+Accepts either the `meta` dict (from `level0.meta.json`) or a `GridSpec` object.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _get(spec, key: str):
+    return spec[key] if isinstance(spec, dict) else getattr(spec, key)
+
+
+def _v_sign(spec) -> float:
+    try:
+        return float(_get(spec, "v_sign"))
+    except (KeyError, AttributeError):
+        return 1.0  # pre-canonical metas default to no flip
+
+
+def cell_to_world(col, row, spec):
+    """(col, row) grid indices -> (u, v) world metres along the two horizontal axes.
+
+    Scalars or numpy arrays. For a cell *centre* pass ``col + 0.5``, ``row + 0.5``.
+    """
+    cs = _get(spec, "cell_size")
+    u = _get(spec, "origin_u") + np.asarray(col, dtype=np.float64) * cs
+    v = _v_sign(spec) * (_get(spec, "origin_v") + np.asarray(row, dtype=np.float64) * cs)
+    return u, v
+
+
+def world_to_cell(u, v, spec):
+    """(u, v) world metres -> fractional (col, row) grid indices (inverse of cell_to_world)."""
+    cs = _get(spec, "cell_size")
+    col = (np.asarray(u, dtype=np.float64) - _get(spec, "origin_u")) / cs
+    row = (_v_sign(spec) * np.asarray(v, dtype=np.float64) - _get(spec, "origin_v")) / cs
+    return col, row
+
+
+def cells_to_world(colrow, spec):
+    """(N,2) array of (col,row) -> (N,2) array of (u,v) world metres."""
+    colrow = np.asarray(colrow, dtype=np.float64)
+    u, v = cell_to_world(colrow[:, 0], colrow[:, 1], spec)
+    return np.stack([u, v], axis=1)

--- a/script/semantic_bev/ground_model.py
+++ b/script/semantic_bev/ground_model.py
@@ -38,6 +38,8 @@ class GridSpec:
     origin_v: float           # world coord of row 0 (second horizontal axis)
     cols: int
     rows: int
+    v_sign: float = 1.0       # canonical row = v_sign * world[v_axis]; ties the overhead
+                              # orientation to gravity, not the model's Y-up/Y-down convention
 
     @property
     def horiz_axes(self) -> tuple[int, int]:
@@ -49,7 +51,8 @@ class Level:
     ordinal: int
     spec: GridSpec
     height: np.ndarray        # (rows, cols) float32, nan where unobserved
-    semantic: np.ndarray      # (rows, cols) uint8 Klass
+    semantic: np.ndarray      # (rows, cols) uint8 Klass -- the *ground* surface class
+    structure: np.ndarray     # (rows, cols) uint8 Klass -- dominant *vertical* class (UNKNOWN=none)
     occupancy: np.ndarray     # (rows, cols) uint8
     coverage: np.ndarray      # (rows, cols) bool
 
@@ -117,10 +120,10 @@ def _nearest_fill(grid: np.ndarray, valid: np.ndarray) -> np.ndarray:
 
 def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarray,
                 cell_size: float = 0.5, up_axis: int = 1, up_sign: float = 1.0,
-                ground_quantile: float = 0.2, obstacle_band: tuple[float, float] = (0.3, 2.2),
+                ground_quantile: float = 0.2,
                 bounds_pct: float = 0.02, ground_height_clip: tuple[float, float] = (0.01, 0.99),
-                min_obstacle_count: int = 3, obstacle_dominance: float = 1.0,
-                occupancy_morph: bool = True,
+                min_obstacle_count: int = 3, min_structure_count: int = 2,
+                solid_gap: float = 0.8, occupancy_morph: bool = True,
                 fill_holes: bool = True, ordinal: int = 0, log=print) -> Level:
     """Rasterise labelled points into a single ground Level."""
     roles = np.array([int(role_of(k)) for k in range(int(max(Klass)) + 1)])[labels]
@@ -128,8 +131,14 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     is_obstacle = roles == int(Role.OBSTACLE)
 
     u_axis, v_axis = (a for a in (0, 1, 2) if a != up_axis)
+    # Canonical overhead handedness: the raster's row axis follows gravity (via up_sign),
+    # not the source model's Y-up/Y-down convention. Without this, a model expressed with
+    # +Y-up (up_sign=+1) and the same scene refined to +Y-down (up_sign=-1) rasterise as
+    # vertical mirror images of each other, because the row axis was pinned to world-Z. The
+    # npz stays honest: world[v_axis] = v_sign * (origin_v + row*cell_size). Georef unaffected.
+    v_sign = -up_sign
     u = positions[:, u_axis]
-    v = positions[:, v_axis]
+    v = v_sign * positions[:, v_axis]
     height = up_sign * positions[:, up_axis]
 
     # Drop SfM floaters: keep ground candidates within a robust global height band. Real
@@ -152,7 +161,7 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     lo_v, hi_v = np.quantile(v[keep], [bounds_pct, 1 - bounds_pct])
     cols = int(np.ceil((hi_u - lo_u) / cell_size)) + 1
     rows = int(np.ceil((hi_v - lo_v) / cell_size)) + 1
-    spec = GridSpec(cell_size, up_axis, up_sign, float(lo_u), float(lo_v), cols, rows)
+    spec = GridSpec(cell_size, up_axis, up_sign, float(lo_u), float(lo_v), cols, rows, v_sign=v_sign)
     ncells = rows * cols
     log(f"  grid {cols}x{rows} @ {cell_size} m ({cols * cell_size:.0f}x{rows * cell_size:.0f} m)")
 
@@ -179,19 +188,32 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     else:
         height_out = height_raster
 
-    # Occupancy = walkability, not "is there anything above the ground". On narrow forest
-    # paths, foliage/branches overhang walkable ground and drop obstacle points into the band,
-    # so "any obstacle point -> blocked" false-blocks the paths the operator literally walked.
-    # Instead block only where obstacle points *dominate* ground points: a trunk/wall/bush has
-    # many obstacle points and little ground beneath it, whereas a path is ground-dominant with
-    # only overhang above. Then require a minimum count and drop isolated specks.
+    # ----- structure footprint + occupancy (solid-to-ground test) --------------
+    # Two independent questions per cell, kept in two rasters:
+    #   structure  -- *what* vertical thing is here: the dominant obstacle class, recorded
+    #                 wherever obstacle points land, walkable underneath or not.
+    #   occupancy  -- *can you walk here*: geometry, not mere presence. A barrier is BLOCKED
+    #                 only when its points reach down near the ground (building / wall / trunk /
+    #                 bush). Tree canopy overhanging a path leaves a clearance gap above the
+    #                 ground, so it stays FREE -- you walk under it (the operator did). This is
+    #                 why "any obstacle point -> blocked" over-blocks tree-lined paths.
     o_cells = cell_of(is_obstacle)
-    delta = height[is_obstacle] - height_out.reshape(-1)[o_cells]
-    lo_b, hi_b = obstacle_band
-    in_band = o_cells[(delta >= lo_b) & (delta <= hi_b)]
-    obs_count = np.bincount(in_band, minlength=ncells).reshape(rows, cols)
-    grd_count = g_count.reshape(rows, cols)
-    blocked = (obs_count >= min_obstacle_count) & (obs_count >= obstacle_dominance * grd_count)
+    obs_count = np.bincount(o_cells, minlength=ncells)
+
+    # Structure class: confidence-weighted obstacle majority where enough points landed.
+    structure_flat = _grouped_majority(o_cells, labels[is_obstacle], confidence[is_obstacle],
+                                       ncells, n_klass)
+    structure_flat[obs_count < min_structure_count] = int(Klass.UNKNOWN)
+    structure = structure_flat.reshape(rows, cols)
+
+    # Solidity: low quantile of the obstacle points' height-above-ground. Small -> the column
+    # reaches the ground (solid); large -> only high overhang (canopy) with walkable clearance.
+    # A low quantile (not the min) so one stray low point can't fake solidity under a canopy.
+    obs_hag = height[is_obstacle] - height_out.reshape(-1)[o_cells]
+    base_hag, _ = _grouped_reduce(o_cells, obs_hag, ncells, "quantile", q=0.1)
+    base_hag = base_hag.reshape(rows, cols)
+    obs_count2d = obs_count.reshape(rows, cols)
+    blocked = (obs_count2d >= min_obstacle_count) & np.isfinite(base_hag) & (base_hag <= solid_gap)
     raw_blocked = int(blocked.sum())
 
     if occupancy_morph and blocked.any():
@@ -207,9 +229,10 @@ def build_level(positions: np.ndarray, labels: np.ndarray, confidence: np.ndarra
     occ[blocked] = BLOCKED
     occupancy = occ
 
-    log(f"  ground cells {int(coverage.sum())}/{ncells} observed"
-        f" ({100 * coverage.mean():.1f}%); blocked {raw_blocked} -> {int(blocked.sum())} after cleanup")
-    return Level(ordinal, spec, height_out, semantic, occupancy, coverage)
+    n_struct = int((structure != int(Klass.UNKNOWN)).sum())
+    log(f"  ground cells {int(coverage.sum())}/{ncells} observed ({100 * coverage.mean():.1f}%); "
+        f"structure cells {n_struct}; blocked {raw_blocked} -> {int(blocked.sum())} after cleanup")
+    return Level(ordinal, spec, height_out, semantic, structure, occupancy, coverage)
 
 
 # ----- export ------------------------------------------------------------------
@@ -233,20 +256,20 @@ def save_level(level: Level, out_dir: str | Path, prefix: str = "level0") -> Non
 
     np.savez_compressed(
         d / f"{prefix}.npz",
-        height=level.height, semantic=level.semantic,
+        height=level.height, semantic=level.semantic, structure=level.structure,
         occupancy=level.occupancy, coverage=level.coverage,
     )
     with open(d / f"{prefix}.meta.json", "w") as f:
         json.dump({
             "ordinal": level.ordinal, "cell_size": s.cell_size,
-            "up_axis": s.up_axis, "up_sign": s.up_sign,
+            "up_axis": s.up_axis, "up_sign": s.up_sign, "v_sign": s.v_sign,
             "origin_u": s.origin_u, "origin_v": s.origin_v,
             "cols": s.cols, "rows": s.rows,
         }, f, indent=2)
 
-    # Orientation: col = +u (=+X), row = +v (=+Z). Shown as-is this is a NON-mirrored
-    # top-down (screen-right=+X, screen-up=-Z), verified against the ARKit trajectory
-    # (Kabsch det=+1, RMSE~0). Do NOT flipud -- that mirrors the map left/right.
+    # Orientation: col = +u (=+X), row = +v where v = -up_sign * world[v_axis]. The row axis
+    # is gravity-canonical (see build_level), so the overhead view renders the same regardless
+    # of whether the source model is Y-up or Y-down. Shown as-is (no flipud -- that mirrors L/R).
     def up(img):
         return img
 
@@ -256,6 +279,12 @@ def save_level(level: Level, out_dir: str | Path, prefix: str = "level0") -> Non
     sem_rgb = lut[level.semantic]
     sem_rgb[~level.coverage] = (30, 30, 30)
     cv2.imwrite(str(d / f"{prefix}_semantic.png"), up(cv2.cvtColor(sem_rgb, cv2.COLOR_RGB2BGR)))
+
+    # Structure footprints (vertical classes): building/wall/tree/... over dimmed ground.
+    struct_rgb = (0.30 * sem_rgb).astype(np.uint8)
+    has_struct = level.structure != int(Klass.UNKNOWN)
+    struct_rgb[has_struct] = lut[level.structure[has_struct]]
+    cv2.imwrite(str(d / f"{prefix}_structure.png"), up(cv2.cvtColor(struct_rgb, cv2.COLOR_RGB2BGR)))
 
     occ_rgb = np.zeros((*level.occupancy.shape, 3), np.uint8)
     occ_rgb[level.occupancy == FREE] = (60, 180, 60)

--- a/script/semantic_bev/gsplat_source.py
+++ b/script/semantic_bev/gsplat_source.py
@@ -1,0 +1,89 @@
+"""Geometry source: a trained *semantic* 3DGS model -> (positions, labels, confidence).
+
+An alternative to the COLMAP sparse-point source (`colmap_io` + `labeling`). A semantic
+3DGS run (``script/gsplat/train.py --semantic``) bakes a taxonomy class into every
+Gaussian, so the BEV builder can consume the Gaussians directly:
+
+  - **denser** than COLMAP tracks (a whole optimised splat cloud, not just triangulated
+    keypoints), and
+  - **already labelled** — no segmentation/voting pass needed here; the labels were
+    distilled multi-view-consistently during Phase 2 of the gsplat trainer.
+
+Returns the same ``(positions, labels, confidence)`` triple as the COLMAP path, so
+``ground_model.build_level`` is unchanged. The gsplat model is in the *same world
+coordinates* as the COLMAP model it was trained from, so gravity/up detection (which needs
+camera orientations) still comes from that COLMAP model in ``pipeline.py``.
+
+Consumes the gsplat run's export dir:
+  point_cloud.ply            -- Gaussian means (+ opacity, used to prune floaters)
+  point_cloud_labels.npy     -- per-Gaussian Klass id  (row-aligned with the .ply)
+  point_cloud_confidence.npy -- per-Gaussian peak softmax prob (optional; 1.0 if absent)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+
+def _read_float_ply(path: Path) -> dict[str, np.ndarray]:
+    """Read an all-float32 binary_little_endian PLY (the format script/gsplat writes).
+
+    Only 'property float <name>' vertex fields are supported -- which is exactly what the
+    gsplat exporter emits. Returns {field_name: (N,) float32}.
+    """
+    with open(path, "rb") as f:
+        if f.readline().strip() != b"ply":
+            raise ValueError(f"{path} is not a PLY file")
+        fmt = f.readline().strip()
+        if b"binary_little_endian" not in fmt:
+            raise ValueError(f"{path}: only binary_little_endian PLY is supported, got {fmt!r}")
+        count, names = None, []
+        while True:
+            line = f.readline().strip()
+            if line.startswith(b"element vertex"):
+                count = int(line.split()[-1])
+            elif line.startswith(b"property"):
+                parts = line.split()
+                if parts[1] != b"float":
+                    raise ValueError(f"{path}: non-float property {line!r} not supported")
+                names.append(parts[-1].decode())
+            elif line == b"end_header":
+                break
+        dtype = np.dtype([(n, "<f4") for n in names])
+        data = np.frombuffer(f.read(count * dtype.itemsize), dtype=dtype, count=count)
+    return {n: np.ascontiguousarray(data[n]) for n in names}
+
+
+def load_gsplat_points(gsplat_dir: str | Path, min_opacity: float = 0.1,
+                       log=print) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Load a semantic 3DGS export as ``(positions (N,3), labels (N,) uint8, conf (N,))``.
+
+    Gaussians with opacity below ``min_opacity`` are dropped: 3DGS leaves many faint
+    floaters that are visually minor but geometric noise for a ground/height model.
+    """
+    d = Path(gsplat_dir)
+    ply = _read_float_ply(d / "point_cloud.ply")
+    positions = np.stack([ply["x"], ply["y"], ply["z"]], axis=1).astype(np.float64)
+    # 'opacity' is stored as a logit (pre-sigmoid), matching the trainer's representation.
+    opacity = 1.0 / (1.0 + np.exp(-ply["opacity"])) if "opacity" in ply else np.ones(len(positions))
+
+    labels = np.load(d / "point_cloud_labels.npy").astype(np.uint8)
+    conf_path = d / "point_cloud_confidence.npy"
+    if conf_path.exists():
+        confidence = np.load(conf_path).astype(np.float32)
+    else:
+        confidence = np.ones(len(labels), dtype=np.float32)
+        log("  no _confidence.npy (older gsplat run); using uniform confidence 1.0")
+
+    if not (len(positions) == len(labels) == len(confidence)):
+        raise ValueError(
+            f"gsplat export row mismatch: {len(positions)} points, {len(labels)} labels, "
+            f"{len(confidence)} conf -- point_cloud.ply and the .npy files must be aligned"
+        )
+
+    keep = opacity >= min_opacity
+    log(f"  gsplat: {len(positions)} Gaussians, kept {int(keep.sum())} "
+        f"with opacity >= {min_opacity}")
+    return positions[keep], labels[keep], confidence[keep]

--- a/script/semantic_bev/imdf_export.py
+++ b/script/semantic_bev/imdf_export.py
@@ -30,6 +30,7 @@ from shapely.geometry.polygon import orient
 from shapely.ops import unary_union
 
 from colmap_io import qvec2rotmat, read_model
+from grid_transform import cells_to_world
 from taxonomy import CLASSES, Klass
 
 # --- allowed category enums (OGC IMDF 1.0.0 / docs.ogc.org/cs/20-094) ---------------
@@ -96,10 +97,7 @@ def fit_world_to_wgs84(recon, frames_path: str | Path, gps_path: str | Path):
 
 def _pix_to_world(pts_xy: np.ndarray, meta: dict) -> np.ndarray:
     """cv2 contour pixels (col=x, row=y) -> world (X,Z) metres."""
-    world = np.empty_like(pts_xy, dtype=np.float64)
-    world[:, 0] = meta["origin_u"] + pts_xy[:, 0] * meta["cell_size"]  # X
-    world[:, 1] = meta["origin_v"] + pts_xy[:, 1] * meta["cell_size"]  # Z
-    return world
+    return cells_to_world(pts_xy, meta)
 
 
 def mask_to_polygons(binary: np.ndarray, meta: dict, simplify_m: float = 0.5,
@@ -180,7 +178,8 @@ def _geom_wgs84(poly: Polygon, to_wgs84) -> dict:
 def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | Path,
                gps_path: str | Path, venue_name: str = "Maguro Park",
                venue_category: str = "themepark", locality: str = "Tokyo",
-               country: str = "JP", smooth: bool = True, log=print) -> dict:
+               country: str = "JP", smooth: bool = True, paths: str = "polygon",
+               log=print) -> dict:
     d = Path(level_dir)
     meta = json.load(open(d / "level0.meta.json"))
     npz = np.load(d / "level0.npz")
@@ -228,7 +227,7 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
                       "display_point": _display_point(venue_poly, to_wgs84),
                       "address_id": address["id"], "building_ids": None})
 
-    units = []
+    units, routing = [], []
     for category, klasses in cat_classes.items():
         if category not in UNIT_CATEGORIES:
             log(f"  skipping unit category '{category}' (not in IMDF enum)")
@@ -237,10 +236,23 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
         # consolidate before tracing: drop specks (open) then fill pinholes (close).
         k = np.ones((3, 3), np.uint8)
         mask = cv2.morphologyEx(cv2.morphologyEx(mask, cv2.MORPH_OPEN, k), cv2.MORPH_CLOSE, k)
-        polys = mask_to_polygons(mask, meta, simplify_m=0.6, min_area_m2=5.0)
+
+        if category == "walkway" and paths == "centerline":
+            # elegant paths: skeleton -> centerline graph -> constant-width polygons
+            from path_centerlines import centerlines_to_polygons, walkway_centerlines
+            cls = walkway_centerlines(mask, meta)
+            merged = centerlines_to_polygons(cls)
+            for c in cls:
+                ll = to_wgs84(c["line"])
+                if len(ll) >= 2:
+                    routing.append({"coords": [[float(x), float(y)] for x, y in ll.tolist()],
+                                    "width_m": round(c["width"], 2)})
+            log(f"  walkway: {len(cls)} centerline segments")
+        else:
+            polys = mask_to_polygons(mask, meta, simplify_m=0.6, min_area_m2=5.0)
+            merged = unary_union(polys) if polys else None
 
         # merge touching pieces, then cartographically smooth each region
-        merged = unary_union(polys) if polys else None
         parts = ([] if merged is None or merged.is_empty
                  else list(merged.geoms) if merged.geom_type == "MultiPolygon" else [merged])
         cat_polys = []
@@ -259,7 +271,7 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
         "manifest": {"version": "1.0.0", "created": datetime.now(timezone.utc).isoformat(),
                      "generated_by": "lar semantic_bev", "language": "en", "extensions": []},
         "address": [address], "venue": [venue], "level": [level], "unit": units,
-        "_geo": geo,
+        "_geo": geo, "_routing": routing,
     }
 
 
@@ -272,6 +284,15 @@ def write_archive(imdf: dict, out_dir: str | Path, log=print) -> None:
         (out / f"{ftype}.geojson").write_text(json.dumps(fc))
     log(f"wrote IMDF archive -> {out} "
         f"({len(imdf['unit'])} units, {len(imdf['level'])} level, {len(imdf['venue'])} venue)")
+
+    # bonus (not part of the IMDF spec): path centerline graph for LAR navigation
+    routing = imdf.get("_routing") or []
+    if routing:
+        fc = {"type": "FeatureCollection", "name": "routing", "features": [
+            {"type": "Feature", "geometry": {"type": "LineString", "coordinates": r["coords"]},
+             "properties": {"width_m": r["width_m"]}} for r in routing]}
+        (out / "routing.geojson").write_text(json.dumps(fc))
+        log(f"  + routing.geojson ({len(fc['features'])} path centerlines)")
 
 
 # ---- self-validation ----------------------------------------------------------------
@@ -335,11 +356,13 @@ def main() -> None:
     ap.add_argument("--venue-name", default="Maguro Park")
     ap.add_argument("--venue-category", default="themepark", choices=sorted(VENUE_CATEGORIES))
     ap.add_argument("--no-smooth", action="store_true", help="disable cartographic smoothing")
+    ap.add_argument("--paths", default="polygon", choices=["polygon", "centerline"],
+                    help="walkway units: traced polygons, or centerline-graph constant-width paths")
     args = ap.parse_args()
 
     imdf = build_imdf(args.level, args.model, args.frames, args.gps,
                       venue_name=args.venue_name, venue_category=args.venue_category,
-                      smooth=not args.no_smooth)
+                      smooth=not args.no_smooth, paths=args.paths)
     ok = validate(imdf)
     write_archive(imdf, args.out or (Path(args.level) / "imdf"))
     if not ok:

--- a/script/semantic_bev/imdf_export.py
+++ b/script/semantic_bev/imdf_export.py
@@ -128,6 +128,30 @@ def mask_to_polygons(binary: np.ndarray, meta: dict, simplify_m: float = 0.5,
     return polys
 
 
+def smooth_polygon(poly: Polygon, radius: float, simplify_m: float,
+                   min_hole_m2: float = 2.0) -> list[Polygon]:
+    """Cartographic smoothing: rounded morphological open+close (removes pixel-staircase and
+    thin protrusions/nicks), then simplify vertices and drop tiny holes. Returns 0+ polygons."""
+    p = (poly.buffer(-radius, join_style=1)      # open: erode+dilate -> drop protrusions
+         .buffer(2 * radius, join_style=1)        # ...then close: dilate+erode -> fill nicks
+         .buffer(-radius, join_style=1))          # (round joins => smooth curves)
+    if p.is_empty:
+        return []
+    out = []
+    for q in (p.geoms if p.geom_type == "MultiPolygon" else [p]):
+        q = q.simplify(simplify_m, preserve_topology=True)
+        if not q.is_valid:
+            q = q.buffer(0)
+        for r in (q.geoms if q.geom_type == "MultiPolygon" else [q]):
+            if r.geom_type != "Polygon" or r.is_empty:
+                continue
+            holes = [h for h in r.interiors if Polygon(h).area >= min_hole_m2]
+            r = Polygon(r.exterior, holes)
+            if r.is_valid and r.area > 0:
+                out.append(orient(r, sign=1.0))
+    return out
+
+
 # ---- IMDF assembly ------------------------------------------------------------------
 
 def _feature(feature_type: str, geometry, props: dict) -> dict:
@@ -156,7 +180,7 @@ def _geom_wgs84(poly: Polygon, to_wgs84) -> dict:
 def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | Path,
                gps_path: str | Path, venue_name: str = "Maguro Park",
                venue_category: str = "themepark", locality: str = "Tokyo",
-               country: str = "JP", log=print) -> dict:
+               country: str = "JP", smooth: bool = True, log=print) -> dict:
     d = Path(level_dir)
     meta = json.load(open(d / "level0.meta.json"))
     npz = np.load(d / "level0.npz")
@@ -178,13 +202,19 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
                         "province": locality, "country": country, "postal_code": None,
                         "postal_code_ext": None, "postal_code_vanity": None})
 
+    cs = meta["cell_size"]
+    smooth_r, simp_m = 1.4 * cs, 0.8 * cs             # smoothing radius / simplify tol in metres
+
     # venue / level boundary = outer boundary of observed coverage (gaps closed)
     cov = cv2.morphologyEx(coverage.astype(np.uint8), cv2.MORPH_CLOSE, np.ones((5, 5), np.uint8))
     boundary_polys = mask_to_polygons(cov, meta, simplify_m=1.0, min_area_m2=20.0)
     if not boundary_polys:
         raise ValueError("no coverage to form a venue boundary")
-    venue_poly = max(boundary_polys, key=lambda p: p.area)
-    venue_poly = Polygon(venue_poly.exterior)          # venue has no holes
+    venue_poly = Polygon(max(boundary_polys, key=lambda p: p.area).exterior)  # no holes
+    if smooth:
+        parts = smooth_polygon(venue_poly, smooth_r * 2, simp_m * 2)
+        if parts:
+            venue_poly = Polygon(max(parts, key=lambda p: p.area).exterior)
 
     venue = _feature("venue", _geom_wgs84(venue_poly, to_wgs84),
                      {"category": venue_category, "restriction": None, "name": _labels(venue_name),
@@ -204,17 +234,26 @@ def build_imdf(level_dir: str | Path, model_dir: str | Path, frames_path: str | 
             log(f"  skipping unit category '{category}' (not in IMDF enum)")
             continue
         mask = (np.isin(semantic, klasses) & coverage).astype(np.uint8)
-        # consolidate before tracing: drop specks (open) then fill pinholes (close), so we get
-        # a few coherent units instead of hundreds of sliver polygons.
+        # consolidate before tracing: drop specks (open) then fill pinholes (close).
         k = np.ones((3, 3), np.uint8)
         mask = cv2.morphologyEx(cv2.morphologyEx(mask, cv2.MORPH_OPEN, k), cv2.MORPH_CLOSE, k)
         polys = mask_to_polygons(mask, meta, simplify_m=0.6, min_area_m2=5.0)
-        for poly in polys:
+
+        # merge touching pieces, then cartographically smooth each region
+        merged = unary_union(polys) if polys else None
+        parts = ([] if merged is None or merged.is_empty
+                 else list(merged.geoms) if merged.geom_type == "MultiPolygon" else [merged])
+        cat_polys = []
+        for part in parts:
+            cat_polys.extend(smooth_polygon(part, smooth_r, simp_m) if smooth else [part])
+        cat_polys = [p for p in cat_polys if p.area >= 5.0]
+
+        for poly in cat_polys:
             units.append(_feature("unit", _geom_wgs84(poly, to_wgs84),
                                   {"category": category, "restriction": None, "accessibility": None,
                                    "name": None, "alt_name": None, "display_point": None,
                                    "level_id": level["id"]}))
-        log(f"  {category}: {len(polys)} unit polygons")
+        log(f"  {category}: {len(cat_polys)} unit polygons")
 
     return {
         "manifest": {"version": "1.0.0", "created": datetime.now(timezone.utc).isoformat(),
@@ -295,10 +334,12 @@ def main() -> None:
     ap.add_argument("--out", default=None, help="archive dir (default <level>/imdf)")
     ap.add_argument("--venue-name", default="Maguro Park")
     ap.add_argument("--venue-category", default="themepark", choices=sorted(VENUE_CATEGORIES))
+    ap.add_argument("--no-smooth", action="store_true", help="disable cartographic smoothing")
     args = ap.parse_args()
 
     imdf = build_imdf(args.level, args.model, args.frames, args.gps,
-                      venue_name=args.venue_name, venue_category=args.venue_category)
+                      venue_name=args.venue_name, venue_category=args.venue_category,
+                      smooth=not args.no_smooth)
     ok = validate(imdf)
     write_archive(imdf, args.out or (Path(args.level) / "imdf"))
     if not ok:

--- a/script/semantic_bev/labeling.py
+++ b/script/semantic_bev/labeling.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import cv2
 import numpy as np
 
-from colmap_io import Reconstruction
+from colmap_io import Reconstruction, qvec2rotmat
 from segmentation import Segmenter, save_mask_png
 from taxonomy import Klass
 
@@ -69,19 +69,43 @@ def segment_and_cache(recon: Reconstruction, image_dir: str | Path,
     return done
 
 
-def accumulate_votes(recon: Reconstruction, store: MaskStore,
-                     image_ids: list[int]) -> tuple[np.ndarray, np.ndarray, dict[int, int]]:
+def accumulate_votes(recon: Reconstruction, store: MaskStore, image_ids: list[int],
+                     max_depth: float = 30.0, log=print) -> tuple[np.ndarray, np.ndarray, dict[int, int]]:
     """Stream masks and tally per-point class votes.
 
     Returns ``(point_ids, votes, index)`` where ``votes`` is (P, num_classes) uint16 and
     ``index`` maps a COLMAP point id to its row.
+
+    Uses the exact observed pixel from each image's 2D keypoints when available. For models
+    with no 2D observations (e.g. a BA export with empty POINTS2D and no point tracks), falls
+    back to reprojecting every point into every image (visibility via depth cap + majority).
     """
     point_ids = np.array(sorted(recon.points3d), dtype=np.int64)
     index = {int(pid): i for i, pid in enumerate(point_ids)}
     n_classes = int(max(Klass)) + 1
     votes = np.zeros((len(point_ids), n_classes), dtype=np.uint16)
 
-    id_set = set(image_ids)
+    if not any(len(recon.images[i].xys) for i in image_ids):
+        log("      model has no 2D observations -> reprojection labeling")
+        pos = np.array([recon.points3d[int(pid)].xyz for pid in point_ids])
+        for img_id in image_ids:
+            im = recon.images[img_id]
+            cam = pos @ qvec2rotmat(im.qvec).T + im.tvec
+            z = cam[:, 2]
+            near = (z > 0.1) & (z < max_depth)
+            if not near.any():
+                continue
+            fx, fy, cx, cy = recon.cameras[im.camera_id].params[:4]
+            px = fx * cam[:, 0] / z + cx
+            py = fy * cam[:, 1] / z + cy
+            mask = store.load(im.name)
+            H, W = mask.shape
+            inb = near & (px >= 0) & (px < W) & (py >= 0) & (py < H)
+            idx = np.nonzero(inb)[0]
+            if len(idx):
+                np.add.at(votes, (idx, mask[py[idx].astype(np.int64), px[idx].astype(np.int64)]), 1)
+        return point_ids, votes, index
+
     for img_id in image_ids:
         img = recon.images[img_id]
         mask = store.load(img.name)

--- a/script/semantic_bev/path_centerlines.py
+++ b/script/semantic_bev/path_centerlines.py
@@ -16,6 +16,8 @@ from shapely.geometry import LineString
 from shapely.ops import unary_union
 from skimage.morphology import skeletonize
 
+from grid_transform import cells_to_world
+
 _NB = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
 _STEP = {o: (2 ** 0.5 if o[0] and o[1] else 1.0) for o in _NB}
 
@@ -93,7 +95,8 @@ def walkway_centerlines(mask: np.ndarray, meta: dict, prune_m: float = 1.5,
         is_spur = deg[path[0]] == 1 or deg[path[-1]] == 1
         if (is_spur and length_m < prune_m) or length_m < min_len_m:
             continue
-        world = np.array([[meta["origin_u"] + x * cs, meta["origin_v"] + y * cs] for y, x in path])
+        rc = np.array(path, dtype=np.float64)  # (N,2) as (row, col)
+        world = cells_to_world(rc[:, ::-1], meta)  # -> (col, row) -> world (X, Z)
         world = _chaikin(world, smooth_iters)
         halfw = np.array([dist[y, x] for y, x in path]) * cs            # dist = half-width
         out.append({"line": world, "width": float(2 * np.median(halfw))})

--- a/script/semantic_bev/path_centerlines.py
+++ b/script/semantic_bev/path_centerlines.py
@@ -1,0 +1,111 @@
+"""Path centerlines: turn blob walkway regions into a smooth centerline graph + clean paths.
+
+A human draws a path as a centerline with a width, not a wiggly polygon. So we skeletonise the
+walkway mask, trace it into a graph (nodes = junctions/endpoints, edges = polylines), prune
+skeleton spurs, smooth each edge, and re-buffer by the measured width into clean constant-width
+paths. The graph doubles as a routing network.
+
+    walkway mask --skeletonize--> graph --prune+smooth--> centerlines (+width) --buffer--> paths
+"""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from shapely.geometry import LineString
+from shapely.ops import unary_union
+from skimage.morphology import skeletonize
+
+_NB = [(-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1)]
+_STEP = {o: (2 ** 0.5 if o[0] and o[1] else 1.0) for o in _NB}
+
+
+def _trace(skel: np.ndarray):
+    """1px skeleton -> (edges, degree). Each edge is a pixel polyline between non-degree-2 nodes."""
+    pts = set(map(tuple, np.argwhere(skel)))
+
+    def nbrs(p):
+        y, x = p
+        return [(y + dy, x + dx) for dy, dx in _NB if (y + dy, x + dx) in pts]
+
+    deg = {p: len(nbrs(p)) for p in pts}
+    nodes = {p for p in pts if deg[p] != 2}
+    edges, seen = [], set()
+    for n in nodes:
+        for m in nbrs(n):
+            if (n, m) in seen:
+                continue
+            path, prev, cur = [n], n, m
+            while True:
+                path.append(cur)
+                seen.add((prev, cur))
+                seen.add((cur, prev))
+                if cur in nodes:
+                    break
+                nxt = [q for q in nbrs(cur) if q != prev]
+                if len(nxt) != 1:
+                    break
+                prev, cur = cur, nxt[0]
+            edges.append(path)
+    return edges, deg
+
+
+def _chaikin(pts: np.ndarray, iters: int) -> np.ndarray:
+    pts = np.asarray(pts, float)
+    for _ in range(iters):
+        if len(pts) < 3:
+            break
+        out = [pts[0]]
+        for a, b in zip(pts[:-1], pts[1:]):
+            out.append(0.75 * a + 0.25 * b)
+            out.append(0.25 * a + 0.75 * b)
+        out.append(pts[-1])
+        pts = np.array(out)
+    return pts
+
+
+def _pix_len(path) -> float:
+    return sum(_STEP[(b[0] - a[0], b[1] - a[1])] for a, b in zip(path[:-1], path[1:]))
+
+
+def walkway_centerlines(mask: np.ndarray, meta: dict, prune_m: float = 1.5,
+                        min_len_m: float = 1.0, smooth_iters: int = 2,
+                        min_component_m2: float = 10.0) -> list[dict]:
+    """Walkway mask -> centerline segments. Each: {'line': (N,2) world XZ, 'width': metres}."""
+    cs = meta["cell_size"]
+    m = mask.astype(np.uint8)
+    m = cv2.morphologyEx(m, cv2.MORPH_CLOSE, np.ones((3, 3), np.uint8))  # heal gaps before skeleton
+
+    # drop disconnected speckle islands (only skeletonise real path components)
+    n, lbl, stats, _ = cv2.connectedComponentsWithStats(m, 8)
+    keep = np.zeros_like(m)
+    for i in range(1, n):
+        if stats[i, cv2.CC_STAT_AREA] * cs * cs >= min_component_m2:
+            keep[lbl == i] = 1
+    m = keep
+    skel = skeletonize(m.astype(bool))
+    dist = cv2.distanceTransform(m, cv2.DIST_L2, 5)                      # px to boundary
+    edges, deg = _trace(skel)
+
+    out = []
+    for path in edges:
+        length_m = _pix_len(path) * cs
+        is_spur = deg[path[0]] == 1 or deg[path[-1]] == 1
+        if (is_spur and length_m < prune_m) or length_m < min_len_m:
+            continue
+        world = np.array([[meta["origin_u"] + x * cs, meta["origin_v"] + y * cs] for y, x in path])
+        world = _chaikin(world, smooth_iters)
+        halfw = np.array([dist[y, x] for y, x in path]) * cs            # dist = half-width
+        out.append({"line": world, "width": float(2 * np.median(halfw))})
+    return out
+
+
+def centerlines_to_polygons(centerlines: list[dict], min_width_m: float = 0.6):
+    """Re-buffer each smooth centerline by half its width -> clean constant-width path polygons."""
+    polys = []
+    for c in centerlines:
+        if len(c["line"]) < 2:
+            continue
+        r = max(c["width"] / 2, min_width_m / 2)
+        polys.append(LineString(c["line"]).buffer(r, cap_style=1, join_style=1))
+    return unary_union(polys) if polys else None

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -49,6 +49,7 @@ def camera_centers(recon: Reconstruction) -> np.ndarray:
 
 def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
         source: str = "colmap", gsplat_dir: str | None = None, min_opacity: float = 0.1,
+        depth_dir: str | None = None, depth_stride: int = 4, depth_voxel: float = 0.05,
         segmenter_kind: str = "heuristic", cell_size: float = 0.5,
         up_axis: int | None = None, up_sign: float | None = None,
         limit: int | None = None, clip_threshold: float = 0.30,
@@ -58,7 +59,32 @@ def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
     store = None
     image_ids = None
 
-    if source == "gsplat":
+    if source == "depth":
+        # Back-project labelled pixels through per-view metric depth. Needs the same masks
+        # as the colmap source; only the geometry (points) comes from depth, not tracks.
+        mask_dir = out / "masks"
+        log(f"[1/4] reading COLMAP model: {model_dir}")
+        recon = read_model(model_dir)
+        image_ids = sorted(recon.images)
+        if limit is not None:
+            image_ids = image_ids[:limit]
+        log(f"[2/4] segmenting ({segmenter_kind}) -> {mask_dir}")
+        seg_kw = {"threshold": clip_threshold} if segmenter_kind == "clipseg" else {}
+        segmenter = make_segmenter(segmenter_kind, **seg_kw)
+        store = MaskStore(mask_dir)
+        segment_and_cache(recon, image_dir, segmenter, store, image_ids,
+                          overwrite=overwrite_masks, log=log)
+        log(f"[3/4] back-projecting depth: {depth_dir}")
+        from depth_backproject import backproject_labeled_points
+        positions, labels, conf = backproject_labeled_points(
+            recon, store, depth_dir, image_ids,
+            stride=depth_stride, voxel=depth_voxel, log=log)
+        labeled = int((labels != int(Klass.UNKNOWN)).sum())
+        log(f"      {labeled}/{len(labels)} points labelled "
+            f"({100 * labeled / max(len(labels), 1):.1f}%)")
+        _log_class_histogram(labels, log)
+        semantic_mode = "vote"  # dense-mask projection is COLMAP-only
+    elif source == "gsplat":
         log(f"[1/4] loading semantic 3DGS points: {gsplat_dir}")
         from gsplat_source import load_gsplat_points
         positions, labels, conf = load_gsplat_points(gsplat_dir, min_opacity=min_opacity, log=log)
@@ -143,13 +169,23 @@ def main() -> None:
     ap.add_argument("--session", default=None,
                     help="LAR session name: fills --model/--images/--gsplat-dir/--out from the "
                          "canonical layout (script/lar_session.py). Explicit flags override.")
-    ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat"],
-                    help="geometry source: 'colmap' sparse points + segmentation (default), or "
-                         "'gsplat' a trained semantic 3DGS export (denser, pre-labelled)")
+    ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat", "depth"],
+                    help="geometry source: 'colmap' sparse points + segmentation (default); "
+                         "'gsplat' a trained semantic 3DGS export; 'depth' back-projected "
+                         "per-view metric depth (MVS/2DGS/mono/3DGS bake-off)")
     ap.add_argument("--gsplat-dir", default=None,
                     help="semantic 3DGS export dir (script/gsplat --out); required for --source gsplat")
     ap.add_argument("--min-opacity", type=float, default=0.1,
                     help="drop Gaussians below this opacity when using --source gsplat")
+    ap.add_argument("--depth-backend", default=None,
+                    help="depth backend name (mvs/2dgs/mono/3dgs); with --session derives "
+                         "--depth-dir and the output tag")
+    ap.add_argument("--depth-dir", default=None,
+                    help="dir of per-view metric depth maps (<stem>.npy); required for --source depth")
+    ap.add_argument("--stride", type=int, default=4,
+                    help="pixel subsample stride for depth back-projection (--source depth)")
+    ap.add_argument("--voxel", type=float, default=0.05,
+                    help="voxel size in metres for depth-point dedup (--source depth)")
     ap.add_argument("--model", default=None,
                     help="COLMAP text model dir. Required for --source colmap; for --source gsplat "
                          "it supplies camera orientations for gravity (unless --up-axis/--up-sign given)")
@@ -170,23 +206,33 @@ def main() -> None:
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
         from lar_session import Session
         s = Session(args.session)
-        args.model = args.model or str(s.best_model())  # geometry (colmap) or gravity (gsplat)
-        args.out = args.out or str(s.sbev_out(args.source))
+        args.model = args.model or str(s.best_model())  # geometry (colmap) or gravity (gsplat/depth)
         if args.source == "gsplat":
             args.gsplat_dir = args.gsplat_dir or str(s.gsplat_out(semantic=True))
+            args.out = args.out or str(s.sbev_out("gsplat"))
+        elif args.source == "depth":
+            args.images = args.images or str(s.images)
+            if args.depth_backend:
+                args.depth_dir = args.depth_dir or str(s.depth_dir(args.depth_backend))
+                args.out = args.out or str(s.sbev_out("depth", tag=args.depth_backend))
         else:
             args.images = args.images or str(s.images)
+            args.out = args.out or str(s.sbev_out("colmap"))
         print(f"session '{args.session}': source={args.source} out={args.out}")
 
     if not args.out:
-        ap.error("need --session or --out")
+        ap.error("need --session (+ --depth-backend for depth) or --out")
     if args.source == "colmap" and (not args.model or not args.images):
         ap.error("--source colmap requires --model and --images (or --session)")
     if args.source == "gsplat" and not args.gsplat_dir:
         ap.error("--source gsplat requires --gsplat-dir (or --session)")
+    if args.source == "depth" and (not args.depth_dir or not args.model or not args.images):
+        ap.error("--source depth requires --depth-dir, --model, --images "
+                 "(or --session + --depth-backend)")
 
     run(args.model, args.images, args.out, source=args.source, gsplat_dir=args.gsplat_dir,
-        min_opacity=args.min_opacity, segmenter_kind=args.segmenter,
+        min_opacity=args.min_opacity, depth_dir=args.depth_dir, depth_stride=args.stride,
+        depth_voxel=args.voxel, segmenter_kind=args.segmenter,
         cell_size=args.cell_size, up_axis=args.up_axis, up_sign=args.up_sign,
         limit=args.limit, clip_threshold=args.clip_threshold,
         overwrite_masks=args.overwrite_masks, semantic_mode=args.semantic_mode)

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -140,6 +140,9 @@ def _log_class_histogram(labels: np.ndarray, log) -> None:
 def main() -> None:
     ap = argparse.ArgumentParser(description="Semantic BEV ground model from COLMAP points "
                                              "or a semantic 3DGS export")
+    ap.add_argument("--session", default=None,
+                    help="LAR session name: fills --model/--images/--gsplat-dir/--out from the "
+                         "canonical layout (script/lar_session.py). Explicit flags override.")
     ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat"],
                     help="geometry source: 'colmap' sparse points + segmentation (default), or "
                          "'gsplat' a trained semantic 3DGS export (denser, pre-labelled)")
@@ -151,7 +154,7 @@ def main() -> None:
                     help="COLMAP text model dir. Required for --source colmap; for --source gsplat "
                          "it supplies camera orientations for gravity (unless --up-axis/--up-sign given)")
     ap.add_argument("--images", default=None, help="directory of source images (--source colmap)")
-    ap.add_argument("--out", required=True, help="output directory")
+    ap.add_argument("--out", default=None, help="output directory (derived from --session if unset)")
     ap.add_argument("--segmenter", default="heuristic", choices=list(SEGMENTER_KINDS))
     ap.add_argument("--cell-size", type=float, default=0.5, help="metres per grid cell")
     ap.add_argument("--up-axis", type=int, default=None, choices=[0, 1, 2], help="0=x,1=y,2=z (auto if unset)")
@@ -162,10 +165,25 @@ def main() -> None:
     ap.add_argument("--semantic-mode", default="vote", choices=["vote", "project"],
                     help="vote: sparse point votes (fast); project: dense-mask projection (cleaner)")
     args = ap.parse_args()
+    if args.session:
+        import sys
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from lar_session import Session
+        s = Session(args.session)
+        args.model = args.model or str(s.best_model())  # geometry (colmap) or gravity (gsplat)
+        args.out = args.out or str(s.sbev_out(args.source))
+        if args.source == "gsplat":
+            args.gsplat_dir = args.gsplat_dir or str(s.gsplat_out(semantic=True))
+        else:
+            args.images = args.images or str(s.images)
+        print(f"session '{args.session}': source={args.source} out={args.out}")
+
+    if not args.out:
+        ap.error("need --session or --out")
     if args.source == "colmap" and (not args.model or not args.images):
-        ap.error("--source colmap requires --model and --images")
+        ap.error("--source colmap requires --model and --images (or --session)")
     if args.source == "gsplat" and not args.gsplat_dir:
-        ap.error("--source gsplat requires --gsplat-dir")
+        ap.error("--source gsplat requires --gsplat-dir (or --session)")
 
     run(args.model, args.images, args.out, source=args.source, gsplat_dir=args.gsplat_dir,
         min_opacity=args.min_opacity, segmenter_kind=args.segmenter,

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -47,37 +47,61 @@ def camera_centers(recon: Reconstruction) -> np.ndarray:
     return np.array([-_qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
 
 
-def run(model_dir: str, image_dir: str, out_dir: str, *,
+def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
+        source: str = "colmap", gsplat_dir: str | None = None, min_opacity: float = 0.1,
         segmenter_kind: str = "heuristic", cell_size: float = 0.5,
         up_axis: int | None = None, up_sign: float | None = None,
         limit: int | None = None, clip_threshold: float = 0.30,
         overwrite_masks: bool = False, semantic_mode: str = "vote", log=print) -> None:
     out = Path(out_dir)
-    mask_dir = out / "masks"
+    recon = None   # COLMAP model: geometry+labels in colmap mode; gravity only in gsplat mode
+    store = None
+    image_ids = None
 
-    log(f"[1/5] reading COLMAP model: {model_dir}")
-    recon = read_model(model_dir)
-    log(f"      {len(recon.images)} images, {recon.num_points} points")
+    if source == "gsplat":
+        log(f"[1/4] loading semantic 3DGS points: {gsplat_dir}")
+        from gsplat_source import load_gsplat_points
+        positions, labels, conf = load_gsplat_points(gsplat_dir, min_opacity=min_opacity, log=log)
+        labeled = int((labels != int(Klass.UNKNOWN)).sum())
+        log(f"      {labeled}/{len(labels)} points labelled "
+            f"({100 * labeled / max(len(labels), 1):.1f}%)")
+        _log_class_histogram(labels, log)
+        # Gravity/up needs camera orientations, which the Gaussians don't carry -- read the
+        # COLMAP model the gsplat run was trained from (same world coords).
+        if (up_axis is None or up_sign is None):
+            if not model_dir:
+                raise SystemExit("--source gsplat needs --model (for gravity) or explicit "
+                                 "--up-axis/--up-sign")
+            recon = read_model(model_dir)
+        if semantic_mode == "project":
+            log("      note: --semantic-mode project is COLMAP-only; using per-Gaussian labels")
+            semantic_mode = "vote"
+    else:
+        mask_dir = out / "masks"
+        log(f"[1/5] reading COLMAP model: {model_dir}")
+        recon = read_model(model_dir)
+        log(f"      {len(recon.images)} images, {recon.num_points} points")
 
-    image_ids = sorted(recon.images)
-    if limit is not None:
-        image_ids = image_ids[:limit]
-        log(f"      limiting to first {len(image_ids)} images")
+        image_ids = sorted(recon.images)
+        if limit is not None:
+            image_ids = image_ids[:limit]
+            log(f"      limiting to first {len(image_ids)} images")
 
-    log(f"[2/5] segmenting ({segmenter_kind}) -> {mask_dir}")
-    seg_kw = {"threshold": clip_threshold} if segmenter_kind == "clipseg" else {}
-    segmenter = make_segmenter(segmenter_kind, **seg_kw)
-    store = MaskStore(mask_dir)
-    segment_and_cache(recon, image_dir, segmenter, store, image_ids,
-                      overwrite=overwrite_masks, log=log)
+        log(f"[2/5] segmenting ({segmenter_kind}) -> {mask_dir}")
+        seg_kw = {"threshold": clip_threshold} if segmenter_kind == "clipseg" else {}
+        segmenter = make_segmenter(segmenter_kind, **seg_kw)
+        store = MaskStore(mask_dir)
+        segment_and_cache(recon, image_dir, segmenter, store, image_ids,
+                          overwrite=overwrite_masks, log=log)
 
-    log("[3/5] voting labels onto points")
-    point_ids, votes, _ = accumulate_votes(recon, store, image_ids)
-    labels, conf = resolve_labels(votes)
-    positions = np.array([recon.points3d[int(pid)].xyz for pid in point_ids])
-    labeled = int((labels != int(Klass.UNKNOWN)).sum())
-    log(f"      {labeled}/{len(labels)} points labelled ({100 * labeled / len(labels):.1f}%)")
-    _log_class_histogram(labels, log)
+        log("[3/5] voting labels onto points")
+        point_ids, votes, _ = accumulate_votes(recon, store, image_ids)
+        labels, conf = resolve_labels(votes)
+        positions = np.array([recon.points3d[int(pid)].xyz for pid in point_ids])
+        labeled = int((labels != int(Klass.UNKNOWN)).sum())
+        log(f"      {labeled}/{len(labels)} points labelled "
+            f"({100 * labeled / len(labels):.1f}%)")
+        _log_class_histogram(labels, log)
 
     if up_axis is None or up_sign is None:
         a, s, vec = detect_gravity_up(recon)
@@ -91,7 +115,7 @@ def run(model_dir: str, image_dir: str, out_dir: str, *,
         if above < 0:
             log("      WARNING: cameras sit BELOW ground along up-axis -- frame may be upside down!")
 
-    log("[4/5] building ground level")
+    log("[build] building ground level")
     level = build_level(positions, labels, conf, cell_size=cell_size,
                         up_axis=up_axis, up_sign=up_sign, log=log)
 
@@ -102,7 +126,7 @@ def run(model_dir: str, image_dir: str, out_dir: str, *,
         level.semantic = sem
         level.coverage = level.coverage | proj_cov  # projection reaches cells sparse points miss
 
-    log(f"[5/5] exporting -> {out}")
+    log(f"[export] -> {out}")
     save_level(level, out, prefix="level0")
     log("done.")
 
@@ -114,9 +138,19 @@ def _log_class_histogram(labels: np.ndarray, log) -> None:
 
 
 def main() -> None:
-    ap = argparse.ArgumentParser(description="Semantic BEV ground model from COLMAP + segmentation")
-    ap.add_argument("--model", required=True, help="COLMAP text model dir (cameras/images/points3D.txt)")
-    ap.add_argument("--images", required=True, help="directory of source images")
+    ap = argparse.ArgumentParser(description="Semantic BEV ground model from COLMAP points "
+                                             "or a semantic 3DGS export")
+    ap.add_argument("--source", default="colmap", choices=["colmap", "gsplat"],
+                    help="geometry source: 'colmap' sparse points + segmentation (default), or "
+                         "'gsplat' a trained semantic 3DGS export (denser, pre-labelled)")
+    ap.add_argument("--gsplat-dir", default=None,
+                    help="semantic 3DGS export dir (script/gsplat --out); required for --source gsplat")
+    ap.add_argument("--min-opacity", type=float, default=0.1,
+                    help="drop Gaussians below this opacity when using --source gsplat")
+    ap.add_argument("--model", default=None,
+                    help="COLMAP text model dir. Required for --source colmap; for --source gsplat "
+                         "it supplies camera orientations for gravity (unless --up-axis/--up-sign given)")
+    ap.add_argument("--images", default=None, help="directory of source images (--source colmap)")
     ap.add_argument("--out", required=True, help="output directory")
     ap.add_argument("--segmenter", default="heuristic", choices=list(SEGMENTER_KINDS))
     ap.add_argument("--cell-size", type=float, default=0.5, help="metres per grid cell")
@@ -128,8 +162,13 @@ def main() -> None:
     ap.add_argument("--semantic-mode", default="vote", choices=["vote", "project"],
                     help="vote: sparse point votes (fast); project: dense-mask projection (cleaner)")
     args = ap.parse_args()
+    if args.source == "colmap" and (not args.model or not args.images):
+        ap.error("--source colmap requires --model and --images")
+    if args.source == "gsplat" and not args.gsplat_dir:
+        ap.error("--source gsplat requires --gsplat-dir")
 
-    run(args.model, args.images, args.out, segmenter_kind=args.segmenter,
+    run(args.model, args.images, args.out, source=args.source, gsplat_dir=args.gsplat_dir,
+        min_opacity=args.min_opacity, segmenter_kind=args.segmenter,
         cell_size=args.cell_size, up_axis=args.up_axis, up_sign=args.up_sign,
         limit=args.limit, clip_threshold=args.clip_threshold,
         overwrite_masks=args.overwrite_masks, semantic_mode=args.semantic_mode)

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -63,8 +63,12 @@ def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
         # Back-project labelled pixels through per-view metric depth. Needs the same masks
         # as the colmap source; only the geometry (points) comes from depth, not tracks.
         mask_dir = out / "masks"
-        log(f"[1/4] reading COLMAP model: {model_dir}")
-        recon = read_model(model_dir)
+        # A backend may ship its own model (e.g. MVS's undistorted one) with matching
+        # intrinsics — prefer it over the passed --model.
+        colocated = Path(depth_dir) / "model"
+        depth_model = colocated if (colocated / "cameras.txt").exists() else Path(model_dir)
+        log(f"[1/4] reading COLMAP model: {depth_model}")
+        recon = read_model(depth_model)
         image_ids = sorted(recon.images)
         if limit is not None:
             image_ids = image_ids[:limit]

--- a/script/semantic_bev/pipeline.py
+++ b/script/semantic_bev/pipeline.py
@@ -53,7 +53,9 @@ def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
         segmenter_kind: str = "heuristic", cell_size: float = 0.5,
         up_axis: int | None = None, up_sign: float | None = None,
         limit: int | None = None, clip_threshold: float = 0.30,
-        overwrite_masks: bool = False, semantic_mode: str = "vote", log=print) -> None:
+        overwrite_masks: bool = False, semantic_mode: str = "vote",
+        rgb_ortho: bool = False, rgb_sub: int = 5, rgb_best_view: bool = False,
+        log=print) -> None:
     out = Path(out_dir)
     recon = None   # COLMAP model: geometry+labels in colmap mode; gravity only in gsplat mode
     store = None
@@ -156,6 +158,19 @@ def run(model_dir: str | None, image_dir: str | None, out_dir: str, *,
         level.semantic = sem
         level.coverage = level.coverage | proj_cov  # projection reaches cells sparse points miss
 
+    if rgb_ortho:
+        if recon is None or not image_dir:
+            log("      skipping --rgb-ortho: needs a COLMAP model (gravity+poses) and --images")
+        else:
+            ids = image_ids if image_ids is not None else sorted(recon.images)
+            log(f"      RGB orthophoto ({rgb_sub}x DEM, "
+                f"{'best-view' if rgb_best_view else 'weighted-mean'}"
+                f"{', ground-gated' if store is not None else ''})")
+            from rgb_projection import project_rgb_ortho, save_ortho
+            rgb, obs = project_rgb_ortho(recon, level, ids, image_dir, store=store,
+                                         sub=rgb_sub, best_view=rgb_best_view, log=log)
+            save_ortho(rgb, obs, out, prefix="level0")
+
     log(f"[export] -> {out}")
     save_level(level, out, prefix="level0")
     log("done.")
@@ -204,6 +219,15 @@ def main() -> None:
     ap.add_argument("--overwrite-masks", action="store_true")
     ap.add_argument("--semantic-mode", default="vote", choices=["vote", "project"],
                     help="vote: sparse point votes (fast); project: dense-mask projection (cleaner)")
+    ap.add_argument("--rgb-ortho", action="store_true",
+                    help="also render a true-colour BEV orthophoto (level0_rgb.png): drape the "
+                         "source RGB onto the DEM, top-down. Needs a COLMAP model + --images")
+    ap.add_argument("--rgb-sub", type=int, default=5,
+                    help="orthophoto super-resolution factor over the DEM grid "
+                         "(fine cell = cell_size/rgb_sub; e.g. 0.5 m DEM + 10 -> 0.05 m ortho)")
+    ap.add_argument("--rgb-best-view", action="store_true",
+                    help="colour each cell from its single closest view (crisper, exposure seams) "
+                         "instead of the inverse-depth weighted mean (smoother)")
     args = ap.parse_args()
     if args.session:
         import sys
@@ -239,7 +263,8 @@ def main() -> None:
         depth_voxel=args.voxel, segmenter_kind=args.segmenter,
         cell_size=args.cell_size, up_axis=args.up_axis, up_sign=args.up_sign,
         limit=args.limit, clip_threshold=args.clip_threshold,
-        overwrite_masks=args.overwrite_masks, semantic_mode=args.semantic_mode)
+        overwrite_masks=args.overwrite_masks, semantic_mode=args.semantic_mode,
+        rgb_ortho=args.rgb_ortho, rgb_sub=args.rgb_sub, rgb_best_view=args.rgb_best_view)
 
 
 if __name__ == "__main__":

--- a/script/semantic_bev/rgb_projection.py
+++ b/script/semantic_bev/rgb_projection.py
@@ -1,0 +1,151 @@
+"""True-colour BEV orthophoto: drape the source RGB onto the DEM, top-down.
+
+Where :mod:`dense_projection` reads the cached *semantic mask* at each ground cell's
+reprojection, this reads the source *RGB image* there -- so the output is a photographic
+overhead map instead of a class raster. Two differences make it a "high-res" map:
+
+  * **Sub-cell grid.** The DEM `Level` is coarse (e.g. 0.5 m, single-valued height is fine
+    at that scale). The orthophoto is rendered at `sub`x finer (e.g. 0.05 m), with each fine
+    cell's ground height *bilinearly sampled from the DEM*. Height varies slowly, so a coarse
+    DEM upsamples cleanly; colour is where we want the resolution.
+  * **RGB accumulation.** Each view contributes an inverse-depth-weighted colour; the per-cell
+    result is the weighted mean (`best_view=False`) or the single closest view's colour
+    (`best_view=True`, crisper but with exposure seams).
+
+Occlusion trick (same as dense_projection): a canopy-covered path cell reprojects to *tree*
+pixels in top-down-ish views and *path* pixels in along-the-path views. When a MaskStore is
+given, a view's colour is accepted only where its pixel is a **ground class**, so tree/sky
+colours are dropped and any clear ground view wins. Without masks, all in-view colours count.
+
+Geometry (height) comes from the DEM; this only produces the colour raster.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from colmap_io import Reconstruction, qvec2rotmat
+from grid_transform import cell_to_world
+from ground_model import GridSpec, Level, _nearest_fill
+from labeling import MaskStore
+from taxonomy import Klass, Role, role_of
+
+
+def _fine_spec(spec: GridSpec, sub: int) -> GridSpec:
+    """A grid over the same footprint/origin as `spec` but `sub`x finer cells."""
+    return GridSpec(
+        cell_size=spec.cell_size / sub,
+        up_axis=spec.up_axis, up_sign=spec.up_sign,
+        origin_u=spec.origin_u, origin_v=spec.origin_v,
+        cols=spec.cols * sub, rows=spec.rows * sub, v_sign=spec.v_sign,
+    )
+
+
+def project_rgb_ortho(recon: Reconstruction, level: Level, image_ids: list[int],
+                      image_dir: str | Path, *, store: MaskStore | None = None,
+                      sub: int = 5, max_depth: float = 20.0, best_view: bool = False,
+                      log=print) -> tuple[np.ndarray, np.ndarray]:
+    """Return (rgb (H,W,3) uint8 BGR, observed (H,W) bool) -- a top-down RGB orthophoto.
+
+    `sub` is the super-resolution factor over the DEM grid (fine cell = cell_size/sub).
+    If `store` is given, each view's colour is gated to ground-class pixels (occlusion-robust).
+    """
+    image_dir = Path(image_dir)
+    fspec = _fine_spec(level.spec, sub)
+    rows, cols = fspec.rows, fspec.cols
+    u_axis, v_axis = fspec.horiz_axes
+    ncells = rows * cols
+    log(f"  ortho grid {cols}x{rows} @ {fspec.cell_size:.3f} m "
+        f"({sub}x the {level.spec.cell_size:.2f} m DEM)")
+
+    # Height for every fine cell: bilinear upsample of the DEM (height varies slowly).
+    h_dem = np.nan_to_num(level.height, nan=0.0).astype(np.float32)
+    h_fine = cv2.resize(h_dem, (cols, rows), interpolation=cv2.INTER_LINEAR)
+
+    # World point at each fine cell centre (u,v from the grid, up-coord from the DEM height).
+    jj, ii = np.meshgrid(np.arange(cols), np.arange(rows))
+    P = np.zeros((ncells, 3))
+    u_world, v_world = cell_to_world(jj.ravel() + 0.5, ii.ravel() + 0.5, fspec)
+    P[:, u_axis] = u_world
+    P[:, v_axis] = v_world
+    P[:, fspec.up_axis] = h_fine.ravel() * fspec.up_sign
+
+    ground_cls = np.array([role_of(k) == Role.GROUND for k in range(int(max(Klass)) + 1)])
+
+    csum = np.zeros((ncells, 3), dtype=np.float32)  # weighted colour accumulator (BGR)
+    wsum = np.zeros(ncells, dtype=np.float32)
+    best_w = np.zeros(ncells, dtype=np.float32) if best_view else None
+
+    for n, img_id in enumerate(image_ids):
+        im = recon.images[img_id]
+        img = cv2.imread(str(image_dir / im.name), cv2.IMREAD_COLOR)  # BGR
+        if img is None:
+            continue
+        H, W = img.shape[:2]
+
+        R = qvec2rotmat(im.qvec)
+        cam = P @ R.T + im.tvec
+        z = cam[:, 2]
+        near = (z > 0.1) & (z < max_depth)
+        if not near.any():
+            continue
+        fx, fy, cx, cy = recon.cameras[im.camera_id].params[:4]
+        px = fx * cam[:, 0] / z + cx
+        py = fy * cam[:, 1] / z + cy
+        inb = near & (px >= 0) & (px < W) & (py >= 0) & (py < H)
+        idx = np.nonzero(inb)[0]
+        if len(idx) == 0:
+            continue
+        xs = px[idx].astype(np.int64)
+        ys = py[idx].astype(np.int64)
+
+        if store is not None:
+            mask = store.load(im.name)
+            if mask.shape[:2] != (H, W):  # mask cached at a different scale than the image
+                mask = cv2.resize(mask, (W, H), interpolation=cv2.INTER_NEAREST)
+            keep = ground_cls[mask[ys, xs]]
+            if not keep.any():
+                continue
+            idx, xs, ys = idx[keep], xs[keep], ys[keep]
+
+        w = (1.0 / z[idx]).astype(np.float32)  # inverse-depth: near, reliable views weigh more
+        colours = img[ys, xs].astype(np.float32)
+        if best_view:
+            take = w > best_w[idx]
+            sel = idx[take]
+            best_w[sel] = w[take]
+            csum[sel] = colours[take]
+        else:
+            np.add.at(csum, idx, colours * w[:, None])
+            np.add.at(wsum, idx, w)
+        if (n + 1) % 100 == 0 or n + 1 == len(image_ids):
+            log(f"  projected {n + 1}/{len(image_ids)} views")
+
+    observed = (best_w > 0) if best_view else (wsum > 0)
+    rgb = np.zeros((ncells, 3), dtype=np.float32)
+    if best_view:
+        rgb[observed] = csum[observed]
+    else:
+        rgb[observed] = csum[observed] / wsum[observed, None]
+    log(f"  ortho: {int(observed.sum())}/{ncells} cells coloured ({100 * observed.mean():.1f}%)")
+
+    rgb = rgb.reshape(rows, cols, 3)
+    obs2d = observed.reshape(rows, cols)
+    # Fill gaps (unobserved / occluded cells) with the nearest coloured cell, per channel.
+    for c in range(3):
+        rgb[..., c] = _nearest_fill(rgb[..., c].astype(np.uint8), obs2d)
+    return rgb.astype(np.uint8), obs2d
+
+
+def save_ortho(rgb: np.ndarray, observed: np.ndarray, out_dir: str | Path,
+               prefix: str = "level0") -> None:
+    """Write the orthophoto (BGR) and an alpha-masked version showing only observed cells."""
+    d = Path(out_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(d / f"{prefix}_rgb.png"), rgb)  # rgb is BGR (cv2 convention)
+    bgra = cv2.cvtColor(rgb, cv2.COLOR_BGR2BGRA)
+    bgra[..., 3] = np.where(observed, 255, 0).astype(np.uint8)
+    cv2.imwrite(str(d / f"{prefix}_rgb_masked.png"), bgra)

--- a/script/semantic_bev/verify_orientation.py
+++ b/script/semantic_bev/verify_orientation.py
@@ -18,6 +18,7 @@ import cv2
 import numpy as np
 
 from colmap_io import read_model
+from grid_transform import world_to_cell
 from pipeline import _qvec2rotmat
 from taxonomy import Klass, Role, role_of
 
@@ -39,9 +40,9 @@ def main() -> None:
     centers = np.array([-_qvec2rotmat(im.qvec).T @ im.tvec for im in recon.images.values()])
     u_axis, v_axis = (a for a in (0, 1, 2) if a != meta["up_axis"])
 
-    # same mapping the raster uses: col = (u-origin)/cell, row = (v-origin)/cell  (no flip)
-    col = ((centers[:, u_axis] - meta["origin_u"]) / meta["cell_size"]).astype(int)
-    row = ((centers[:, v_axis] - meta["origin_v"]) / meta["cell_size"]).astype(int)
+    # same mapping the raster uses (single source of truth in grid_transform)
+    col_f, row_f = world_to_cell(centers[:, u_axis], centers[:, v_axis], meta)
+    col, row = col_f.astype(int), row_f.astype(int)
     inb = (col >= 0) & (col < meta["cols"]) & (row >= 0) & (row < meta["rows"])
     col, row = col[inb], row[inb]
 

--- a/script/semantic_bev/view_imdf.py
+++ b/script/semantic_bev/view_imdf.py
@@ -28,7 +28,7 @@ HTML = """<!doctype html><html><head><meta charset="utf-8">
 .legend{{background:#fff;padding:8px 10px;border-radius:6px;font:13px sans-serif;line-height:1.6;box-shadow:0 1px 4px rgba(0,0,0,.3)}}
 .sw{{display:inline-block;width:12px;height:12px;margin-right:6px;border:1px solid #0003;vertical-align:middle}}</style>
 </head><body><div id="map"></div><script>
-const UNIT={units}, VENUE={venue}, LEVEL={level}, STYLE={style};
+const UNIT={units}, VENUE={venue}, LEVEL={level}, STYLE={style}, ROUTING={routing};
 const map=L.map('map');
 L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png',
   {{maxZoom:20,attribution:'&copy; OpenStreetMap'}}).addTo(map);
@@ -37,6 +37,8 @@ const units=L.geoJSON(UNIT,{{
   style:f=>STYLE[f.properties.category]||{{color:'#888',fillColor:'#bbb',fillOpacity:.5,weight:1}},
   onEachFeature:(f,l)=>l.bindPopup(`<b>${{f.feature_type}}</b><br>category: ${{f.properties.category}}<br>id: ${{f.id}}`)
 }}).addTo(map);
+if(ROUTING&&ROUTING.features&&ROUTING.features.length)
+  L.geoJSON(ROUTING,{{style:{{color:'#c0392b',weight:2,opacity:0.9,dashArray:'4 3'}}}}).addTo(map);
 const ven=L.geoJSON(VENUE,{{style:{venue_style}}}).addTo(map);
 map.fitBounds(ven.getBounds().pad(0.1));
 const lg=L.control({{position:'bottomright'}});
@@ -56,11 +58,14 @@ def main() -> None:
 
     venue = json.load(open(d / "venue.geojson"))
     title = venue["features"][0]["properties"]["name"].get("en", "IMDF Venue")
+    routing_path = d / "routing.geojson"
+    routing = json.load(open(routing_path)) if routing_path.exists() else {"features": []}
     html = HTML.format(
         title=title,
         units=json.dumps(json.load(open(d / "unit.geojson"))),
         venue=json.dumps(venue),
         level=json.dumps(json.load(open(d / "level.geojson"))),
+        routing=json.dumps(routing),
         style=json.dumps(STYLE),
         venue_style=json.dumps(VENUE_STYLE),
     )


### PR DESCRIPTION
## What

Adds a **true-colour BEV orthophoto** to the semantic-BEV pipeline: drape the source RGB onto the DEM, top-down, into `level0_rgb.png`. It's the RGB sibling of `--semantic-mode project` — same reprojection, but it reads the source **image** at each ground cell instead of the semantic mask, at a **finer grid**.

- `--rgb-ortho` — render the orthophoto.
- `--rgb-sub N` — render at `N`× the DEM resolution (fine cell = `cell_size / N`). Height varies slowly, so the coarse DEM upsamples cleanly and colour gets the resolution (e.g. `--cell-size 0.5 --rgb-sub 10` → 0.05 m ortho).
- `--rgb-best-view` — crisp single-closest-view colour vs the default smoother inverse-depth weighted mean.
- Occlusion-robust: when masks exist, a view's colour is kept only where its pixel is a **ground class** (canopy/wall colours dropped), the same trick as `dense_projection`.

## Files
- `rgb_projection.py` (new) — the projection + `save_ortho`.
- `pipeline.py` — flag wiring.
- `README.md` — docs.

## Smoke test
Ran on `maguro-park-after-itchy` (60 images, `--rgb-sub 6` → 0.083 m): 99% of cells coloured, ground-gated. Produces a recognizable overhead map (paved/roof, grass, dirt path). Weighted-mean shows mild parallax ghosting on non-flat features; `--rgb-best-view` is the crisp alternative.

> ⚠️ **Base branch note:** the remote `arkit-covisibility-matching` is behind your local by several semantic_bev commits, so this PR's diff currently shows those intermediate commits too. Push your local branch and the diff will collapse to just the 3 files here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)